### PR TITLE
u-boot: Enable flash protection for IOT2050

### DIFF
--- a/recipes-bsp/u-boot/files/upstream/0001-arm-dts-Add-IOT2050-device-tree-files.patch
+++ b/recipes-bsp/u-boot/files/upstream/0001-arm-dts-Add-IOT2050-device-tree-files.patch
@@ -1,7 +1,7 @@
-From ef42ed1ce4ba33de0e883a6632a541248b31dabe Mon Sep 17 00:00:00 2001
+From 97feb0a90f895c54a6e7827be38d7db75a47cd84 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 30 Nov 2020 10:13:04 +0100
-Subject: [PATCH 01/26] arm: dts: Add IOT2050 device tree files
+Subject: [PATCH 01/28] arm: dts: Add IOT2050 device tree files
 
 Prepares for the addition of the IOT2050 board which is based on the TI
 AM65x. The board comes in two variants, Basic and Advanced, so there are
@@ -872,5 +872,5 @@ index 0000000000..80c56df0b9
 +	status = "disabled";
 +};
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0002-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
+++ b/recipes-bsp/u-boot/files/upstream/0002-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
@@ -1,7 +1,7 @@
-From f94e05575281cd7774febeed45e5873afbb7725a Mon Sep 17 00:00:00 2001
+From 4479ca81e585b3e24ce18c3cdbc1ab402d7d9348 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 11 May 2020 20:10:16 +0200
-Subject: [PATCH 02/26] board: siemens: Add support for SIMATIC IOT2050 devices
+Subject: [PATCH 02/28] board: siemens: Add support for SIMATIC IOT2050 devices
 
 This adds support for the IOT2050 Basic and Advanced devices. The Basic
 used the dual-core AM6528 GP processor, the Advanced one the AM6548 HS
@@ -640,5 +640,5 @@ index 0000000000..2d1b1b1150
 +
 +#endif /* __CONFIG_IOT2050_H */
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0003-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
+++ b/recipes-bsp/u-boot/files/upstream/0003-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
@@ -1,7 +1,7 @@
-From 1aad05328cf24eaa9c4effbda5b5af38b2a98b20 Mon Sep 17 00:00:00 2001
+From 8d6cc2b7b67eb175ecde1c9d2ab7e46a3f9eb720 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 21 Jun 2020 09:04:30 +0200
-Subject: [PATCH 03/26] watchdog: rti_wdt: Add support for loading firmware
+Subject: [PATCH 03/28] watchdog: rti_wdt: Add support for loading firmware
 
 To avoid the need of extra boot scripting on AM65x for loading a
 watchdog firmware, add the required rproc init and loading logic for the
@@ -162,5 +162,5 @@ index 0000000000..78d99ff9f2
 +rti_wdt_fw_size:
 +.int rti_wdt_fw_end - rti_wdt_fw
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0004-net-eth-uclass-eth_get_dev-based-on-SEQ_ALIAS-instea.patch
+++ b/recipes-bsp/u-boot/files/upstream/0004-net-eth-uclass-eth_get_dev-based-on-SEQ_ALIAS-instea.patch
@@ -1,7 +1,7 @@
-From 7e4fdb19adbecdb006c6f207f68cf98c8befd2e9 Mon Sep 17 00:00:00 2001
+From 51e33f54827794b44662453f9345b73a4ff738b4 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:53 +0530
-Subject: [PATCH 04/26] net: eth-uclass: eth_get_dev based on SEQ_ALIAS instead
+Subject: [PATCH 04/28] net: eth-uclass: eth_get_dev based on SEQ_ALIAS instead
  of probe order
 
 In case of multiple eth interfaces currently eth_get_dev
@@ -36,5 +36,5 @@ index e14695c0f1..e1b9fbd14a 100644
  }
  
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0005-net-eth-uclass-call-stop-only-for-active-devices.patch
+++ b/recipes-bsp/u-boot/files/upstream/0005-net-eth-uclass-call-stop-only-for-active-devices.patch
@@ -1,7 +1,7 @@
-From 7ba870f6c061d373c8989b655892ac244faa1f10 Mon Sep 17 00:00:00 2001
+From 58e7288b13e4a9d4ef1480ecc987c0c24eb72f43 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:54 +0530
-Subject: [PATCH 05/26] net: eth-uclass: call stop only for active devices
+Subject: [PATCH 05/28] net: eth-uclass: call stop only for active devices
 
 Currently stop is being called unconditionally without even
 checking if start is called which will result in crash where
