### PR TITLE
ethernet: Swap eth0 and eth1 port

### DIFF
--- a/recipes-kernel/linux/files/0001-iot2050-add-iot2050-platform-support.patch
+++ b/recipes-kernel/linux/files/0001-iot2050-add-iot2050-platform-support.patch
@@ -1,7 +1,7 @@
-From 5283cfac179d7c6a40d659d26d121747df9f73e3 Mon Sep 17 00:00:00 2001
+From 0150bce056a6628e4f9209672ca234a9bd815446 Mon Sep 17 00:00:00 2001
 From: Le Jin <le.jin@siemens.com>
 Date: Mon, 18 Nov 2019 17:58:08 +0800
-Subject: [PATCH 01/22] iot2050: add iot2050 platform support
+Subject: [PATCH 01/23] iot2050: add iot2050 platform support
 
 Add support for two iot2050 variants, BASIC and ADVANCED.
 Also add support for fixed gpio number naming.
@@ -177,7 +177,7 @@ index 000000000000..471f9b131db0
 +};
 diff --git a/arch/arm64/boot/dts/siemens/iot2050-common.dtsi b/arch/arm64/boot/dts/siemens/iot2050-common.dtsi
 new file mode 100644
-index 000000000000..e1ba5572dcea
+index 000000000000..ab0362c70e97
 --- /dev/null
 +++ b/arch/arm64/boot/dts/siemens/iot2050-common.dtsi
 @@ -0,0 +1,742 @@
