### PR TITLE
regen-rootfs-uuid: Reduce risk of image corruption on hard-reset

### DIFF
--- a/recipes-core/regen-rootfs-uuid/files/regen-rootfs-uuid.sh
+++ b/recipes-core/regen-rootfs-uuid/files/regen-rootfs-uuid.sh
@@ -23,3 +23,4 @@ sfdisk --part-uuid ${BOOT_DEV} ${ROOT_PART} ${NEW_UUID}
 
 sed -i 's/'${OLD_UUID}'/'${NEW_UUID}'/i' /etc/default/u-boot-script
 update-u-boot-script
+sync


### PR DESCRIPTION
See also https://support.industry.siemens.com/tf/ww/en/posts/exampla-image-only-starts-once/237158/?page=0&pageSize=10#post929842