### PR TITLE
refine kernel device tree

### DIFF
--- a/recipes-app/iot2050setup/files/iot2050setup.py
+++ b/recipes-app/iot2050setup/files/iot2050setup.py
@@ -17,7 +17,7 @@ class ansicolors:
 class TopMenu:
     def __init__(self):
         self.gscreen = SnackScreen()
-        self.boardType = subprocess.check_output('grep -a -o -P "IOT2050-\w*" /proc/device-tree/model',
+        self.boardType = subprocess.check_output('grep -a -o -P "IOT2050 \w*" /proc/device-tree/model',
                                                  shell=True).lstrip().rstrip().decode('utf-8')
 
     def show(self):
@@ -473,9 +473,9 @@ class PeripheralsMenu:
         self.terminateStatus = ''
         if (switchMode == 'RS485') or (switchMode == 'RS422'):
             self.terminateStatus = self.selectTerminate()
-        if self.topmenu.boardType == 'IOT2050-BASIC':
+        if self.topmenu.boardType == 'IOT2050 Basic':
             self.setBasicBoard(switchMode)
-        elif self.topmenu.boardType == 'IOT2050-ADVANCED':
+        elif self.topmenu.boardType == 'IOT2050 Advanced':
             self.setAdvancedBoard(switchMode)
         else:
             return

--- a/recipes-core/customizations-example/files/board-configuration
+++ b/recipes-core/customizations-example/files/board-configuration
@@ -69,7 +69,7 @@ def initAruinoPins():
 
 
 def initExternalSerialMode():
-    command = 'grep -a -o -P "IOT2050-\w*" /proc/device-tree/model'
+    command = 'grep -a -o -P "IOT2050 \w*" /proc/device-tree/model'
     boardType = subprocess.check_output(command, shell=True).lstrip().rstrip().decode('utf-8')
     initMode = config['User_configuration']['External_Serial_Init_Mode']
     currentMode = config['User_configuration']['External_Serial_Current_Mode']
@@ -80,9 +80,9 @@ def initExternalSerialMode():
         saveConfig(config)
 
     command = ""
-    if boardType == "IOT2050-BASIC":
+    if boardType == "IOT2050 Basic":
         command = "switchserialmode ttyuart -D /dev/ttyS2 -m " + initMode
-    elif boardType == "IOT2050-ADVANCED":
+    elif boardType == "IOT2050 Advanced":
         if initMode == "RS232":
             command = "switchserialmode cp210x -D cp2102n24 -m gpio -v 0"
         elif initMode == "RS485":

--- a/recipes-kernel/linux/files/0001-iot2050-add-iot2050-platform-support.patch
+++ b/recipes-kernel/linux/files/0001-iot2050-add-iot2050-platform-support.patch
@@ -1,4 +1,4 @@
-From f3cff2d5e56dcc2287d1689894b576e87c98562c Mon Sep 17 00:00:00 2001
+From ed5b2c3e07b04ac89344af3b118ece6650666cfd Mon Sep 17 00:00:00 2001
 From: Le Jin <le.jin@siemens.com>
 Date: Mon, 18 Nov 2019 17:58:08 +0800
 Subject: [PATCH 01/14] iot2050: add iot2050 platform support
@@ -9,21 +9,25 @@ Also add support for fixed gpio number naming.
 Signed-off-by: le.jin <le.jin@siemens.com>
 ---
  arch/arm64/boot/dts/ti/Makefile               |   5 +
- .../boot/dts/ti/k3-am65-iot2050-common.dtsi   | 750 ++++++++++++++++++
- .../ti/k3-am6528-iot2050-basic-common.dtsi    |  55 ++
- .../dts/ti/k3-am6528-iot2050-basic-oldfw.dts  |  13 +
- .../boot/dts/ti/k3-am6528-iot2050-basic.dts   |  16 +
- .../ti/k3-am6548-iot2050-advanced-oldfw.dts   |  65 ++
- .../dts/ti/k3-am6548-iot2050-advanced.dts     |  16 +
+ .../boot/dts/ti/k3-am65-iot2050-oldfw.dtsi    |  37 +
+ arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi   | 734 ++++++++++++++++++
+ .../dts/ti/k3-am6528-iot2050-basic-oldfw.dts  |  10 +
+ .../boot/dts/ti/k3-am6528-iot2050-basic.dts   |  12 +
+ .../boot/dts/ti/k3-am6528-iot2050-basic.dtsi  |  47 ++
+ .../ti/k3-am6548-iot2050-advanced-oldfw.dts   |  10 +
+ .../dts/ti/k3-am6548-iot2050-advanced.dts     |  12 +
+ .../dts/ti/k3-am6548-iot2050-advanced.dtsi    |  53 ++
  drivers/gpio/gpio-davinci.c                   |  10 +
  drivers/tty/serial/8250/8250_port.c           |   5 +-
- 9 files changed, 933 insertions(+), 2 deletions(-)
- create mode 100644 arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi
- create mode 100644 arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-common.dtsi
+ 11 files changed, 933 insertions(+), 2 deletions(-)
+ create mode 100644 arch/arm64/boot/dts/ti/k3-am65-iot2050-oldfw.dtsi
+ create mode 100644 arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
  create mode 100644 arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-oldfw.dts
  create mode 100644 arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts
+ create mode 100644 arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dtsi
  create mode 100644 arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-oldfw.dts
  create mode 100644 arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts
+ create mode 100644 arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dtsi
 
 diff --git a/arch/arm64/boot/dts/ti/Makefile b/arch/arm64/boot/dts/ti/Makefile
 index b952d3e730d6..3f6fc2f8445c 100644
@@ -41,24 +45,66 @@ index b952d3e730d6..3f6fc2f8445c 100644
  dtb-$(CONFIG_ARCH_K3_J721E_SOC) += k3-j721e-common-proc-board.dtb \
  				   k3-j721e-proc-board-tps65917.dtb \
  				   k3-j721e-common-proc-board-infotainment.dtbo \
-diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi
+diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050-oldfw.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050-oldfw.dtsi
 new file mode 100644
-index 000000000000..c585fdfcc5cc
+index 000000000000..5396aea0fb5e
 --- /dev/null
-+++ b/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi
-@@ -0,0 +1,750 @@
++++ b/arch/arm64/boot/dts/ti/k3-am65-iot2050-oldfw.dtsi
+@@ -0,0 +1,37 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
-+ * (C) Copyright 2019 Siemens AG
++ * (C) Copyright 2018-2020 Siemens AG
 + */
++
++/* workaround for uart issues (DMA warnings and RCU preempt) */
++
++&main_uart0 {
++	/delete-property/ dmas;
++	/delete-property/ dma-names;
++};
++
++&main_uart1 {
++	/delete-property/ dmas;
++	/delete-property/ dma-names;
++};
++
++&mcu_uart0 {
++	/delete-property/ dmas;
++	/delete-property/ dma-names;
++};
++
++/*
++ * Swap clock TISCI clock IDs between sdhci0 and sdhci1 to work
++ * around an issue in System Firmware 2019.12a (and earlier) known
++ * as SYSFW-3179.
++ */
++
++&sdhci0 {
++	clocks = <&k3_clks 48 0>, <&k3_clks 48 1>;
++	assigned-clocks = <&k3_clks 48 1>;
++	assigned-clock-rates = <142860000>;
++};
++
++&sdhci1 {
++	clocks = <&k3_clks 47 0>, <&k3_clks 47 1>;
++};
+diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
+new file mode 100644
+index 000000000000..1bf743e944bd
+--- /dev/null
++++ b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
+@@ -0,0 +1,734 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * (C) Copyright 2018-2020 Siemens AG
++ */
++
 +#include <dt-bindings/input/input.h>
 +#include <dt-bindings/net/ti-dp83867.h>
 +#include <dt-bindings/phy/phy.h>
++#include "k3-am654.dtsi"
 +
 +/ {
-+	compatible = "siemens,am654-iot2050", "ti,am654";
-+	model = "SIMATIC IOT2050 common";
-+
 +	aliases {
 +		ethernet1 = &pruss0_emac0;
 +		ethernet2 = &pruss0_emac1;
@@ -73,7 +119,7 @@ index 000000000000..c585fdfcc5cc
 +		bootargs = "earlycon=ns16550a,mmio32,0x02800000";
 +	};
 +
-+	reserved_memory: reserved-memory {
++	reserved_memory {
 +		#address-cells = <2>;
 +		#size-cells = <2>;
 +		ranges;
@@ -113,6 +159,50 @@ index 000000000000..c585fdfcc5cc
 +			alignment = <0x1000>;
 +			no-map;
 +		};
++	};
++
++	gpio_leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&leds_pins_default>;
++
++		status-led-red {
++			gpios = <&wkup_gpio0 32 GPIO_ACTIVE_HIGH>;
++			panic-indicator;
++			linux,default-trigger = "gpio";
++		};
++
++		status-led-green {
++			gpios = <&wkup_gpio0 24 GPIO_ACTIVE_HIGH>;
++			panic-indicator-off;
++			linux,default-trigger = "gpio";
++		};
++
++		user-led0-red {
++			gpios = <&pcal9535_3 14 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "gpio";
++		};
++
++		user-led0-green {
++			gpios = <&pcal9535_2 15 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "gpio";
++		};
++
++		user-led1-red {
++			gpios = <&wkup_gpio0 17 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "gpio";
++		};
++
++		user-led1-green {
++			gpios = <&wkup_gpio0 22 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "gpio";
++		};
++	};
++
++	dp_refclk: clock {
++		compatible = "fixed-clock";
++		#clock-cells = <0>;
++		clock-frequency = <19200000>;
 +	};
 +
 +	/* Dual Ethernet application node on PRU-ICSSG0 */
@@ -166,50 +256,6 @@ index 000000000000..c585fdfcc5cc
 +			/* Filled in by bootloader */
 +			local-mac-address = [00 00 00 00 00 00];
 +		};