@@ -194,8 +194,8 @@ index 000000000000..e1ba5572dcea
 +	model = "SIMATIC IOT2050 common";
 +
 +	aliases {
++		ethernet0 = &pruss0_emac1;
 +		ethernet1 = &pruss0_emac0;
-+		ethernet2 = &pruss0_emac1;
 +		gpio0 = &main_gpio0;
 +		gpio96 = &main_gpio1;
 +		gpio186 = &wkup_gpio0;

--- a/recipes-kernel/linux/files/0002-Add-support-for-U9300C-TD-LTE-module.patch
+++ b/recipes-kernel/linux/files/0002-Add-support-for-U9300C-TD-LTE-module.patch
@@ -1,7 +1,7 @@
-From 17d74fd2df7c080e2c8978579e35e35a88144ec5 Mon Sep 17 00:00:00 2001
+From 8784bee0976104682c7027dca9e65318c42ecc83 Mon Sep 17 00:00:00 2001
 From: Su Bao Cheng <baocheng.su@siemens.com>
 Date: Tue, 23 Apr 2019 10:07:17 +0800
-Subject: [PATCH 02/22] Add support for U9300C TD-LTE module
+Subject: [PATCH 02/23] Add support for U9300C TD-LTE module
 
 Author: Gao Nian  <nian.gao@siemens.com>
 Signed-off-by: Su Bao Cheng <baocheng.su@siemens.com>

--- a/recipes-kernel/linux/files/0003-feat-Add-CP210x-driver-support-to-software-flow-cont.patch
+++ b/recipes-kernel/linux/files/0003-feat-Add-CP210x-driver-support-to-software-flow-cont.patch
@@ -1,7 +1,7 @@
-From 307404678bae5bf3d3eb2c39bd852def482ebaee Mon Sep 17 00:00:00 2001
+From b89eb88bde6433bfaa16987fa8ee470ae3d6016e Mon Sep 17 00:00:00 2001
 From: Su Bao Cheng <baocheng.su@siemens.com>
 Date: Mon, 15 Jul 2019 15:46:09 +0800
-Subject: [PATCH 03/22] feat: Add CP210x driver support to software flow
+Subject: [PATCH 03/23] feat: Add CP210x driver support to software flow
  control
 
 Signed-off-by: Wang Sheng Long <shenglong.wang.ext@siemens.com>

--- a/recipes-kernel/linux/files/0004-fix-disable-usb-lpm-to-fix-usb-device-reset.patch
+++ b/recipes-kernel/linux/files/0004-fix-disable-usb-lpm-to-fix-usb-device-reset.patch
@@ -1,7 +1,7 @@
-From a5e11cc5941248ff5f1aa2f2f263be4a300232bc Mon Sep 17 00:00:00 2001
+From 82f0a52f29cb7cfc75dd963262050ca4367b227f Mon Sep 17 00:00:00 2001
 From: Sheng Long Wang <shenglong.wang.ext@siemens.com>
 Date: Tue, 13 Aug 2019 09:30:38 +0800
-Subject: [PATCH 04/22] fix: disable usb lpm to fix usb device reset
+Subject: [PATCH 04/23] fix: disable usb lpm to fix usb device reset
 
 ---
  drivers/usb/core/hub.c | 2 +-

--- a/recipes-kernel/linux/files/0005-Fix-DP-maybe-not-display-problem.patch
+++ b/recipes-kernel/linux/files/0005-Fix-DP-maybe-not-display-problem.patch
@@ -1,7 +1,7 @@
-From 6494ab018e65022d1689559eed188e5ed43dd8ea Mon Sep 17 00:00:00 2001
+From 66bcac70359c889b9258e3f212311348591aa862 Mon Sep 17 00:00:00 2001
 From: Sheng Long Wang <shenglong.wang.ext@siemens.com>
 Date: Tue, 13 Aug 2019 10:27:44 +0800
-Subject: [PATCH 05/22] Fix: DP maybe not display problem.
+Subject: [PATCH 05/23] Fix: DP maybe not display problem.
 
 Three reasons:
 	1. No entry link training phase

--- a/recipes-kernel/linux/files/0006-fix-fix-the-hardware-flow-function-of-cp2102n24.patch
+++ b/recipes-kernel/linux/files/0006-fix-fix-the-hardware-flow-function-of-cp2102n24.patch
@@ -1,7 +1,7 @@
-From 4d26330948ffe13fa3118d209acdf2342a07661f Mon Sep 17 00:00:00 2001
+From d1a248f5d54f1d6a8e8d1f210a9e4a3da5290862 Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Wed, 21 Aug 2019 16:22:30 +0800
-Subject: [PATCH 06/22] fix:fix the hardware flow function of cp2102n24
+Subject: [PATCH 06/23] fix:fix the hardware flow function of cp2102n24
 
 Signed-off-by: Gao Nian <nian.gao@siemens.com>
 ---

--- a/recipes-kernel/linux/files/0007-serial-8250-8250_omap-Fix-DMA-teardown-sequence-duri.patch
+++ b/recipes-kernel/linux/files/0007-serial-8250-8250_omap-Fix-DMA-teardown-sequence-duri.patch
@@ -1,7 +1,7 @@
-From c1b5b5013e492b3162d8ca914d958454ab98b328 Mon Sep 17 00:00:00 2001
+From 0f739e1c33b3caa80b32ff19c25e9f9bc4c298f6 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 17 Sep 2019 14:53:27 +0530
-Subject: [PATCH 07/22] serial: 8250: 8250_omap: Fix DMA teardown sequence
+Subject: [PATCH 07/23] serial: 8250: 8250_omap: Fix DMA teardown sequence
  during RX timeout
 
 Calling dmaengine_terminate_async() does not guarantee all the data that

--- a/recipes-kernel/linux/files/0008-serial-8250-8250_omap-Remove-redundant-call-to-omap_.patch
+++ b/recipes-kernel/linux/files/0008-serial-8250-8250_omap-Remove-redundant-call-to-omap_.patch
@@ -1,7 +1,7 @@
-From e4be373b1fbf9822e0d02c7d763980348ab254c9 Mon Sep 17 00:00:00 2001
+From 96057c5a0d484ce22a33aff497bf0be9a672726e Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 17 Sep 2019 14:53:28 +0530
-Subject: [PATCH 08/22] serial: 8250: 8250_omap: Remove redundant call to
+Subject: [PATCH 08/23] serial: 8250: 8250_omap: Remove redundant call to
  omap_8250_rx_dma_flush
 
 omap_8250_rx_dma_flush() is called twice in am654_8250_handle_rx_dma()

--- a/recipes-kernel/linux/files/0009-feat-add-io-expander-pcal9535-support.patch
+++ b/recipes-kernel/linux/files/0009-feat-add-io-expander-pcal9535-support.patch
@@ -1,7 +1,7 @@
-From 242bd3c176b132223ab67b05e1779a4653350691 Mon Sep 17 00:00:00 2001
+From 14645aa9302a36f84a8edb6a1a2034733ca77fee Mon Sep 17 00:00:00 2001
 From: "le.jin" <le.jin@siemens.com>
 Date: Wed, 9 Oct 2019 17:08:43 +0800
-Subject: [PATCH 09/22] feat:add io expander pcal9535 support
+Subject: [PATCH 09/23] feat:add io expander pcal9535 support
 
 Signed-off-by: le.jin <le.jin@siemens.com>
 ---

--- a/recipes-kernel/linux/files/0010-feat-modify-kernel-to-load-fw-from-MTD-for-pru-rtu.patch
+++ b/recipes-kernel/linux/files/0010-feat-modify-kernel-to-load-fw-from-MTD-for-pru-rtu.patch
@@ -1,7 +1,7 @@
-From e2348e65a09f34c6d4896abdc1b920c08396ecaa Mon Sep 17 00:00:00 2001
+From d9b1263424244e0cb66c8444ed0d453c77ba136e Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Fri, 25 Oct 2019 14:54:06 +0800
-Subject: [PATCH 10/22] feat:modify kernel to load fw from MTD for pru&rtu
+Subject: [PATCH 10/23] feat:modify kernel to load fw from MTD for pru&rtu
 
 Signed-off-by: Gao Nian <nian.gao@siemens.com>
 ---
@@ -10,7 +10,7 @@ Signed-off-by: Gao Nian <nian.gao@siemens.com>
  2 files changed, 59 insertions(+), 14 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/siemens/iot2050-common.dtsi b/arch/arm64/boot/dts/siemens/iot2050-common.dtsi
-index e1ba5572dcea..c0ac25d2f60c 100644
+index ab0362c70e97..d26185b60b18 100644
 --- a/arch/arm64/boot/dts/siemens/iot2050-common.dtsi
 +++ b/arch/arm64/boot/dts/siemens/iot2050-common.dtsi
 @@ -75,10 +75,10 @@

--- a/recipes-kernel/linux/files/0011-setting-the-RJ45-port-led-behavior.patch
+++ b/recipes-kernel/linux/files/0011-setting-the-RJ45-port-led-behavior.patch
@@ -1,7 +1,7 @@
-From 5809de4e53c2ace180563fae1b7a7c35ee01ce76 Mon Sep 17 00:00:00 2001
+From ff3fde2cc10c8918bb7d2e479687b71c5cda89bf Mon Sep 17 00:00:00 2001
 From: zengchao <chao.zeng@siemens.com>
 Date: Wed, 6 Nov 2019 11:21:49 +0800
-Subject: [PATCH 11/22] setting the RJ45 port led behavior
+Subject: [PATCH 11/23] setting the RJ45 port led behavior
 
 Signed-off-by: zengchao <chao.zeng@siemens.com>
 ---

--- a/recipes-kernel/linux/files/0012-fix-clear-the-cycle-buffer-of-serial.patch
+++ b/recipes-kernel/linux/files/0012-fix-clear-the-cycle-buffer-of-serial.patch
@@ -1,7 +1,7 @@
-From 6b72637818243212847489a51048f9ce5a2577d3 Mon Sep 17 00:00:00 2001
+From fc2e27663652b9961a0c4ee62dd8132e3683d7df Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Tue, 26 Nov 2019 09:05:56 +0800
-Subject: [PATCH 12/22] fix:clear the cycle buffer of serial
+Subject: [PATCH 12/23] fix:clear the cycle buffer of serial
 
 1.the last residual data will be sent next time
 

--- a/recipes-kernel/linux/files/0013-fix-4169461-fixed-eth-link-down-when-autoneg-off.patch
+++ b/recipes-kernel/linux/files/0013-fix-4169461-fixed-eth-link-down-when-autoneg-off.patch
@@ -1,7 +1,7 @@
-From 1da9df7f4ea442863cf4af24e3cba29d79de5ea3 Mon Sep 17 00:00:00 2001
+From 8a14429609d349b49005fdd5507029dceadd6dde Mon Sep 17 00:00:00 2001
 From: Sheng Long Wang <shenglong.wang.ext@siemens.com>
 Date: Fri, 13 Dec 2019 12:35:56 +0800
-Subject: [PATCH 13/22] fix(4169461):fixed eth link down when autoneg off
+Subject: [PATCH 13/23] fix(4169461):fixed eth link down when autoneg off
 
 1.dp83867: enable robust auto-mdix
 

--- a/recipes-kernel/linux/files/0014-refactor-move-ioexpander-node-to-mcu-i2c0-for-LM5.patch
+++ b/recipes-kernel/linux/files/0014-refactor-move-ioexpander-node-to-mcu-i2c0-for-LM5.patch
@@ -1,7 +1,7 @@
-From 7ce1011ad4a74b3dd0931ae633ca918a4dd18331 Mon Sep 17 00:00:00 2001
+From 9f2952f1975a38d7f4f3e9f7b20cbe06177888a8 Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Tue, 10 Dec 2019 11:33:37 +0800
-Subject: [PATCH 14/22] refactor:move ioexpander node to mcu-i2c0 for LM5
+Subject: [PATCH 14/23] refactor:move ioexpander node to mcu-i2c0 for LM5
 
 Signed-off-by: Gao Nian <nian.gao@siemens.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Gao Nian <nian.gao@siemens.com>
  1 file changed, 24 insertions(+), 24 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/siemens/iot2050-common.dtsi b/arch/arm64/boot/dts/siemens/iot2050-common.dtsi
-index c0ac25d2f60c..0b5e05ea8ba0 100644
+index d26185b60b18..a0862971a074 100644
 --- a/arch/arm64/boot/dts/siemens/iot2050-common.dtsi
 +++ b/arch/arm64/boot/dts/siemens/iot2050-common.dtsi
 @@ -483,6 +483,30 @@

--- a/recipes-kernel/linux/files/0015-fix-rproc-r5-0-set_config-failed-in-linux.patch
+++ b/recipes-kernel/linux/files/0015-fix-rproc-r5-0-set_config-failed-in-linux.patch
@@ -1,7 +1,7 @@
-From f390154dd87aec7ccee4f7f11ccb7c9d2be30bc4 Mon Sep 17 00:00:00 2001
+From 20b9740a1de4e03d292974188f6f59646f1ab4ad Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Thu, 2 Jan 2020 14:00:09 +0800
-Subject: [PATCH 15/22] fix: rproc r5-0 set_config failed in linux
+Subject: [PATCH 15/23] fix: rproc r5-0 set_config failed in linux
 
 Signed-off-by: Gao Nian <nian.gao@siemens.com>
 ---

--- a/recipes-kernel/linux/files/0016-feat-extend-led-panic-indicator-on-and-off.patch
+++ b/recipes-kernel/linux/files/0016-feat-extend-led-panic-indicator-on-and-off.patch
@@ -1,7 +1,7 @@
-From 02d8a735b979126c08d7e40204f8854f0be09004 Mon Sep 17 00:00:00 2001
+From fa9587bdb4eda3e57594bcc64a99182658d53c6f Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Fri, 3 Jan 2020 14:50:16 +0800
-Subject: [PATCH 16/22] feat:extend led panic-indicator on and off
+Subject: [PATCH 16/23] feat:extend led panic-indicator on and off
 
 Signed-off-by: Gao Nian <nian.gao@siemens.com>
 ---
@@ -13,7 +13,7 @@ Signed-off-by: Gao Nian <nian.gao@siemens.com>
  5 files changed, 30 insertions(+), 7 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/siemens/iot2050-common.dtsi b/arch/arm64/boot/dts/siemens/iot2050-common.dtsi
-index 0b5e05ea8ba0..89f354528830 100644
+index a0862971a074..924c89bf0a46 100644
 --- a/arch/arm64/boot/dts/siemens/iot2050-common.dtsi
 +++ b/arch/arm64/boot/dts/siemens/iot2050-common.dtsi
 @@ -132,6 +132,7 @@

--- a/recipes-kernel/linux/files/0017-fix-can-not-auto-negotiate-to-100M-with-4-wire.patch
+++ b/recipes-kernel/linux/files/0017-fix-can-not-auto-negotiate-to-100M-with-4-wire.patch
@@ -1,7 +1,7 @@
-From 55b5f9b868edd8e99b993052107d586315ad5e43 Mon Sep 17 00:00:00 2001
+From ef57d07683c94973fa2ac0205a2346c0fd0577c1 Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Tue, 4 Feb 2020 22:03:52 +0800
-Subject: [PATCH 17/22] fix:can not auto negotiate to 100M with 4-wire
+Subject: [PATCH 17/23] fix:can not auto negotiate to 100M with 4-wire
 
 Signed-off-by: Gao Nian <nian.gao@siemens.com>
 ---

--- a/recipes-kernel/linux/files/0018-change-OSPI-clock-id-to-support-sysfw-19.12.patch
+++ b/recipes-kernel/linux/files/0018-change-OSPI-clock-id-to-support-sysfw-19.12.patch
@@ -1,7 +1,7 @@
-From 7e8f41a7aa4ca5ac70c328447843a733a47419f9 Mon Sep 17 00:00:00 2001
+From 74ce03dde6d7dae58614dc6b4b83d63d8c3be8a6 Mon Sep 17 00:00:00 2001
 From: "le.jin" <le.jin@siemens.com>
 Date: Mon, 2 Mar 2020 23:01:32 +0800
-Subject: [PATCH 18/22] change OSPI clock id to support sysfw 19.12
+Subject: [PATCH 18/23] change OSPI clock id to support sysfw 19.12
 
 Signed-off-by: le.jin <le.jin@siemens.com>
 ---

--- a/recipes-kernel/linux/files/0019-feat-set-sdhci0-clock-frequency-to-142.86MHz.patch
+++ b/recipes-kernel/linux/files/0019-feat-set-sdhci0-clock-frequency-to-142.86MHz.patch
@@ -1,7 +1,7 @@
-From cbd91e849e606e1b7d24fc454620f266be5defed Mon Sep 17 00:00:00 2001
+From e78f7a6fd16adcd9120179a676846436845ce6a7 Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Mon, 17 Feb 2020 11:56:33 +0800
-Subject: [PATCH 19/22] feat: set sdhci0 clock frequency to 142.86MHz
+Subject: [PATCH 19/23] feat: set sdhci0 clock frequency to 142.86MHz
 
 1. catch up eth sdhci driver of SDK6.3
 2. merge the patch files provided by TI:
@@ -51,7 +51,7 @@ index 88b04c974294..9a83edbbeae1 100644
  };
 \ No newline at end of file
 diff --git a/arch/arm64/boot/dts/siemens/iot2050-common.dtsi b/arch/arm64/boot/dts/siemens/iot2050-common.dtsi
