### PR TITLE
feat: enable soc device ID driver

### DIFF
--- a/recipes-bsp/u-boot/files/upstream/0001-arm-dts-Add-IOT2050-device-tree-files.patch
+++ b/recipes-bsp/u-boot/files/upstream/0001-arm-dts-Add-IOT2050-device-tree-files.patch
@@ -1,7 +1,7 @@
-From 7ad97960dface3b377afcbb1e80fd99141943293 Mon Sep 17 00:00:00 2001
+From ef42ed1ce4ba33de0e883a6632a541248b31dabe Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 30 Nov 2020 10:13:04 +0100
-Subject: [PATCH 01/25] arm: dts: Add IOT2050 device tree files
+Subject: [PATCH 01/26] arm: dts: Add IOT2050 device tree files
 
 Prepares for the addition of the IOT2050 board which is based on the TI
 AM65x. The board comes in two variants, Basic and Advanced, so there are

--- a/recipes-bsp/u-boot/files/upstream/0002-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
+++ b/recipes-bsp/u-boot/files/upstream/0002-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
@@ -1,7 +1,7 @@
-From f3c44d444fe5efecd6abc2a6ed9378fc6b447647 Mon Sep 17 00:00:00 2001
+From f94e05575281cd7774febeed45e5873afbb7725a Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 11 May 2020 20:10:16 +0200
-Subject: [PATCH 02/25] board: siemens: Add support for SIMATIC IOT2050 devices
+Subject: [PATCH 02/26] board: siemens: Add support for SIMATIC IOT2050 devices
 
 This adds support for the IOT2050 Basic and Advanced devices. The Basic
 used the dual-core AM6528 GP processor, the Advanced one the AM6548 HS

--- a/recipes-bsp/u-boot/files/upstream/0003-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
+++ b/recipes-bsp/u-boot/files/upstream/0003-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
@@ -1,7 +1,7 @@
-From 15684e84f15bf6f1c6391da8b5d2b3daae89af11 Mon Sep 17 00:00:00 2001
+From 1aad05328cf24eaa9c4effbda5b5af38b2a98b20 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 21 Jun 2020 09:04:30 +0200
-Subject: [PATCH 03/25] watchdog: rti_wdt: Add support for loading firmware
+Subject: [PATCH 03/26] watchdog: rti_wdt: Add support for loading firmware
 
 To avoid the need of extra boot scripting on AM65x for loading a
 watchdog firmware, add the required rproc init and loading logic for the

--- a/recipes-bsp/u-boot/files/upstream/0004-net-eth-uclass-eth_get_dev-based-on-SEQ_ALIAS-instea.patch
+++ b/recipes-bsp/u-boot/files/upstream/0004-net-eth-uclass-eth_get_dev-based-on-SEQ_ALIAS-instea.patch
@@ -1,7 +1,7 @@
-From 20f5aa4025c0625b6cb6eed93e752d42333b586e Mon Sep 17 00:00:00 2001
+From 7e4fdb19adbecdb006c6f207f68cf98c8befd2e9 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:53 +0530
-Subject: [PATCH 04/25] net: eth-uclass: eth_get_dev based on SEQ_ALIAS instead
+Subject: [PATCH 04/26] net: eth-uclass: eth_get_dev based on SEQ_ALIAS instead
  of probe order
 
 In case of multiple eth interfaces currently eth_get_dev

--- a/recipes-bsp/u-boot/files/upstream/0005-net-eth-uclass-call-stop-only-for-active-devices.patch
+++ b/recipes-bsp/u-boot/files/upstream/0005-net-eth-uclass-call-stop-only-for-active-devices.patch
@@ -1,7 +1,7 @@
-From a2bab4f40ba70442b50ea27a2ecb7cd0fc63e2b3 Mon Sep 17 00:00:00 2001
+From 7ba870f6c061d373c8989b655892ac244faa1f10 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:54 +0530
-Subject: [PATCH 05/25] net: eth-uclass: call stop only for active devices
+Subject: [PATCH 05/26] net: eth-uclass: call stop only for active devices
 
 Currently stop is being called unconditionally without even
 checking if start is called which will result in crash where