-+	};
-+
-+	leds {
-+		compatible = "gpio-leds";
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&leds_pins_default>;
-+
-+		status-led-red {
-+			gpios = <&wkup_gpio0 32 GPIO_ACTIVE_HIGH>;
-+			panic-indicator;
-+			linux,default-trigger = "gpio";
-+		};
-+
-+		status-led-green {
-+			gpios = <&wkup_gpio0 24 GPIO_ACTIVE_HIGH>;
-+			panic-indicator-off;
-+			linux,default-trigger = "gpio";
-+		};
-+
-+		user-led0-red {
-+			gpios = <&pcal9535_3 14 GPIO_ACTIVE_HIGH>;
-+			linux,default-trigger = "gpio";
-+		};
-+
-+		user-led0-green {
-+			gpios = <&pcal9535_2 15 GPIO_ACTIVE_HIGH>;
-+			linux,default-trigger = "gpio";
-+		};
-+
-+		user-led1-red {
-+			gpios = <&wkup_gpio0 17 GPIO_ACTIVE_HIGH>;
-+			linux,default-trigger = "gpio";
-+		};
-+
-+		user-led1-green {
-+			gpios = <&wkup_gpio0 22 GPIO_ACTIVE_HIGH>;
-+			linux,default-trigger = "gpio";
-+		};
-+	};
-+
-+	dp_refclk: clock {
-+		compatible = "fixed-clock";
-+		#clock-cells = <0>;
-+		clock-frequency = <19200000>;
 +	};
 +};
 +
