### PR TITLE
WIP: Add mtdparts definition for upstream 5.9

### DIFF
--- a/conf/machine/iot2050.conf
+++ b/conf/machine/iot2050.conf
@@ -17,6 +17,8 @@ PREFERRED_PROVIDER_u-boot-${MACHINE} = "u-boot-iot2050"
 KERNEL_NAME ?= "iot2050"
 
 IMAGE_TYPE ?= "wic-img"
-WKS_FILE ?= "iot2050"
+WKS_FILE ?= "iot2050.wks.in"
 
 IMAGE_INSTALL += "u-boot-script"
+
+OSPI_MTDPARTS = "512k(ospi.tiboot3),2m(ospi.tispl),4m(ospi.u-boot),128k(ospi.env),128k(ospi.env.backup),1m(ospi.sysfw),64k(pru0-fw),64k(pru1-fw),64k(rtu0-fw),64k(rtu1-fw),-@8m(ospi.rootfs)"

--- a/wic/iot2050.wks.in
+++ b/wic/iot2050.wks.in
@@ -10,4 +10,4 @@
 
 part / --source rootfs-u-boot --sourceparams="no_initrd=yes,script_prepend=env exists fdtfile || if test \${board_name} = IOT2050-ADVANCED; then set fdtfile siemens/iot2050-advanced.dtb; else setenv fdtfile siemens/iot2050-basic-oldfw.dtb; fi" --fstype ext4 --label rootfs --align 1024 --use-uuid
 
-bootloader --ptable gpt --append "console=ttyS3,115200n8 earlycon=ns16550a,mmio32,0x02810000 mtdparts=47040000.spi.0:512k(ospi.tiboot3),2m(ospi.tispl),4m(ospi.u-boot),128k(ospi.env),128k(ospi.env.backup),1m(ospi.sysfw),64k(pru0-fw),64k(pru1-fw),64k(rtu0-fw),64k(rtu1-fw),-@8m(ospi.rootfs) rw rootwait"
+bootloader --ptable gpt --append "console=ttyS3,115200n8 earlycon=ns16550a,mmio32,0x02810000 rw rootwait mtdparts=spi7.0:${OSPI_MTDPARTS};47040000.spi.0:${OSPI_MTDPARTS}"


### PR DESCRIPTION
The device name of the OSPI changed in 5.9, and that requires us to
provide mtdparts both for the old 47040000.spi.0 as well as the new
spi7.0. Move the common part into a variable and convert the wks file
into a template for that purpose.

Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>