--- a/recipes-bsp/u-boot/files/upstream/0006-misc-uclass-Introduce-misc_init_by_ofnode.patch
+++ b/recipes-bsp/u-boot/files/upstream/0006-misc-uclass-Introduce-misc_init_by_ofnode.patch
@@ -1,7 +1,7 @@
-From 27cefc36506ec052ebedf03430cdc8455bffd3fc Mon Sep 17 00:00:00 2001
+From 9f3d92ba477fda886803a5fa41ef58d80e01c194 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:55 +0530
-Subject: [PATCH 06/25] misc: uclass: Introduce misc_init_by_ofnode
+Subject: [PATCH 06/26] misc: uclass: Introduce misc_init_by_ofnode
 
 Introduce misc_init_by_ofnode to probe a misc device
 using its ofnode.

--- a/recipes-bsp/u-boot/files/upstream/0007-soc-ti-pruss-add-a-misc-driver-for-PRUSS-in-TI-SoCs.patch
+++ b/recipes-bsp/u-boot/files/upstream/0007-soc-ti-pruss-add-a-misc-driver-for-PRUSS-in-TI-SoCs.patch
@@ -1,7 +1,7 @@
-From 34b38c8d3f828d79bef1c8fbb2e8cd95e17a0b40 Mon Sep 17 00:00:00 2001
+From 268ba60eae1912d71e95174b1c4687fd5ceb2414 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:56 +0530
-Subject: [PATCH 07/25] soc: ti: pruss: add a misc driver for PRUSS in TI SoCs
+Subject: [PATCH 07/26] soc: ti: pruss: add a misc driver for PRUSS in TI SoCs
 
 The Programmable Real-Time Unit - Industrial Communication
 Subsystem (PRU-ICSS) is present of various TI SoCs such as

--- a/recipes-bsp/u-boot/files/upstream/0008-remoteproc-pruss-add-PRU-remoteproc-driver.patch
+++ b/recipes-bsp/u-boot/files/upstream/0008-remoteproc-pruss-add-PRU-remoteproc-driver.patch
@@ -1,7 +1,7 @@
-From 71e625830f94f19d47b32b5bc93c2351da56bf9c Mon Sep 17 00:00:00 2001
+From fb783236be8a4a13b041b86aa07236dfaeaa82fa Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:57 +0530
-Subject: [PATCH 08/25] remoteproc: pruss: add PRU remoteproc driver
+Subject: [PATCH 08/26] remoteproc: pruss: add PRU remoteproc driver
 
 The Programmable Real-Time Unit Subsystem (PRUSS) consists of
 dual 32-bit RISC cores (Programmable Real-Time Units, or PRUs)

--- a/recipes-bsp/u-boot/files/upstream/0009-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
+++ b/recipes-bsp/u-boot/files/upstream/0009-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
@@ -1,7 +1,7 @@
-From 8a0d0fe099e466234c809b400cbe846b2a953b16 Mon Sep 17 00:00:00 2001
+From 21572fe559b73710c87e02e6bcd8963232d34f2d Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:58 +0530
-Subject: [PATCH 09/25] net: ti: icssg-prueth: Add ICSSG ethernet driver
+Subject: [PATCH 09/26] net: ti: icssg-prueth: Add ICSSG ethernet driver
 
 This is the Ethernet driver for TI SoCs with the
 ICSSG PRU Sub-system running EMAC firmware.