@@ -474,10 +520,6 @@ index 000000000000..c585fdfcc5cc
 +&main_uart1 {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&main_uart1_pins_default>;
-+
-+	/* workaround for uart issues (DMA warnings and RCU preempt) */
-+	/delete-property/ dmas;
-+	/delete-property/ dma-names;
 +};
 +
 +&main_uart2 {
@@ -487,10 +529,6 @@ index 000000000000..c585fdfcc5cc
 +&mcu_uart0 {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&arduino_uart_pins_default>;
-+
-+	/* workaround for uart issues (DMA warnings and RCU preempt) */
-+	/delete-property/ dmas;
-+	/delete-property/ dma-names;
 +};
 +
 +&main_gpio0 {
@@ -627,19 +665,12 @@ index 000000000000..c585fdfcc5cc
 +	status = "disabled";
 +};
 +
-+
 +&ecap0 {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&ecap0_pins_default>;
 +};
 +
 +&sdhci1 {
-+	/*
-+	 * Swap clock TISCI clock IDs between sdhci0 and sdhci1 to work
-+	 * around an issue in System Firmware 2019.12a (and earlier) known
-+	 * as SYSFW-3179.
-+	 */
-+	clocks = <&k3_clks 47 0>, <&k3_clks 47 1>;
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&main_mmc1_pins_default>;
 +	ti,driver-strength-ohm = <50>;
@@ -648,20 +679,6 @@ index 000000000000..c585fdfcc5cc
 +
 +&gpu {
 +	status = "okay";
-+};
-+
-+&dwc3_1 {
-+	status = "okay";
-+};
-+
-+&usb1_phy {
-+	status = "okay";
-+};
-+
-+&usb1 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&usb1_pins_default>;
-+	dr_mode = "otg";
 +};
 +
 +&dwc3_0 {
@@ -675,6 +692,20 @@ index 000000000000..c585fdfcc5cc
 +&usb0 {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&usb0_pins_default>;
++	dr_mode = "host";
++};
++
++&dwc3_1 {
++	status = "okay";
++};
++
++&usb1_phy {
++	status = "okay";
++};
++
++&usb1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&usb1_pins_default>;
 +	dr_mode = "host";
 +};
 +
@@ -797,24 +828,54 @@ index 000000000000..c585fdfcc5cc
 +&eip76d_trng {
 +	status = "disabled";
 +};
-diff --git a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-common.dtsi b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-common.dtsi
+diff --git a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-oldfw.dts b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-oldfw.dts
 new file mode 100644
-index 000000000000..9a2fcf02accf
+index 000000000000..405ebc7fb444
 --- /dev/null
-+++ b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-common.dtsi
-@@ -0,0 +1,55 @@
++++ b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-oldfw.dts
+@@ -0,0 +1,10 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
-+ * (C) Copyright 2020 Siemens AG
++ * (C) Copyright 2018-2020 Siemens AG
 + */
 +
 +/dts-v1/;
-+/* TBD: should include the Dual Core dtsi*/
-+#include "k3-am654.dtsi"
-+#include "k3-am65-iot2050-common.dtsi"
++
++#include "k3-am65-iot2050.dtsi"
++#include "k3-am6528-iot2050-basic.dtsi"
++#include "k3-am65-iot2050-oldfw.dtsi"
+diff --git a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts
+new file mode 100644
+index 000000000000..835bd694feb0
+--- /dev/null
++++ b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts
+@@ -0,0 +1,12 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * (C) Copyright 2018-2020 Siemens AG
++ */
++
++/dts-v1/;
++
++#include "k3-am65-iot2050.dtsi"
++#include "k3-am6528-iot2050-basic.dtsi"
++#include "k3-am65-main-abi3_x.dtsi"
++#include "k3-am65-mcu-abi3_x.dtsi"
++#include "k3-am65-wakeup-abi3_x.dtsi"
+diff --git a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dtsi b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dtsi
+new file mode 100644
+index 000000000000..14d0fa84dd2b
+--- /dev/null
++++ b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dtsi
+@@ -0,0 +1,47 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * (C) Copyright 2018-2020 Siemens AG
++ */
 +
 +/ {
-+	model = "SIMATIC IOT2050-BASIC";
++	compatible = "siemens,iot2050-basic", "ti,am654";
++	model = "SIMATIC IOT2050 Basic";
 +
 +	memory@80000000 {
 +		device_type = "memory";
@@ -849,74 +910,59 @@ index 000000000000..9a2fcf02accf
 +&main_uart0 {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&main_uart0_pins_default>;
-+
-+	/* workaround for uart issues (DMA warnings and RCU preempt) */
-+	/delete-property/ dmas;
-+	/delete-property/ dma-names;
 +};
 +
 +&sdhci0 {
 +	status = "disabled";
 +};
-diff --git a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-oldfw.dts b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-oldfw.dts
+diff --git a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-oldfw.dts b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-oldfw.dts
 new file mode 100644
-index 000000000000..e82c1e42a290
+index 000000000000..f17cc47e0560
 --- /dev/null
-+++ b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-oldfw.dts
-@@ -0,0 +1,13 @@
++++ b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-oldfw.dts
+@@ -0,0 +1,10 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
-+ * (C) Copyright 2020 Siemens AG
++ * (C) Copyright 2018-2020 Siemens AG
 + */
 +
 +/dts-v1/;
 +
-+#include "k3-am6528-iot2050-basic-common.dtsi"
-+
-+/ {
-+	model = "SIMATIC IOT2050-BASIC";
-+	compatible = "siemens,am654-iot2050", "ti,am654";
-+};
-diff --git a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts
++#include "k3-am65-iot2050.dtsi"
++#include "k3-am6548-iot2050-advanced.dtsi"
++#include "k3-am65-iot2050-oldfw.dtsi"
+diff --git a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts
 new file mode 100644
-index 000000000000..f7a2dcd76f52
+index 000000000000..a98c00af983b
 --- /dev/null
-+++ b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts
-@@ -0,0 +1,16 @@
++++ b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts
+@@ -0,0 +1,12 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
-+ * (C) Copyright 2019 Siemens AG
++ * (C) Copyright 2018-2020 Siemens AG
 + */
 +
 +/dts-v1/;
 +
-+#include "k3-am6528-iot2050-basic-common.dtsi"
++#include "k3-am65-iot2050.dtsi"
++#include "k3-am6548-iot2050-advanced.dtsi"
 +#include "k3-am65-main-abi3_x.dtsi"
 +#include "k3-am65-mcu-abi3_x.dtsi"
 +#include "k3-am65-wakeup-abi3_x.dtsi"
-+
-+/ {
-+	model = "SIMATIC IOT2050-BASIC";
-+	compatible = "siemens,am654-iot2050", "ti,am654";
-+};
-diff --git a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-oldfw.dts b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-oldfw.dts
+diff --git a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dtsi b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dtsi
 new file mode 100644
-index 000000000000..0c9dae6f763e
+index 000000000000..498e6cc7fa87
 --- /dev/null
-+++ b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-oldfw.dts
-@@ -0,0 +1,65 @@
++++ b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dtsi
+@@ -0,0 +1,53 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
-+ * (C) Copyright 2019 Siemens AG
++ * (C) Copyright 2018-2020 Siemens AG
 + */
 +
-+/dts-v1/;
-+
-+#include "k3-am654.dtsi"
-+#include "k3-am65-iot2050-common.dtsi"
-+
 +/ {
-+	model = "SIMATIC IOT2050-ADVANCED";
++	compatible = "siemens,iot2050-advanced", "ti,am654";
++	model = "SIMATIC IOT2050 Advanced";
 +
 +	aliases {
 +		mmc0 = &sdhci1;
@@ -955,43 +1001,12 @@ index 000000000000..0c9dae6f763e
 +};
 +
 +&sdhci0 {
-+	/*
-+	 * Swap clock TISCI clock IDs between sdhci0 and sdhci1 to work
-+	 * around an issue in System Firmware 2019.12a (and earlier) known
-+	 * as SYSFW-3179.
-+	 */
-+	clocks = <&k3_clks 48 0>, <&k3_clks 48 1>;
-+	assigned-clocks = <&k3_clks 48 1>;
-+	assigned-clock-rates = <142860000>;
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&main_mmc0_pins_default>;
 +	bus-width = <8>;
 +	non-removable;
 +	ti,driver-strength-ohm = <50>;
 +	disable-wp;
-+};
-\ No newline at end of file
-diff --git a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts
-new file mode 100644
-index 000000000000..2c1ca1db1a9f
---- /dev/null
-+++ b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts
-@@ -0,0 +1,16 @@
-+// SPDX-License-Identifier: GPL-2.0
-+/*
-+ * (C) Copyright 2019 Siemens AG
-+ */
-+
-+/dts-v1/;
-+
-+#include "k3-am6548-iot2050-advanced-oldfw.dts"
-+#include "k3-am65-main-abi3_x.dtsi"
-+#include "k3-am65-mcu-abi3_x.dtsi"
-+#include "k3-am65-wakeup-abi3_x.dtsi"
-+
-+/ {
-+	model = "SIMATIC IOT2050-ADVANCED";
-+	compatible = "siemens,am654-iot2050", "ti,am654";
 +};
 diff --git a/drivers/gpio/gpio-davinci.c b/drivers/gpio/gpio-davinci.c
 index 994ecd597abe..5030a14e86b5 100644
@@ -1038,5 +1053,5 @@ index aa4de6907f77..7019cc4e675d 100644
  			status = serial8250_rx_chars(up, status);
  	}
 -- 
-2.27.0
+2.25.1
 

--- a/recipes-kernel/linux/files/0002-Add-support-for-U9300C-TD-LTE-module.patch
+++ b/recipes-kernel/linux/files/0002-Add-support-for-U9300C-TD-LTE-module.patch
@@ -1,4 +1,4 @@
-From 66564e3aed6cf5bcc92128c3691e71d5486e98aa Mon Sep 17 00:00:00 2001
+From fef7fee855dd2737c013b8e92853f0e5fba54cf3 Mon Sep 17 00:00:00 2001
 From: Su Bao Cheng <baocheng.su@siemens.com>
 Date: Tue, 23 Apr 2019 10:07:17 +0800
 Subject: [PATCH 02/14] Add support for U9300C TD-LTE module
@@ -32,5 +32,5 @@ index 2905274e3626..72d30e29c4d1 100644
  	{ USB_DEVICE_AND_INTERFACE_INFO(HAIER_VENDOR_ID, HAIER_PRODUCT_CE81B, 0xff, 0xff, 0xff) },
  	/* Pirelli  */
 -- 
-2.27.0
+2.25.1
 

--- a/recipes-kernel/linux/files/0003-feat-Add-CP210x-driver-support-to-software-flow-cont.patch
+++ b/recipes-kernel/linux/files/0003-feat-Add-CP210x-driver-support-to-software-flow-cont.patch
@@ -1,4 +1,4 @@
-From 886cae812336e699e8fa765c0aa2fccf452f52b4 Mon Sep 17 00:00:00 2001
+From 23b032085260f968ba42ca7bdbd09833e91228de Mon Sep 17 00:00:00 2001
 From: Su Bao Cheng <baocheng.su@siemens.com>
 Date: Mon, 15 Jul 2019 15:46:09 +0800
 Subject: [PATCH 03/14] feat: Add CP210x driver support to software flow
@@ -186,5 +186,5 @@ index 7ae121567098..7815062ed980 100644
  
  static int cp210x_tiocmset(struct tty_struct *tty,
 -- 
-2.27.0
+2.25.1
 

--- a/recipes-kernel/linux/files/0004-fix-disable-usb-lpm-to-fix-usb-device-reset.patch
+++ b/recipes-kernel/linux/files/0004-fix-disable-usb-lpm-to-fix-usb-device-reset.patch
@@ -1,4 +1,4 @@
-From 9cf622a1a3216924634510ecc0b20136579af415 Mon Sep 17 00:00:00 2001
+From 87103fbd6acdc9151b8555e7d6f82359a5931d30 Mon Sep 17 00:00:00 2001
 From: Sheng Long Wang <shenglong.wang.ext@siemens.com>
 Date: Tue, 13 Aug 2019 09:30:38 +0800
 Subject: [PATCH 04/14] fix: disable usb lpm to fix usb device reset
@@ -21,5 +21,5 @@ index b33ec768404b..4fa95d89bfaf 100644
  
  	if (hub)
 -- 
-2.27.0
+2.25.1
 

--- a/recipes-kernel/linux/files/0005-Fix-DP-maybe-not-display-problem.patch
+++ b/recipes-kernel/linux/files/0005-Fix-DP-maybe-not-display-problem.patch
@@ -1,4 +1,4 @@
-From 32a8dfa7210227236c2b69857e8fbffbca1c0bb0 Mon Sep 17 00:00:00 2001
+From 65ee83551b90cc3b9e323a2329fe362b48ec6a55 Mon Sep 17 00:00:00 2001
 From: Sheng Long Wang <shenglong.wang.ext@siemens.com>
 Date: Tue, 13 Aug 2019 10:27:44 +0800
 Subject: [PATCH 05/14] Fix: DP maybe not display problem.
@@ -369,5 +369,5 @@ index c0b26135dbd5..fc2eadda02f8 100644
   * drm_kms_helper_poll_enable - re-enable output polling.
   * @dev: drm_device
 -- 
-2.27.0
+2.25.1
 

--- a/recipes-kernel/linux/files/0006-fix-fix-the-hardware-flow-function-of-cp2102n24.patch
+++ b/recipes-kernel/linux/files/0006-fix-fix-the-hardware-flow-function-of-cp2102n24.patch
@@ -1,4 +1,4 @@
-From dbbf386777937adb98ab474d0264f66221a801a5 Mon Sep 17 00:00:00 2001
+From ddea2e157156a96da44ff70cf195a3a357680d73 Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Wed, 21 Aug 2019 16:22:30 +0800
 Subject: [PATCH 06/14] fix:fix the hardware flow function of cp2102n24
@@ -49,5 +49,5 @@ index 7815062ed980..5d50eb092975 100644
  	} else {
  		dev_dbg(dev, "%s - flow control = NONE\n", __func__);
 -- 
-2.27.0
+2.25.1
 

--- a/recipes-kernel/linux/files/0007-feat-add-io-expander-pcal9535-support.patch
+++ b/recipes-kernel/linux/files/0007-feat-add-io-expander-pcal9535-support.patch
@@ -1,4 +1,4 @@
-From 2d3cb72d1513b30d46aff01bc45d3630a3d76e3f Mon Sep 17 00:00:00 2001
+From 6a0a73a057f8db38c3cfe890f885ef20c672e278 Mon Sep 17 00:00:00 2001
 From: "le.jin" <le.jin@siemens.com>
 Date: Wed, 9 Oct 2019 17:08:43 +0800
 Subject: [PATCH 07/14] feat:add io expander pcal9535 support
@@ -359,5 +359,5 @@ index a4d5eb37744a..c3af8cf978f6 100644
  						unsigned offset);
  
 -- 
-2.27.0
+2.25.1
 

--- a/recipes-kernel/linux/files/0008-setting-the-RJ45-port-led-behavior.patch
+++ b/recipes-kernel/linux/files/0008-setting-the-RJ45-port-led-behavior.patch
@@ -1,4 +1,4 @@
-From 436c5ad8bee85d5164256295e60ad52f8c847911 Mon Sep 17 00:00:00 2001
+From b81aa7bfcf477606bdfecbebd14dfd362ec7107e Mon Sep 17 00:00:00 2001
 From: zengchao <chao.zeng@siemens.com>
 Date: Wed, 6 Nov 2019 11:21:49 +0800
 Subject: [PATCH 08/14] setting the RJ45 port led behavior
@@ -34,5 +34,5 @@ index a7c34418eb37..a35ccaf6bb1b 100644
  }
  
 -- 
-2.27.0
+2.25.1
 

--- a/recipes-kernel/linux/files/0009-fix-clear-the-cycle-buffer-of-serial.patch
+++ b/recipes-kernel/linux/files/0009-fix-clear-the-cycle-buffer-of-serial.patch
@@ -1,4 +1,4 @@
-From 73a2a26db298fd2cd79578d7978dde31fa4dc18b Mon Sep 17 00:00:00 2001
+From 10c38135c6457b93593af42f54c47bdc1c33c929 Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Tue, 26 Nov 2019 09:05:56 +0800
 Subject: [PATCH 09/14] fix:clear the cycle buffer of serial
@@ -25,5 +25,5 @@ index 979e4c861a6b..47d90ed7e96e 100644
  	pm_runtime_put_autosuspend(port->dev);
  	free_irq(port->irq, port);
 -- 
-2.27.0
+2.25.1
 

--- a/recipes-kernel/linux/files/0010-feat-extend-led-panic-indicator-on-and-off.patch
+++ b/recipes-kernel/linux/files/0010-feat-extend-led-panic-indicator-on-and-off.patch
@@ -1,4 +1,4 @@
-From e029fae42a5552f772b0918261397049ee19cf2a Mon Sep 17 00:00:00 2001
+From 9fd9c64e2ffbd58d0057d09a2e77c9d73eff71d5 Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Tue, 22 Dec 2020 15:05:56 +0800
 Subject: [PATCH 10/14] feat:extend led panic-indicator on and off
@@ -121,5 +121,5 @@ index 577dadc4990a..73090c752808 100644
  	int 		num_leds;
  	const struct gpio_led *leds;
 -- 
-2.27.0
+2.25.1
 

--- a/recipes-kernel/linux/files/0011-fix-can-not-auto-negotiate-to-100M-with-4-wire.patch
+++ b/recipes-kernel/linux/files/0011-fix-can-not-auto-negotiate-to-100M-with-4-wire.patch
@@ -1,4 +1,4 @@
-From 34023158423b90cc2b55c5859e151a8fbb4949eb Mon Sep 17 00:00:00 2001
+From 20b89f52b90e67cb6e807a67adb7e7b6257f2407 Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Tue, 4 Feb 2020 22:03:52 +0800
 Subject: [PATCH 11/14] fix:can not auto negotiate to 100M with 4-wire
@@ -98,5 +98,5 @@ index a35ccaf6bb1b..2d1d3a0d151d 100644
  		.ack_interrupt	= dp83867_ack_interrupt,
  		.config_intr	= dp83867_config_intr,
 -- 
-2.27.0
+2.25.1
 

--- a/recipes-kernel/linux/files/0012-feat-change-mmc-order-using-alias-in-dts.patch
+++ b/recipes-kernel/linux/files/0012-feat-change-mmc-order-using-alias-in-dts.patch
@@ -1,4 +1,4 @@
-From bcabda46d4dac66795e4ef8ca78b6bcc554ca8aa Mon Sep 17 00:00:00 2001
+From 9d2a8acfcbbe8d57e991bc7e0705cf5d999e90a2 Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Tue, 22 Dec 2020 15:08:17 +0800
 Subject: [PATCH 12/14] feat:change mmc order using alias in dts
@@ -58,5 +58,5 @@ index f57f5de54206..5db720c6591b 100644
  
  	host->parent = dev;
 -- 
-2.27.0
+2.25.1
 

--- a/recipes-kernel/linux/files/0013-fix-PLL4_DCO-freq-over-range-cause-DP-not-display.patch
+++ b/recipes-kernel/linux/files/0013-fix-PLL4_DCO-freq-over-range-cause-DP-not-display.patch
@@ -1,4 +1,4 @@
-From bdf02a2f137773d2220bd267e86f08bba9570387 Mon Sep 17 00:00:00 2001
+From 721709b7b9402f0a59db85ea24231da446ebba22 Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Fri, 11 Dec 2020 17:20:12 +0800
 Subject: [PATCH 13/14] fix:PLL4_DCO freq over range cause DP not display
@@ -246,5 +246,5 @@ index 32f7535a0f83..b43cd213b6d9 100644
  }
  
 -- 
-2.27.0
+2.25.1
 

--- a/recipes-kernel/linux/files/0014-iot2050-Provide-dtb-for-devices-using-boot-load-V01..patch
+++ b/recipes-kernel/linux/files/0014-iot2050-Provide-dtb-for-devices-using-boot-load-V01..patch
@@ -1,6 +1,6 @@
-From 2370ace0ef982ad80bd91323c7140ffe52e991da Mon Sep 17 00:00:00 2001
+From 98418ea201036b78c702ed8a6ebbaf1e57081249 Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
-Date: Tue, 22 Dec 2020 15:23:54 +0800
+Date: Tue, 29 Dec 2020 15:19:47 +0800
 Subject: [PATCH 14/14] iot2050: Provide dtb for devices using boot load
  V01.00.00.1
 
@@ -12,13 +12,13 @@ Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
  1 file changed, 14 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-oldfw.dts b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-oldfw.dts
-index e82c1e42a290..6c276b252433 100644
+index 405ebc7fb444..28a2ec6ec4ca 100644
 --- a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-oldfw.dts
 +++ b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-oldfw.dts
-@@ -11,3 +11,17 @@
- 	model = "SIMATIC IOT2050-BASIC";
- 	compatible = "siemens,am654-iot2050", "ti,am654";
- };
+@@ -8,3 +8,17 @@
+ #include "k3-am65-iot2050.dtsi"
+ #include "k3-am6528-iot2050-basic.dtsi"
+ #include "k3-am65-iot2050-oldfw.dtsi"
 +
 +/* Compat support for bootloader V01.00.00.1 */
 +