@@ -28,5 +28,5 @@ index e1b9fbd14a..bb4c362ede 100644
  	/* clear the MAC address */
  	memset(pdata->enetaddr, 0, ARP_HLEN);
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0006-misc-uclass-Introduce-misc_init_by_ofnode.patch
+++ b/recipes-bsp/u-boot/files/upstream/0006-misc-uclass-Introduce-misc_init_by_ofnode.patch
@@ -1,7 +1,7 @@
-From 9f3d92ba477fda886803a5fa41ef58d80e01c194 Mon Sep 17 00:00:00 2001
+From 4b1b7e00d25b66ea2f283d797112b1524aee9481 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:55 +0530
-Subject: [PATCH 06/26] misc: uclass: Introduce misc_init_by_ofnode
+Subject: [PATCH 06/28] misc: uclass: Introduce misc_init_by_ofnode
 
 Introduce misc_init_by_ofnode to probe a misc device
 using its ofnode.
@@ -80,5 +80,5 @@ index 12d1325ee2..79263ed480 100644
   * struct misc_ops - Driver model Misc operations
   *
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0007-soc-ti-pruss-add-a-misc-driver-for-PRUSS-in-TI-SoCs.patch
+++ b/recipes-bsp/u-boot/files/upstream/0007-soc-ti-pruss-add-a-misc-driver-for-PRUSS-in-TI-SoCs.patch
@@ -1,7 +1,7 @@
-From 268ba60eae1912d71e95174b1c4687fd5ceb2414 Mon Sep 17 00:00:00 2001
+From 7894263cbceee9c905e96ba509d0c1d8c5b1fe99 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:56 +0530
-Subject: [PATCH 07/26] soc: ti: pruss: add a misc driver for PRUSS in TI SoCs
+Subject: [PATCH 07/28] soc: ti: pruss: add a misc driver for PRUSS in TI SoCs
 
 The Programmable Real-Time Unit - Industrial Communication
 Subsystem (PRU-ICSS) is present of various TI SoCs such as
@@ -239,5 +239,5 @@ index 0000000000..9eadeef172
 +int pruss_request_shrmem_region(struct udevice *dev, phys_addr_t *loc);
 +int pruss_request_tm_region(struct udevice *dev, phys_addr_t *loc);
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0008-remoteproc-pruss-add-PRU-remoteproc-driver.patch
+++ b/recipes-bsp/u-boot/files/upstream/0008-remoteproc-pruss-add-PRU-remoteproc-driver.patch
@@ -1,7 +1,7 @@
-From fb783236be8a4a13b041b86aa07236dfaeaa82fa Mon Sep 17 00:00:00 2001
+From 6f73f79c1978f8a4d35f8f44c52a2061259588fb Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:57 +0530
-Subject: [PATCH 08/26] remoteproc: pruss: add PRU remoteproc driver
+Subject: [PATCH 08/28] remoteproc: pruss: add PRU remoteproc driver
 
 The Programmable Real-Time Unit Subsystem (PRUSS) consists of
 dual 32-bit RISC cores (Programmable Real-Time Units, or PRUs)
@@ -461,5 +461,5 @@ index 0000000000..2d01550431
 +	.priv_auto_alloc_size = sizeof(struct pru_privdata),
 +};
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0009-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
+++ b/recipes-bsp/u-boot/files/upstream/0009-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
@@ -1,7 +1,7 @@
-From 21572fe559b73710c87e02e6bcd8963232d34f2d Mon Sep 17 00:00:00 2001
+From 5802c857ed6c202211abeaaab7cab8d7ec591f0a Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:58 +0530
-Subject: [PATCH 09/26] net: ti: icssg-prueth: Add ICSSG ethernet driver
+Subject: [PATCH 09/28] net: ti: icssg-prueth: Add ICSSG ethernet driver
 
 This is the Ethernet driver for TI SoCs with the
 ICSSG PRU Sub-system running EMAC firmware.