-index 89f354528830..c58ae32547a2 100644
+index 924c89bf0a46..e5cd3a6ba856 100644
 --- a/arch/arm64/boot/dts/siemens/iot2050-common.dtsi
 +++ b/arch/arm64/boot/dts/siemens/iot2050-common.dtsi
 @@ -585,9 +585,16 @@

--- a/recipes-kernel/linux/files/0020-feat-change-mmc-order-using-alias-in-dts.patch
+++ b/recipes-kernel/linux/files/0020-feat-change-mmc-order-using-alias-in-dts.patch
@@ -1,7 +1,7 @@
-From 6d7ccabd9df5c304a67d692233f6060b744e6b93 Mon Sep 17 00:00:00 2001
+From b7ea5bfc15d4dbcd21a2846af190d68b4b54b25d Mon Sep 17 00:00:00 2001
 From: "le.jin" <le.jin@siemens.com>
 Date: Wed, 9 Oct 2019 15:22:09 +0800
-Subject: [PATCH 20/22] feat:change mmc order using alias in dts
+Subject: [PATCH 20/23] feat:change mmc order using alias in dts
 
 1. modify kernel to support mmc alias in dts
 2. change SD to mmc0 and EMMC to mmc1 via alias in dts

--- a/recipes-kernel/linux/files/0021-fix-PLL4_DCO-freq-over-range-cause-DP-not-display.patch
+++ b/recipes-kernel/linux/files/0021-fix-PLL4_DCO-freq-over-range-cause-DP-not-display.patch
@@ -1,7 +1,7 @@
-From 02e86566ee70f66cfdb4fb49535ed5d78b20754d Mon Sep 17 00:00:00 2001
+From 25ee1f3560134b82edbe8c62e1c21d3986f70ed8 Mon Sep 17 00:00:00 2001
 From: Sheng Long Wang <shenglong.wang.ext@siemens.com>
 Date: Tue, 7 Apr 2020 15:30:06 +0800
