### PR TITLE
customizations-base: Allow local extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 isar/
+recipes-core/customizations-base/local.inc

--- a/recipes-core/customizations-base/customizations-base_0.1-iot2050-debian.bb
+++ b/recipes-core/customizations-base/customizations-base_0.1-iot2050-debian.bb
@@ -10,6 +10,9 @@
 
 inherit dpkg-raw
 
+# optional local customizations, not part of the repository
+include local.inc
+
 DESCRIPTION = "IOT2050 reference image customizations"
 
 DEBIAN_DEPENDS = "u-boot-tools"
@@ -33,4 +36,3 @@ do_install() {
     install -v -d ${D}/etc
     install -v -m 644 ${WORKDIR}/hosts ${D}/etc/hosts
 }
-


### PR DESCRIPTION
Taken from jailhouse-images: Allow to enhance the customizations-base
package via a local.inc that is outside of versioning control, e.g. to
inject wifi credentials or authorized ssh keys.

Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>