--- a/recipes-bsp/u-boot/files/upstream/0010-arm-dts-k3-am65-main-Add-msmc_ram-node.patch
+++ b/recipes-bsp/u-boot/files/upstream/0010-arm-dts-k3-am65-main-Add-msmc_ram-node.patch
@@ -1,7 +1,7 @@
-From 42497b2caa896391427e42f6bef68ea2c9d62a48 Mon Sep 17 00:00:00 2001
+From 13c4c859cef7c4644ce5092caedfbddef240b5ee Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:59 +0530
-Subject: [PATCH 10/25] arm: dts: k3-am65-main: Add msmc_ram node
+Subject: [PATCH 10/26] arm: dts: k3-am65-main: Add msmc_ram node
 
 Add msmc_ram node needed for prueth
 

--- a/recipes-bsp/u-boot/files/upstream/0011-arm-dts-k3-am654-base-board-u-boot-Add-icssg-specifi.patch
+++ b/recipes-bsp/u-boot/files/upstream/0011-arm-dts-k3-am654-base-board-u-boot-Add-icssg-specifi.patch
@@ -1,7 +1,7 @@
-From 583cd8191deda61faa9e10828e6f49675fcf2564 Mon Sep 17 00:00:00 2001
+From f2a34e920ea51975ecba88daf9368cf1cf20a9c5 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:49:00 +0530
-Subject: [PATCH 11/25] arm: dts: k3-am654-base-board-u-boot: Add icssg
+Subject: [PATCH 11/26] arm: dts: k3-am654-base-board-u-boot: Add icssg
  specific msmc_ram carveout nodes
 
 Add icssg specific msmc_ram carveout nodes

--- a/recipes-bsp/u-boot/files/upstream/0012-arm-dts-k3-am65-main-Add-scm_conf-node.patch
+++ b/recipes-bsp/u-boot/files/upstream/0012-arm-dts-k3-am65-main-Add-scm_conf-node.patch
@@ -1,7 +1,7 @@
-From 3f120715e7dc59782008dc798e0a2c2a945e2dde Mon Sep 17 00:00:00 2001
+From f4e85852b54df151a6020abd9b99bc91541d2687 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:49:01 +0530
-Subject: [PATCH 12/25] arm: dts: k3-am65-main: Add scm_conf node
+Subject: [PATCH 12/26] arm: dts: k3-am65-main: Add scm_conf node
 
 Add scm_conf node needed for prueth.
 

--- a/recipes-bsp/u-boot/files/upstream/0013-arm-dts-k3-am65-main-Add-pruss-nodes-for-ICSSG2.patch
+++ b/recipes-bsp/u-boot/files/upstream/0013-arm-dts-k3-am65-main-Add-pruss-nodes-for-ICSSG2.patch
@@ -1,7 +1,7 @@
-From c5147a2c3f4f275e5ef8f448fac7e636bd2b5a67 Mon Sep 17 00:00:00 2001
+From ca78c8712bde267f8366b851416d7e2c79db9bbe Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 30 Apr 2020 12:10:17 +0530
-Subject: [PATCH 13/25] arm: dts: k3-am65-main: Add pruss nodes for ICSSG2
+Subject: [PATCH 13/26] arm: dts: k3-am65-main: Add pruss nodes for ICSSG2
 
 Add pruss nodes. This is based 4.19 DT with interrupt properties
 removed from pur/rtu nodes.

--- a/recipes-bsp/u-boot/files/upstream/0014-arm64-dts-ti-am654-base-board-add-ICSSG2-Ethernet-su.patch
+++ b/recipes-bsp/u-boot/files/upstream/0014-arm64-dts-ti-am654-base-board-add-ICSSG2-Ethernet-su.patch
@@ -1,7 +1,7 @@
-From 27f841fe72db3440aa07632b432454f0231178ff Mon Sep 17 00:00:00 2001
+From cf4bfe25e2191066968e72e33e7fdf65d71285c1 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:49:03 +0530
-Subject: [PATCH 14/25] arm64: dts: ti: am654-base-board: add ICSSG2 Ethernet
+Subject: [PATCH 14/26] arm64: dts: ti: am654-base-board: add ICSSG2 Ethernet
  support
 
 ICSSG2 provide dual Gigabit Ethernet support.

