### PR TITLE
linux: Fix dtb path error in boot.scr

### DIFF
--- a/wic/iot2050.wks
+++ b/wic/iot2050.wks
@@ -8,6 +8,6 @@
 # COPYING.MIT file in the top-level directory.
 #
 
-part / --source rootfs-u-boot --sourceparams="no_initrd=yes,script_prepend=env exists fdtfile || if test \\\"\${board_name}\\\" = \\\"IOT2050-ADVANCED\\\"; then set fdtfile ti/k3-am6528-iot2050-advanced-oldfw.dtb; else setenv fdtfile ti/k3-am6548-iot2050-basic-oldfw.dtb; fi" --fstype ext4 --label rootfs --align 1024 --use-uuid
+part / --source rootfs-u-boot --sourceparams="no_initrd=yes,script_prepend=env exists fdtfile || if test \\\"\${board_name}\\\" = \\\"IOT2050-ADVANCED\\\"; then set fdtfile ti/k3-am6548-iot2050-advanced-oldfw.dtb; else setenv fdtfile ti/k3-am6528-iot2050-basic-oldfw.dtb; fi" --fstype ext4 --label rootfs --align 1024 --use-uuid
 
 bootloader --ptable gpt --append "console=ttyS3,115200n8 earlycon=ns16550a,mmio32,0x02810000 mtdparts=47040000.spi.0:512k(ospi.tiboot3),2m(ospi.tispl),4m(ospi.u-boot),128k(ospi.env),128k(ospi.env.backup),1m(ospi.sysfw),64k(pru0-fw),64k(pru1-fw),64k(rtu0-fw),64k(rtu1-fw),-@8m(ospi.rootfs) rw rootwait"


### PR DESCRIPTION
The dtb paths in boot.scr are wrongly swapped between am6528 and am6548.

Signed-off-by: Su Baocheng <baocheng.su@siemens.com>