@@ -34,5 +34,5 @@ index e82c1e42a290..6c276b252433 100644
 +	power-domains = <&k3_pds 55 TI_SCI_PD_EXCLUSIVE>;
 +};
 -- 
-2.27.0
+2.25.1
 

--- a/wic/iot2050.wks
+++ b/wic/iot2050.wks
@@ -8,6 +8,6 @@
 # COPYING.MIT file in the top-level directory.
 #
 
-part / --source rootfs-u-boot --sourceparams="no_initrd=yes,script_prepend=env exists fdtfile || if test \\\"\${board_name}\\\" = \\\"IOT2050-ADVANCED\\\"; then set fdtfile siemens/iot2050-advanced-oldfw.dtb; else setenv fdtfile siemens/iot2050-basic-oldfw.dtb; fi" --fstype ext4 --label rootfs --align 1024 --use-uuid
+part / --source rootfs-u-boot --sourceparams="no_initrd=yes,script_prepend=env exists fdtfile || if test \\\"\${board_name}\\\" = \\\"IOT2050-ADVANCED\\\"; then set fdtfile ti/k3-am6528-iot2050-advanced-oldfw.dtb; else setenv fdtfile ti/k3-am6548-iot2050-basic-oldfw.dtb; fi" --fstype ext4 --label rootfs --align 1024 --use-uuid
 
 bootloader --ptable gpt --append "console=ttyS3,115200n8 earlycon=ns16550a,mmio32,0x02810000 mtdparts=47040000.spi.0:512k(ospi.tiboot3),2m(ospi.tispl),4m(ospi.u-boot),128k(ospi.env),128k(ospi.env.backup),1m(ospi.sysfw),64k(pru0-fw),64k(pru1-fw),64k(rtu0-fw),64k(rtu1-fw),-@8m(ospi.rootfs) rw rootwait"


### PR DESCRIPTION
Extract oldfw related changes to k3-am65-iot2050-oldfw.dtsi, includes
uart dma workaround and the clock swapping of sdhci. Also change the
includings correspondingly.

Remove the word 'common' from iot2050.dtsi, sarcasticly our boards have
a lot that not in common.

Change the compatible and model string according to Jan's upstreaming
patch.

Change the dr_mode of usb1 to `host`.

Change board name in iot2050setup.py and board-configuration