--- a/recipes-bsp/u-boot/files/upstream/0015-configs-am65x_evm_a53_defconfig-Enable-prueth-config.patch
+++ b/recipes-bsp/u-boot/files/upstream/0015-configs-am65x_evm_a53_defconfig-Enable-prueth-config.patch
@@ -1,7 +1,7 @@
-From cbc7153e6af9066c1c956b0d38fedb56f4b89bc6 Mon Sep 17 00:00:00 2001
+From bfcaa784308b56a453473ec4b2511c2a6be9bced Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 30 Apr 2020 12:17:50 +0530
-Subject: [PATCH 15/25] configs: am65x_evm_a53_defconfig: Enable prueth configs
+Subject: [PATCH 15/26] configs: am65x_evm_a53_defconfig: Enable prueth configs
 
 Enable prueth configs
 

--- a/recipes-bsp/u-boot/files/upstream/0016-net-ti-icssg-prueth-Drop-unsupported-modes-from-the-.patch
+++ b/recipes-bsp/u-boot/files/upstream/0016-net-ti-icssg-prueth-Drop-unsupported-modes-from-the-.patch
@@ -1,7 +1,7 @@
-From a79560bad235cc60638b11e6a489a63f3041efad Mon Sep 17 00:00:00 2001
+From 1586cee9ac0b587fe4649c7b7b3d822b5128f577 Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:30 +0000
-Subject: [PATCH 16/25] net: ti: icssg-prueth: Drop unsupported modes from the
+Subject: [PATCH 16/26] net: ti: icssg-prueth: Drop unsupported modes from the
  PHY
 
 Currently driver supports only 100M and 1G Full duplex modes and

--- a/recipes-bsp/u-boot/files/upstream/0017-net-ti-icssg-prueth-use-constants-instead-of-hardcod.patch
+++ b/recipes-bsp/u-boot/files/upstream/0017-net-ti-icssg-prueth-use-constants-instead-of-hardcod.patch
@@ -1,7 +1,7 @@
-From 17729012fefe23e362e366e84d3529e75df487d5 Mon Sep 17 00:00:00 2001
+From ffd10b1bcdf2b4955443d9ce3e49352bb08129cb Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:31 +0000
-Subject: [PATCH 17/25] net: ti: icssg-prueth: use constants instead of
+Subject: [PATCH 17/26] net: ti: icssg-prueth: use constants instead of
  hardcoded values
 
 Use existing constants for speed and duplex values instead of

--- a/recipes-bsp/u-boot/files/upstream/0018-net-ti-icssg-prueth-use-a-single-chn_name-variable-i.patch
+++ b/recipes-bsp/u-boot/files/upstream/0018-net-ti-icssg-prueth-use-a-single-chn_name-variable-i.patch
@@ -1,7 +1,7 @@
-From 60a97ee5b16a3300458611431c36427fa0dae9cd Mon Sep 17 00:00:00 2001
+From 52adaa20cb7f79ab75e9b337f8c24236b1b6dd74 Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:32 +0000
-Subject: [PATCH 18/25] net: ti: icssg-prueth: use a single chn_name variable
+Subject: [PATCH 18/26] net: ti: icssg-prueth: use a single chn_name variable
  in prueth_start()
 
 Use a single array variable for chn_name in prueth_start() by re-arranging

--- a/recipes-bsp/u-boot/files/upstream/0019-net-ti-icssg-prueth-Add-port-speed-duplex-command.patch
+++ b/recipes-bsp/u-boot/files/upstream/0019-net-ti-icssg-prueth-Add-port-speed-duplex-command.patch
@@ -1,7 +1,7 @@
-From 8666f686bd3d8efb164c99569382e83f458bb206 Mon Sep 17 00:00:00 2001
+From b0c3b196a95fd8629c6606b7b50103d264aad583 Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:33 +0000
-Subject: [PATCH 19/25] net: ti: icssg-prueth: Add port speed/duplex command
+Subject: [PATCH 19/26] net: ti: icssg-prueth: Add port speed/duplex command
 
 This patch adds port speed/duplex command to firmware once
 the link is up. ICSSG firmware uses default of 10M Half duplex