@@ -1153,5 +1153,5 @@ index 0000000000..2af14ed5b2
 +	regmap_write(miig_rt, offs[slice].mac1, mac1);
 +}
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0010-arm-dts-k3-am65-main-Add-msmc_ram-node.patch
+++ b/recipes-bsp/u-boot/files/upstream/0010-arm-dts-k3-am65-main-Add-msmc_ram-node.patch
@@ -1,7 +1,7 @@
-From 13c4c859cef7c4644ce5092caedfbddef240b5ee Mon Sep 17 00:00:00 2001
+From 471a3e648b1966e66755c9ef40d3ca84868a25c5 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:59 +0530
-Subject: [PATCH 10/26] arm: dts: k3-am65-main: Add msmc_ram node
+Subject: [PATCH 10/28] arm: dts: k3-am65-main: Add msmc_ram node
 
 Add msmc_ram node needed for prueth
 
@@ -45,5 +45,5 @@ index 028f57379b..9bfe147b5c 100644
  		compatible = "arm,gic-v3";
  		#address-cells = <2>;
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0011-arm-dts-k3-am654-base-board-u-boot-Add-icssg-specifi.patch
+++ b/recipes-bsp/u-boot/files/upstream/0011-arm-dts-k3-am654-base-board-u-boot-Add-icssg-specifi.patch
@@ -1,7 +1,7 @@
-From f2a34e920ea51975ecba88daf9368cf1cf20a9c5 Mon Sep 17 00:00:00 2001
+From 882231081af496e2ea552d72939a4a84a32d1515 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:49:00 +0530
-Subject: [PATCH 11/26] arm: dts: k3-am654-base-board-u-boot: Add icssg
+Subject: [PATCH 11/28] arm: dts: k3-am654-base-board-u-boot: Add icssg
  specific msmc_ram carveout nodes
 
 Add icssg specific msmc_ram carveout nodes
@@ -32,5 +32,5 @@ index d75d1b1c28..f2956651e6 100644
 +	};
 +};
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0012-arm-dts-k3-am65-main-Add-scm_conf-node.patch
+++ b/recipes-bsp/u-boot/files/upstream/0012-arm-dts-k3-am65-main-Add-scm_conf-node.patch
@@ -1,7 +1,7 @@
-From f4e85852b54df151a6020abd9b99bc91541d2687 Mon Sep 17 00:00:00 2001
+From 8137711e834e2c2cc64dc35075feb319649013fd Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:49:01 +0530
-Subject: [PATCH 12/26] arm: dts: k3-am65-main: Add scm_conf node
+Subject: [PATCH 12/28] arm: dts: k3-am65-main: Add scm_conf node
 
 Add scm_conf node needed for prueth.
 
@@ -30,5 +30,5 @@ index 9bfe147b5c..b85e999e2e 100644
  		compatible = "ti,am654-secure-proxy";
  		#mbox-cells = <1>;
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0013-arm-dts-k3-am65-main-Add-pruss-nodes-for-ICSSG2.patch
+++ b/recipes-bsp/u-boot/files/upstream/0013-arm-dts-k3-am65-main-Add-pruss-nodes-for-ICSSG2.patch
@@ -1,7 +1,7 @@
-From ca78c8712bde267f8366b851416d7e2c79db9bbe Mon Sep 17 00:00:00 2001
+From 759e65ea6d7db140e1506eb00cc932a4fdd1d7a8 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 30 Apr 2020 12:10:17 +0530
-Subject: [PATCH 13/26] arm: dts: k3-am65-main: Add pruss nodes for ICSSG2
+Subject: [PATCH 13/28] arm: dts: k3-am65-main: Add pruss nodes for ICSSG2
 
 Add pruss nodes. This is based 4.19 DT with interrupt properties
 removed from pur/rtu nodes.
@@ -114,5 +114,5 @@ index b85e999e2e..4b5460ad24 100644
 +	};
  };
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0014-arm64-dts-ti-am654-base-board-add-ICSSG2-Ethernet-su.patch
+++ b/recipes-bsp/u-boot/files/upstream/0014-arm64-dts-ti-am654-base-board-add-ICSSG2-Ethernet-su.patch
@@ -1,7 +1,7 @@
-From cf4bfe25e2191066968e72e33e7fdf65d71285c1 Mon Sep 17 00:00:00 2001
+From 9d5aa6a437b5d6832eb50fd5fbb9bec3c44bd6a3 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:49:03 +0530
-Subject: [PATCH 14/26] arm64: dts: ti: am654-base-board: add ICSSG2 Ethernet
+Subject: [PATCH 14/28] arm64: dts: ti: am654-base-board: add ICSSG2 Ethernet
  support
 
 ICSSG2 provide dual Gigabit Ethernet support.
