### PR TITLE
ci: Run RT image build in separate job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,22 +3,29 @@ name: CI
 on: [push]
 
 jobs:
-  images:
-    name: Images
+  debian-example-image:
+    name: Debian example image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Example image
+      - name: Build image
         run: ./kas-container build kas-iot2050-example.yml
-      - name: Upload example image
+      - name: Upload image
         uses: actions/upload-artifact@v2
         with:
           name: iot2050-example-image
           path: build/tmp/deploy/images/iot2050/iot2050-image-example-iot2050-debian-iot2050.wic.img*
-      - name: RT example image
+
+  debian-rt-example-image:
+    name: Debian RT example image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build image
         run: ./kas-container build kas-iot2050-example.yml:kas/opt/preempt-rt.yml
-      - name: Upload RT example image
+      - name: Upload image
         uses: actions/upload-artifact@v2
         with:
           name: iot2050-example-image-rt


### PR DESCRIPTION
Seems we overflow some log limits on github now. Splitting up will also
speed up the completion, at the price of building the common pieces of
both images twice.