--- a/recipes-bsp/u-boot/files/upstream/0020-net-ti-icssg-prueth-Add-shutdown-command.patch
+++ b/recipes-bsp/u-boot/files/upstream/0020-net-ti-icssg-prueth-Add-shutdown-command.patch
@@ -1,7 +1,7 @@
-From c397e5e13c53f194655b873ffe643f7ea91b83b3 Mon Sep 17 00:00:00 2001
+From aa76d73df7c22c73e0cc5be4840f6dabae751eb0 Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:34 +0000
-Subject: [PATCH 20/25] net: ti: icssg-prueth: Add shutdown command
+Subject: [PATCH 20/26] net: ti: icssg-prueth: Add shutdown command
 
 As part of prueth_stop(), stop the firmware packet processing
 by issuing a shutdown command so that interface is taken down

--- a/recipes-bsp/u-boot/files/upstream/0021-net-ti-icssg-prueth-Auto-start-PRU-and-RTU-when-star.patch
+++ b/recipes-bsp/u-boot/files/upstream/0021-net-ti-icssg-prueth-Auto-start-PRU-and-RTU-when-star.patch
@@ -1,7 +1,7 @@
-From c104370b9ec41a0e93d2e8f1e97411806687036e Mon Sep 17 00:00:00 2001
+From f1665e2264fa4f1bb1b00c49f7c12206d7f3338e Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 19 May 2020 17:07:44 +0200
-Subject: [PATCH 21/25] net: ti: icssg-prueth: Auto-start PRU and RTU when
+Subject: [PATCH 21/26] net: ti: icssg-prueth: Auto-start PRU and RTU when
  starting the interface
 
 This avoids having to do that explicitly on every usage, allowing to

--- a/recipes-bsp/u-boot/files/upstream/0022-config_distro_bootcmd-Add-platform-start-script-hook.patch
+++ b/recipes-bsp/u-boot/files/upstream/0022-config_distro_bootcmd-Add-platform-start-script-hook.patch
@@ -1,7 +1,7 @@
-From e1c02919369aefd0793f9e022cd4fcbb43542b3c Mon Sep 17 00:00:00 2001
+From f040e079a49cd396a7b31fe39b432988a7bff3ab Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 19 May 2020 17:10:27 +0200
-Subject: [PATCH 22/25] config_distro_bootcmd: Add platform start script hook
+Subject: [PATCH 22/26] config_distro_bootcmd: Add platform start script hook
  for networking
 
 This can be used by boards to inject start commands needed for platform

--- a/recipes-bsp/u-boot/files/upstream/0023-arm-dts-k3-am65-main-Add-ICSSG0-1-nodes.patch
+++ b/recipes-bsp/u-boot/files/upstream/0023-arm-dts-k3-am65-main-Add-ICSSG0-1-nodes.patch
@@ -1,7 +1,7 @@
-From bf59b381e8196d5eb582e9802b3dc09956498880 Mon Sep 17 00:00:00 2001
+From 6175d3a3f5e03313361d3b5267480219af2495a0 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Mon, 10 Feb 2020 16:59:29 +0530
-Subject: [PATCH 23/25] arm: dts: k3-am65-main: Add ICSSG0/1 nodes
+Subject: [PATCH 23/26] arm: dts: k3-am65-main: Add ICSSG0/1 nodes
 
 Add the ICCSG0/1 and child nodes.
 