@@ -160,5 +160,5 @@ index f2956651e6..a522ad71d7 100644
 +	};
 +};
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0015-configs-am65x_evm_a53_defconfig-Enable-prueth-config.patch
+++ b/recipes-bsp/u-boot/files/upstream/0015-configs-am65x_evm_a53_defconfig-Enable-prueth-config.patch
@@ -1,7 +1,7 @@
-From bfcaa784308b56a453473ec4b2511c2a6be9bced Mon Sep 17 00:00:00 2001
+From d4a71bf4a059149190b867284442a684f862031f Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 30 Apr 2020 12:17:50 +0530
-Subject: [PATCH 15/26] configs: am65x_evm_a53_defconfig: Enable prueth configs
+Subject: [PATCH 15/28] configs: am65x_evm_a53_defconfig: Enable prueth configs
 
 Enable prueth configs
 
@@ -43,5 +43,5 @@ index 941073ce7f..a87c23f373 100644
  CONFIG_OF_LIBFDT_OVERLAY=y
 +CONFIG_SPL_SYSCON=y
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0016-net-ti-icssg-prueth-Drop-unsupported-modes-from-the-.patch
+++ b/recipes-bsp/u-boot/files/upstream/0016-net-ti-icssg-prueth-Drop-unsupported-modes-from-the-.patch
@@ -1,7 +1,7 @@
-From 1586cee9ac0b587fe4649c7b7b3d822b5128f577 Mon Sep 17 00:00:00 2001
+From 6d17c97d3cd9b8dcbbe9ba559a42c550c9b3574f Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:30 +0000
-Subject: [PATCH 16/26] net: ti: icssg-prueth: Drop unsupported modes from the
+Subject: [PATCH 16/28] net: ti: icssg-prueth: Drop unsupported modes from the
  PHY
 
 Currently driver supports only 100M and 1G Full duplex modes and
@@ -33,5 +33,5 @@ index 03160b415a..e61dc51247 100644
  	phydev->advertising = phydev->supported;
  
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0017-net-ti-icssg-prueth-use-constants-instead-of-hardcod.patch
+++ b/recipes-bsp/u-boot/files/upstream/0017-net-ti-icssg-prueth-use-constants-instead-of-hardcod.patch
@@ -1,7 +1,7 @@
-From ffd10b1bcdf2b4955443d9ce3e49352bb08129cb Mon Sep 17 00:00:00 2001
+From ee290e35c3237a43b96b12aa4eeb18dec388becc Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:31 +0000
-Subject: [PATCH 17/26] net: ti: icssg-prueth: use constants instead of
+Subject: [PATCH 17/28] net: ti: icssg-prueth: use constants instead of
  hardcoded values
 
 Use existing constants for speed and duplex values instead of
@@ -34,5 +34,5 @@ index e61dc51247..971a4631f1 100644
  		icssg_update_rgmii_cfg(priv->miig_rt, gig_en, full_duplex,
  				       priv->slice);
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0018-net-ti-icssg-prueth-use-a-single-chn_name-variable-i.patch
+++ b/recipes-bsp/u-boot/files/upstream/0018-net-ti-icssg-prueth-use-a-single-chn_name-variable-i.patch
@@ -1,7 +1,7 @@
-From 52adaa20cb7f79ab75e9b337f8c24236b1b6dd74 Mon Sep 17 00:00:00 2001
+From 346832e87b640d11b22046c933a97d825834ba4d Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:32 +0000
-Subject: [PATCH 18/26] net: ti: icssg-prueth: use a single chn_name variable
+Subject: [PATCH 18/28] net: ti: icssg-prueth: use a single chn_name variable
  in prueth_start()
 
 Use a single array variable for chn_name in prueth_start() by re-arranging
@@ -46,5 +46,5 @@ index 971a4631f1..19511638c9 100644
  		dev_err(dev, "RX dma get failed %d\n", ret);
  
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0019-net-ti-icssg-prueth-Add-port-speed-duplex-command.patch
+++ b/recipes-bsp/u-boot/files/upstream/0019-net-ti-icssg-prueth-Add-port-speed-duplex-command.patch
@@ -1,7 +1,7 @@
-From b0c3b196a95fd8629c6606b7b50103d264aad583 Mon Sep 17 00:00:00 2001
+From 65effdb358dada39d0f677fb6c971b8c31772859 Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:33 +0000
-Subject: [PATCH 19/26] net: ti: icssg-prueth: Add port speed/duplex command
+Subject: [PATCH 19/28] net: ti: icssg-prueth: Add port speed/duplex command
 
 This patch adds port speed/duplex command to firmware once
 the link is up. ICSSG firmware uses default of 10M Half duplex
