### PR TITLE
Fix backport package selection for npm

### DIFF
--- a/conf/distro/preferences.npm-backport
+++ b/conf/distro/preferences.npm-backport
@@ -1,3 +1,7 @@
+Package: node-cacache node-copy-concurrently node-mkdirp node-uuid
+Pin: release n=buster
+Pin-Priority: 802
+
 Package: npm node-*
 Pin: release n=buster-backports
 Pin-Priority: 801


### PR DESCRIPTION
Something changed in buster-backports, breaking the simple selection of
all node-* packages from there. We need to keep four of them at stable
versions.
