### PR TITLE
tcf-agent: Disable SSL transport encryption

### DIFF
--- a/recipes-app/tcf-agent/files/debian/tcf-agent.service
+++ b/recipes-app/tcf-agent/files/debian/tcf-agent.service
@@ -3,7 +3,7 @@ Description=tcf-agent
 After=network.target
 
 [Service]
-ExecStart=/usr/sbin/tcf-agent -L- -l0 -s SSL:
+ExecStart=/usr/sbin/tcf-agent -L- -l0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Doesn't work (lacks cert generation e.g.) but also doesn't add any value
because there is no authentication anyway with tcf-agent.
