### PR TITLE
sdk: Add libjson-c, fix zlib arch

### DIFF
--- a/conf/distro/isar.conf
+++ b/conf/distro/isar.conf
@@ -51,4 +51,4 @@ HOST_DISTRO_APT_SOURCES_remove_packages-snapshot = "${DISTRO_APT_SOURCES_MAINLIN
 HOST_DISTRO_APT_PREFERENCES += "conf/distro/preferences.upstream-libssl"
 
 SDK_INSTALL += "linux-headers-${KERNEL_NAME} mraa"
-SDK_PREINSTALL += "zlib1g-dev"
+SDK_PREINSTALL += "zlib1g-dev:${DISTRO_ARCH} libjson-c-dev:${DISTRO_ARCH}"


### PR DESCRIPTION
libjson-c is needed for linking against mraa. And zlib1g-dev should come
for the target architecture.

Closes: #62