--- a/recipes-bsp/u-boot/files/upstream/0024-iot2050-Add-ICSSG0-Ethernet-support.patch
+++ b/recipes-bsp/u-boot/files/upstream/0024-iot2050-Add-ICSSG0-Ethernet-support.patch
@@ -1,7 +1,7 @@
-From 7bf4abc7ba7ee841d12189e8b3d5bde7a7501e29 Mon Sep 17 00:00:00 2001
+From c5cb5915814a9dca09c2e3604d261f9f4a71c9d4 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 17 May 2020 20:10:30 +0200
-Subject: [PATCH 24/25] iot2050: Add ICSSG0 Ethernet support
+Subject: [PATCH 24/26] iot2050: Add ICSSG0 Ethernet support
 
 Analogously to the am654-base-board, this adds support for the dual
 Gigabit Ethernet on IOT2050. Here it is connected to ICSSG0. Either mii0

--- a/recipes-bsp/u-boot/files/upstream/0025-iot2050-config-the-default-device-tree.patch
+++ b/recipes-bsp/u-boot/files/upstream/0025-iot2050-config-the-default-device-tree.patch
@@ -1,7 +1,7 @@
-From 85b312bc4a7de4fdfff7908159c35b16962f49ea Mon Sep 17 00:00:00 2001
+From 208eb553c24ba80405e1024d716e12e2379f8677 Mon Sep 17 00:00:00 2001
 From: Chao Zeng <chao.zeng@siemens.com>
 Date: Mon, 28 Dec 2020 15:32:49 +0800
-Subject: [PATCH 25/25] iot2050: config the default device tree
+Subject: [PATCH 25/26] iot2050: config the default device tree
 
 modify the default device tree according to the new dts naming
 

--- a/recipes-bsp/u-boot/files/upstream/0026-enable-soc-device-ID-driver.patch
+++ b/recipes-bsp/u-boot/files/upstream/0026-enable-soc-device-ID-driver.patch
@@ -1,0 +1,29 @@
+From e9dae53b9e0bab261e971020254a27f83a3a1f60 Mon Sep 17 00:00:00 2001
+From: Chao Zeng <chao.zeng@siemens.com>
+Date: Fri, 15 Jan 2021 15:23:02 +0800
+Subject: [PATCH 26/26] enable soc device ID driver
+
+This allows Texas Instruments Keystone 3 SoCs to identify
+specifics about the SoC in use
+
+Signed-off-by: Chao Zeng <chao.zeng@siemens.com>
+---
+ configs/iot2050_defconfig | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configs/iot2050_defconfig b/configs/iot2050_defconfig
+index f2f2496c11..38619f3f7b 100644
+--- a/configs/iot2050_defconfig
++++ b/configs/iot2050_defconfig
+@@ -121,6 +121,8 @@ CONFIG_DM_RESET=y
+ CONFIG_RESET_TI_SCI=y
+ CONFIG_DM_SERIAL=y
+ CONFIG_SOC_TI=y
++CONFIG_SOC_DEVICE_TI_K3=y
++CONFIG_SOC_DEVICE=y
+ CONFIG_TI_PRUSS=y
+ CONFIG_SPI=y
+ CONFIG_DM_SPI=y
+-- 
+2.17.1
+

--- a/recipes-bsp/u-boot/u-boot-iot2050-2021.x-upstream.inc
+++ b/recipes-bsp/u-boot/u-boot-iot2050-2021.x-upstream.inc
@@ -37,6 +37,7 @@ SRC_URI += " \
     file://upstream/0023-arm-dts-k3-am65-main-Add-ICSSG0-1-nodes.patch \
     file://upstream/0024-iot2050-Add-ICSSG0-Ethernet-support.patch \
     file://upstream/0025-iot2050-config-the-default-device-tree.patch \
+    file://upstream/0026-enable-soc-device-ID-driver.patch \
     "
 
 U_BOOT_REV = "51f65b506f37252acb3cd4184ef5e1fc20da13a2"


### PR DESCRIPTION
This allows Texas Instruments Keystone 3 SoCs to identify
specifics about the SoC in use

Signed-off-by: Chao Zeng <chao.zeng@siemens.com>