-Subject: [PATCH 21/22] fix:PLL4_DCO freq over range cause DP not display
+Subject: [PATCH 21/23] fix:PLL4_DCO freq over range cause DP not display
 
   1.some DP may be can not display.
   2.reason: TI sysfw can not correct set PLL4 some frequency
@@ -20,7 +20,7 @@ Signed-off-by: Sheng Long Wang <shenglong.wang.ext@siemens.com>
  1 file changed, 207 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/tidss/tidss_dispc7.c b/drivers/gpu/drm/tidss/tidss_dispc7.c
-index 3c81b1186e..74d2fb4c51 100644
+index 3c81b1186efb..74d2fb4c51d7 100644
 --- a/drivers/gpu/drm/tidss/tidss_dispc7.c
 +++ b/drivers/gpu/drm/tidss/tidss_dispc7.c
 @@ -33,6 +33,21 @@
@@ -258,5 +258,5 @@ index 3c81b1186e..74d2fb4c51 100644
  
  /* OVR */
 -- 
-2.22.0
+2.17.1
 

--- a/recipes-kernel/linux/files/0022-iot2050-Roll-back-basic-dtb-to-V01.00.00.1-release.patch
+++ b/recipes-kernel/linux/files/0022-iot2050-Roll-back-basic-dtb-to-V01.00.00.1-release.patch
@@ -1,7 +1,7 @@
-From 0ef3b310bb5c63aeb1f1468c06a739a4e69b2066 Mon Sep 17 00:00:00 2001
+From 65bcbc6ae1249840477ad2cd66c83bb1ba53c387 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 2 May 2020 11:02:12 +0200
-Subject: [PATCH 22/22] iot2050: Roll back basic dtb to V01.00.00.1 release
+Subject: [PATCH 22/23] iot2050: Roll back basic dtb to V01.00.00.1 release
 
 That release came with sysfw 19.7.1 which had some... variations.
 