@@ -265,5 +265,5 @@ index 19511638c9..5d5b932f63 100644
  	for (i = 8; i < 16; i++)
  		config->tx_buf_sz[i] = cpu_to_le32(0x1800);
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0020-net-ti-icssg-prueth-Add-shutdown-command.patch
+++ b/recipes-bsp/u-boot/files/upstream/0020-net-ti-icssg-prueth-Add-shutdown-command.patch
@@ -1,7 +1,7 @@
-From aa76d73df7c22c73e0cc5be4840f6dabae751eb0 Mon Sep 17 00:00:00 2001
+From d977ef3f316ff4d5c97365c34ae94b64af39a393 Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:34 +0000
-Subject: [PATCH 20/26] net: ti: icssg-prueth: Add shutdown command
+Subject: [PATCH 20/28] net: ti: icssg-prueth: Add shutdown command
 
 As part of prueth_stop(), stop the firmware packet processing
 by issuing a shutdown command so that interface is taken down
@@ -42,5 +42,5 @@ index 5d5b932f63..5abb221601 100644
  
  	dma_disable(&priv->dma_tx);
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0021-net-ti-icssg-prueth-Auto-start-PRU-and-RTU-when-star.patch
+++ b/recipes-bsp/u-boot/files/upstream/0021-net-ti-icssg-prueth-Auto-start-PRU-and-RTU-when-star.patch
@@ -1,7 +1,7 @@
-From f1665e2264fa4f1bb1b00c49f7c12206d7f3338e Mon Sep 17 00:00:00 2001
+From 47b1183df6a95361ea788ec98caa5742440e8ecb Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 19 May 2020 17:07:44 +0200
-Subject: [PATCH 21/26] net: ti: icssg-prueth: Auto-start PRU and RTU when
+Subject: [PATCH 21/28] net: ti: icssg-prueth: Auto-start PRU and RTU when
  starting the interface
 
 This avoids having to do that explicitly on every usage, allowing to
@@ -71,5 +71,5 @@ index 5abb221601..4cb1fa079f 100644
  				 (u8 *)pdata->enetaddr);
  	icssg_class_default(priv->miig_rt, priv->slice);
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0022-config_distro_bootcmd-Add-platform-start-script-hook.patch
+++ b/recipes-bsp/u-boot/files/upstream/0022-config_distro_bootcmd-Add-platform-start-script-hook.patch
@@ -1,7 +1,7 @@
-From f040e079a49cd396a7b31fe39b432988a7bff3ab Mon Sep 17 00:00:00 2001
+From b13c2728387c749f6e9b50da531a9a4e965b62ea Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 19 May 2020 17:10:27 +0200
-Subject: [PATCH 22/26] config_distro_bootcmd: Add platform start script hook
+Subject: [PATCH 22/28] config_distro_bootcmd: Add platform start script hook
  for networking
 
 This can be used by boards to inject start commands needed for platform
@@ -44,5 +44,5 @@ index c9862260a3..6ee251680f 100644
  		"if pxe get; then " \
  			"pxe boot; " \
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0023-arm-dts-k3-am65-main-Add-ICSSG0-1-nodes.patch
+++ b/recipes-bsp/u-boot/files/upstream/0023-arm-dts-k3-am65-main-Add-ICSSG0-1-nodes.patch
@@ -1,7 +1,7 @@
-From 6175d3a3f5e03313361d3b5267480219af2495a0 Mon Sep 17 00:00:00 2001
+From 8ac4cf0545bf24fc144d6316736dc2da4bb65d69 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Mon, 10 Feb 2020 16:59:29 +0530
-Subject: [PATCH 23/26] arm: dts: k3-am65-main: Add ICSSG0/1 nodes
+Subject: [PATCH 23/28] arm: dts: k3-am65-main: Add ICSSG0/1 nodes
 
 Add the ICCSG0/1 and child nodes.
 