@@ -33,5 +33,5 @@ index 471f9b131db0..fe5900219a19 100644
 +	power-domains = <&k3_pds 55 TI_SCI_PD_EXCLUSIVE>;
 +};
 -- 
-2.16.4
+2.17.1
 

--- a/recipes-kernel/linux/files/0023-ethernet-add-the-alias-support-for-the-ethernet-driv.patch
+++ b/recipes-kernel/linux/files/0023-ethernet-add-the-alias-support-for-the-ethernet-driv.patch
@@ -1,0 +1,52 @@
+From f75956d44496092c325955dc93f4563656f58dbd Mon Sep 17 00:00:00 2001
+From: Chao Zeng <chao.zeng@siemens.com>
+Date: Thu, 18 Jun 2020 09:13:39 +0800
+Subject: [PATCH 23/23] ethernet:add the  alias support for the ethernet driver
+
+Signed-off-by: Chao Zeng <chao.zeng@siemens.com>
+---
+ drivers/net/ethernet/ti/icssg_prueth.c | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ethernet/ti/icssg_prueth.c b/drivers/net/ethernet/ti/icssg_prueth.c
+index 0984daafa585..3517be959f4d 100644
+--- a/drivers/net/ethernet/ti/icssg_prueth.c
++++ b/drivers/net/ethernet/ti/icssg_prueth.c
+@@ -1808,7 +1808,7 @@ static int prueth_probe(struct platform_device *pdev)
+ 	struct device_node *eth0_node, *eth1_node;
+ 	const struct of_device_id *match;
+ 	struct pruss *pruss[NUM_ICSSG];
+-	int i, ret, msmc_ram_size;
++	int i, ret, msmc_ram_size, id;
+ 
+ 	if (!np)
+ 		return -ENODEV;	/* we don't support non DT */
+@@ -2017,6 +2017,12 @@ static int prueth_probe(struct platform_device *pdev)
+ 
+ 	/* register the network devices */
+ 	if (eth0_node) {
++		id = of_alias_get_id(eth0_node,"ethernet");
++		if (id < 0){
++			dev_err(dev, "device does not have an alias id\n");
++			return id;
++		}
++		sprintf(prueth->emac[PRUETH_MAC0]->ndev->name,"eth%d",id);
+ 		ret = register_netdev(prueth->emac[PRUETH_MAC0]->ndev);
+ 		if (ret) {
+ 			dev_err(dev, "can't register netdev for port MII0");
+@@ -2027,6 +2033,12 @@ static int prueth_probe(struct platform_device *pdev)
+ 	}
+ 
+ 	if (eth1_node) {
++		id = of_alias_get_id(eth1_node,"ethernet");
++		if (id < 0){
++			dev_err(dev, "device does not have an alias id\n");
++			return id;
++		}
++		sprintf(prueth->emac[PRUETH_MAC1]->ndev->name,"eth%d",id);
+ 		ret = register_netdev(prueth->emac[PRUETH_MAC1]->ndev);
+ 		if (ret) {
+ 			dev_err(dev, "can't register netdev for port MII1");
+-- 
+2.17.1
+

--- a/recipes-kernel/linux/linux-iot2050_4.19.59+.bb
+++ b/recipes-kernel/linux/linux-iot2050_4.19.59+.bb
@@ -33,7 +33,8 @@ SRC_URI += "file://0001-iot2050-add-iot2050-platform-support.patch \
     file://0019-feat-set-sdhci0-clock-frequency-to-142.86MHz.patch \
     file://0020-feat-change-mmc-order-using-alias-in-dts.patch \
     file://0021-fix-PLL4_DCO-freq-over-range-cause-DP-not-display.patch \
-    file://0022-iot2050-Roll-back-basic-dtb-to-V01.00.00.1-release.patch"
+    file://0022-iot2050-Roll-back-basic-dtb-to-V01.00.00.1-release.patch \
+    file://0023-ethernet-add-the-alias-support-for-the-ethernet-driv.patch"
 
 KERNEL_REV = "5f8c1c6121da785bbe7ecc5896877a2537b5d6eb"
 SRC_URI[sha256sum] = "ef031959fd8242b943d0aa54ad4bf6338b698577739867701f6d7c7d04ec6e1f"


### PR DESCRIPTION
    as the ethernet labels on the box do not correspond to the
    ethernet port on the board.so needed swap the ethernet port.

    1. add the alias support for the ethernet driver

    2. modify the alias configuration to swap the ethernet port
Signed-off-by: Chao Zeng <chao.zeng@siemens.com>