@@ -228,5 +228,5 @@ index 4b5460ad24..cb28c411ef 100644
  		compatible = "ti,am654-icssg";
  		power-domains = <&k3_pds 64 TI_SCI_PD_EXCLUSIVE>;
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0024-iot2050-Add-ICSSG0-Ethernet-support.patch
+++ b/recipes-bsp/u-boot/files/upstream/0024-iot2050-Add-ICSSG0-Ethernet-support.patch
@@ -1,7 +1,7 @@
-From c5cb5915814a9dca09c2e3604d261f9f4a71c9d4 Mon Sep 17 00:00:00 2001
+From 88f1cd7fcb49f95623ee0a6dd6120f3b0421d668 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 17 May 2020 20:10:30 +0200
-Subject: [PATCH 24/26] iot2050: Add ICSSG0 Ethernet support
+Subject: [PATCH 24/28] iot2050: Add ICSSG0 Ethernet support
 
 Analogously to the am654-base-board, this adds support for the dual
 Gigabit Ethernet on IOT2050. Here it is connected to ICSSG0. Either mii0
@@ -320,5 +320,5 @@ index 2d1b1b1150..7c0d340f6b 100644
  #include <config_distro_bootcmd.h>
  
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0025-iot2050-config-the-default-device-tree.patch
+++ b/recipes-bsp/u-boot/files/upstream/0025-iot2050-config-the-default-device-tree.patch
@@ -1,7 +1,7 @@
-From 208eb553c24ba80405e1024d716e12e2379f8677 Mon Sep 17 00:00:00 2001
+From 6b108e6dd62359809f627609fa091feb732f461c Mon Sep 17 00:00:00 2001
 From: Chao Zeng <chao.zeng@siemens.com>
 Date: Mon, 28 Dec 2020 15:32:49 +0800
-Subject: [PATCH 25/26] iot2050: config the default device tree
+Subject: [PATCH 25/28] iot2050: config the default device tree
 
 modify the default device tree according to the new dts naming
 
@@ -29,5 +29,5 @@ index 31931e7a5a..f2f2496c11 100644
  CONFIG_ENV_IS_IN_SPI_FLASH=y
  CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0026-enable-soc-device-ID-driver.patch
+++ b/recipes-bsp/u-boot/files/upstream/0026-enable-soc-device-ID-driver.patch
@@ -1,7 +1,7 @@
-From e9dae53b9e0bab261e971020254a27f83a3a1f60 Mon Sep 17 00:00:00 2001
+From 2b66b40c9e4ee1952da3223971376f4fe9cfd036 Mon Sep 17 00:00:00 2001
 From: Chao Zeng <chao.zeng@siemens.com>
 Date: Fri, 15 Jan 2021 15:23:02 +0800
-Subject: [PATCH 26/26] enable soc device ID driver
+Subject: [PATCH 26/28] enable soc device ID driver
 
 This allows Texas Instruments Keystone 3 SoCs to identify
 specifics about the SoC in use
@@ -25,5 +25,5 @@ index f2f2496c11..38619f3f7b 100644
  CONFIG_SPI=y
  CONFIG_DM_SPI=y
 -- 
-2.17.1
+2.25.1
 

--- a/recipes-bsp/u-boot/files/upstream/0027-iot2050-Add-support-for-flash-protect.patch
+++ b/recipes-bsp/u-boot/files/upstream/0027-iot2050-Add-support-for-flash-protect.patch
@@ -1,0 +1,32 @@
+From fbb415a6ad15195146ef1f2720032ba17555d38c Mon Sep 17 00:00:00 2001
+From: Su Baocheng <baocheng.su@siemens.com>
+Date: Wed, 20 Jan 2021 16:52:19 +0800
+Subject: [PATCH 27/28] iot2050: Add support for flash protect
+
+IOT2050 use a Winbond flash that support lock & unlock, but it was not
+enabled.
+
+This winbond flash is a similar one to STMICRO, and can reuse the lock
+unlock logic for STMICRO chips. So by adding CONFIG_SPI_FLASH_STMICRO
+to iot2050_defconfig, the flash protection could be supported.
+
+Signed-off-by: Su Baocheng <baocheng.su@siemens.com>
+---
+ configs/iot2050_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configs/iot2050_defconfig b/configs/iot2050_defconfig
+index 38619f3f7b..1439434cdf 100644
+--- a/configs/iot2050_defconfig
++++ b/configs/iot2050_defconfig
+@@ -96,6 +96,7 @@ CONFIG_MMC_SDHCI_ADMA=y
+ CONFIG_MMC_SDHCI_AM654=y
+ CONFIG_DM_SPI_FLASH=y
+ CONFIG_SPI_FLASH_SFDP_SUPPORT=y
++CONFIG_SPI_FLASH_STMICRO=y
+ CONFIG_SPI_FLASH_WINBOND=y
+ # CONFIG_SPI_FLASH_USE_4K_SECTORS is not set
+ CONFIG_PHY_TI=y
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/files/upstream/0028-mtd-spi-Add-support-of-flash-protection-to-w25q128.patch
+++ b/recipes-bsp/u-boot/files/upstream/0028-mtd-spi-Add-support-of-flash-protection-to-w25q128.patch
@@ -1,0 +1,59 @@
+From c6cd732e6a7376e29ca167564dba77cbbc744f9c Mon Sep 17 00:00:00 2001
+From: Su Baocheng <baocheng.su@siemens.com>
+Date: Wed, 20 Jan 2021 19:05:47 +0800
+Subject: [PATCH 28/28] mtd: spi: Add support of flash protection to w25q128
+
+The NOR flash w25q128 denoted by JEDEC ID 0xef4018 actually represents
+various models. From Winbond's website, I could only find 3 types of
+them:
+
+    W25Q128JV-IQ/JQ
+    datasheet:https://www.winbond.com/resource-files/
+w25q128jv%20revg%2004082019%20plus.pdf
+
+    W25Q128FV (SPI Mode)
+    datasheet: https://www.winbond.com/resource-files/
+w25q128fv%20rev.m%2005132016%20kms.pdf
+
+    W25Q128BV
+    datesheet: https://www.winbond.com/resource-files/
+w25q128bv_revh_100313_wo_automotive.pdf
+
+According to the datasheets, all of these 3 types support BP(0,1,2) and
+TB bits in the status register (SR), so it could reuse the flash
+protection logic for ST Micro.
+
+So it should be safe to add the SPI_NOR_HAS_LOCK and SPI_NOR_HAS_TB
+flags to the w25q128 entry of spi_nor_ids table.
+
+Signed-off-by: Su Baocheng <baocheng.su@siemens.com>
+---
+ drivers/mtd/spi/spi-nor-ids.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/mtd/spi/spi-nor-ids.c b/drivers/mtd/spi/spi-nor-ids.c
+index 09e8196048..0486d42829 100644
+--- a/drivers/mtd/spi/spi-nor-ids.c
++++ b/drivers/mtd/spi/spi-nor-ids.c
+@@ -318,7 +318,17 @@ const struct flash_info spi_nor_ids[] = {
+ 	{ INFO("w25q80bl", 0xef4014, 0, 64 * 1024,  16, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ INFO("w25q16cl", 0xef4015, 0, 64 * 1024,  32, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ INFO("w25q64cv", 0xef4017, 0, 64 * 1024,  128, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+-	{ INFO("w25q128", 0xef4018, 0, 64 * 1024, 256, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
++	/* There are 3 types of w25q128 with JEDEC ID 0xef4018:
++	 *     W25Q128JV-IQ/JQ
++	 *     W25Q128FV (SPI Mode)
++	 *     W25Q128BV
++	 *  According to the datasheets, All of these 3 types support
++	 *  protection through BP{0,1,2}, TB in the status register (SR).
++	 */
++	{ INFO("w25q128", 0xef4018, 0, 64 * 1024, 256,
++			SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
++			SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
++	},
+ 	{ INFO("w25q256", 0xef4019, 0, 64 * 1024, 512, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ #endif
+ #ifdef CONFIG_SPI_FLASH_XMC
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/u-boot-iot2050-2021.x-upstream.inc
+++ b/recipes-bsp/u-boot/u-boot-iot2050-2021.x-upstream.inc
@@ -38,6 +38,8 @@ SRC_URI += " \
     file://upstream/0024-iot2050-Add-ICSSG0-Ethernet-support.patch \
     file://upstream/0025-iot2050-config-the-default-device-tree.patch \
     file://upstream/0026-enable-soc-device-ID-driver.patch \
+    file://upstream/0027-iot2050-Add-support-for-flash-protect.patch \
+    file://upstream/0028-mtd-spi-Add-support-of-flash-protection-to-w25q128.patch \
     "
 
 U_BOOT_REV = "51f65b506f37252acb3cd4184ef5e1fc20da13a2"


### PR DESCRIPTION
The flash chip of IOT2050 is a Winbond chip and can reuse the same
logic of flash protection of STMICRO chips.

User can use `sf protect lock` and `sf protect unlock` commands to lock
& unlock the flash.
