### PR TITLE
Add support for interactive and automatic eMMC installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ First checkout the desired tag. Then build the image or sdk by appending the `ka
 ./kas-container build kas-iot2050-example.yml:kas/opt/sdk.yml:kas/opt/package-lock.yml
 ```
 
-## Booting the Image from SD card
+## Booting the image from SD card
 
 Under Linux, insert an unused SD card. Assuming the SD card takes device
 /dev/mmcblk0, use dd to copy the image to it. For example:
@@ -106,6 +106,23 @@ use that to ssh in.
 
 NOTE: To login, the default username and password is `root`.
 And you are required to change the default password when first login.
+
+## Installing the image on the eMMC (IOT2050 Advanced only)
+
+During the very first boot of the image from an SD card or USB stick, you can
+request the installation to the eMMC. For that, press the USER button while
+the status LED is blinking orange during that first boot. Hold the button for
+at least 5 seconds to start the installation.
+
+NOTE: All content of the eMMC will be overwritten by this procedure!
+
+The ongoing installation is signaled by a fast blinking status LED. Wait for
+several minutes until the LED stops blinking and the device reboots to the
+eMMC. You can safely remove the SD card or USB stick at that point.
+
+The installation can also be triggered automatically by creating the file
+`/etc/install-on-emmc` on the vanilla image by mounting it under Linux and
+executing, e.g., `touch <mountpoint>/etc/install-on-emmc`.
 
 ## Selecting a boot device
 

--- a/recipes-core/images/iot2050-image-example.bb
+++ b/recipes-core/images/iot2050-image-example.bb
@@ -96,6 +96,7 @@ IMAGE_INSTALL += " \
     expand-on-first-boot \
     sshd-regen-keys \
     regen-rootfs-uuid \
+    install-on-emmc \
     customizations-example \
     switchserialmode \
     iot2050setup \

--- a/recipes-core/install-on-emmc/files/install-on-emmc-on-first-boot.service
+++ b/recipes-core/install-on-emmc/files/install-on-emmc-on-first-boot.service
@@ -1,0 +1,23 @@
+#
+# Copyright (c) Siemens AG, 2021
+#
+# Authors:
+#  Jan Kiszka <jan.kiszka@siemens.com>
+#
+# SPDX-License-Identifier: MIT
+
+[Unit]
+Description=Optional installation on eMMC
+DefaultDependencies=no
+Conflicts=shutdown.target
+Before=systemd-remount-fs.service shutdown.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/share/install-on-emmc/install-on-emmc.sh
+StandardOutput=syslog+console
+StandardError=syslog+console
+
+[Install]
+WantedBy=systemd-remount-fs.service

--- a/recipes-core/install-on-emmc/files/install-on-emmc.sh
+++ b/recipes-core/install-on-emmc/files/install-on-emmc.sh
@@ -1,0 +1,140 @@
+#!/bin/sh
+#
+# Copyright (c) Siemens AG, 2021
+#
+# Authors:
+#  Jan Kiszka <jan.kiszka@siemens.com>
+#
+# SPDX-License-Identifier: MIT
+
+LED_ORANGE="1 1"
+LED_RED="0 1"
+LED_GREEN="1 0"
+
+turn_leds_off()
+{
+	echo 0 > /sys/class/leds/status-led-green/brightness
+	echo 0 > /sys/class/leds/status-led-red/brightness
+}
+
+end_blinking()
+{
+	local PID=${BLINK_PID}
+
+	if [ -n "${PID}" ]; then
+		unset BLINK_PID
+		kill ${PID}
+		turn_leds_off
+	fi
+}
+
+terminate()
+{
+	end_blinking
+
+	mount -o remount,rw /
+	systemctl disable install-on-emmc-on-first-boot.service
+}
+
+start_timer()
+{
+	(
+		sleep $1
+		kill -ALRM $$
+	)&
+	TIMER_PID=$!
+}
+
+timer_expired()
+{
+	echo "Timeout expired, skipping eMMC installation."
+	kill ${GPIOMON_PID}
+	exit 0
+}
+
+blink()
+{
+	(
+		while true; do
+			echo $1 > /sys/class/leds/status-led-green/brightness
+			echo $2 > /sys/class/leds/status-led-red/brightness
+			sleep $3;
+
+			turn_leds_off
+			sleep $3
+		done
+	)&
+	BLINK_PID=$!
+}
+
+ROOT_DEV="$(findmnt / -o source -n)"
+BOOT_DEV="$(echo "${ROOT_DEV}" | sed 's/p\?[0-9]*$//')"
+EMMC_DEV="$(ls /dev/mmcblk*boot0 2>/dev/null | sed 's/boot0//')"
+
+trap terminate 0
+
+if [ -z "${EMMC_DEV}" ]; then
+	echo "No eMMC found"
+	exit 0
+fi
+
+if [ "${EMMC_DEV}" = "${BOOT_DEV}" ]; then
+	echo "Already booting from eMMC"
+	exit 0
+fi
+
+# Presence of /etc/install-on-emmc skips button check
+if [ -e /etc/install-on-emmc ]; then
+	echo "Found /etc/install-on-emmc, starting installation on eEMMC"
+else
+	echo "Press USER button to install on eMMC, you have 20 seconds"
+	echo "WARNING: All data on eMMC will be overwritten!"
+	GPIO_PIN=$(gpiofind USER-button)
+
+	blink ${LED_ORANGE} 1
+
+	trap timer_expired ALRM
+	start_timer 20
+
+	gpiomon -f -s -n 1 ${GPIO_PIN} &
+	GPIOMON_PID=$!
+	wait ${GPIOMON_PID}
+
+	kill ${TIMER_PID}
+	end_blinking
+
+	blink ${LED_RED} 0.25
+
+	echo "Hold USER button for 5 seconds to confirm"
+	for N in $(seq 50); do
+		if [ $(gpioget ${GPIO_PIN}) = 1 ]; then
+			echo "Terminated - rebooting..."
+			reboot
+		fi
+		sleep 0.1
+	done
+
+	end_blinking
+fi
+
+blink ${LED_GREEN} 0.25
+
+# Calculate number of sectors to write:
+# Start of boot partition + sectors in that partition
+SECTORS="$(($(sfdisk -d ${BOOT_DEV} 2>/dev/null | tail -1 | sed 's/.*start=[[:space:]]*\([^,]*\), size=[[:space:]]*\([^,]*\).*/\1+\2/')))"
+
+echo "Writing ${SECTORS} sectors to eMMC ${EMMC_DEV}..."
+dd if=${BOOT_DEV} of=${EMMC_DEV} count=${SECTORS}
+
+echo "Updating partition UUID of eMMC rootfs"
+partx -u ${EMMC_DEV}
+mount ${EMMC_DEV}p1 /mnt
+mount -o bind /dev /mnt/dev
+mount -t proc proc /mnt/proc
+chroot /mnt sh -c ' \
+    /usr/share/regen-rootfs-uuid/regen-rootfs-uuid.sh
+    /bin/systemctl disable regen-rootfs-uuid-on-first-boot.service
+    /bin/systemctl disable install-on-emmc-on-first-boot.service'
+umount /mnt/dev /mnt/proc /mnt
+
+reboot

--- a/recipes-core/install-on-emmc/files/postinst
+++ b/recipes-core/install-on-emmc/files/postinst
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+systemctl enable install-on-emmc-on-first-boot.service

--- a/recipes-core/install-on-emmc/install-on-emmc_1.0.bb
+++ b/recipes-core/install-on-emmc/install-on-emmc_1.0.bb
@@ -1,0 +1,27 @@
+#
+# Copyright (c) Siemens AG, 2021
+#
+# Authors:
+#  Jan Kiszka <jan.kiszka@siemens.com>
+#
+# SPDX-License-Identifier: MIT
+
+inherit dpkg-raw
+
+DESCRIPTION = "This service provides the option to install on eMMC during first boot"
+
+DEPENDS = "regen-rootfs-uuid"
+DEBIAN_DEPENDS = "systemd, fdisk, util-linux, regen-rootfs-uuid"
+
+SRC_URI = " \
+    file://install-on-emmc-on-first-boot.service \
+    file://install-on-emmc.sh \
+    file://postinst"
+
+do_install() {
+    install -d -m 755 ${D}/lib/systemd/system
+    install -m 644 ${WORKDIR}/install-on-emmc-on-first-boot.service ${D}/lib/systemd/system/
+
+    install -d -m 755 ${D}/usr/share/install-on-emmc
+    install -m 755 ${WORKDIR}/install-on-emmc.sh ${D}/usr/share/install-on-emmc/
+}

--- a/wic/iot2050.wks
+++ b/wic/iot2050.wks
@@ -10,4 +10,4 @@
 
 part / --source rootfs-u-boot --sourceparams="no_initrd=yes,script_prepend=env exists fdtfile || if test \\\"\${board_name}\\\" = \\\"IOT2050-ADVANCED\\\"; then set fdtfile ti/k3-am6548-iot2050-advanced-oldfw.dtb; else setenv fdtfile ti/k3-am6528-iot2050-basic-oldfw.dtb; fi" --fstype ext4 --label rootfs --align 1024 --use-uuid
 
-bootloader --ptable gpt --append "console=ttyS3,115200n8 earlycon=ns16550a,mmio32,0x02810000 mtdparts=47040000.spi.0:512k(ospi.tiboot3),2m(ospi.tispl),4m(ospi.u-boot),128k(ospi.env),128k(ospi.env.backup),1m(ospi.sysfw),64k(pru0-fw),64k(pru1-fw),64k(rtu0-fw),64k(rtu1-fw),-@8m(ospi.rootfs) rw rootwait"
+bootloader --ptable gpt --append "console=ttyS3,115200n8 earlycon=ns16550a,mmio32,0x02810000 mtdparts=47040000.spi.0:512k(ospi.tiboot3),2m(ospi.tispl),4m(ospi.u-boot),128k(ospi.env),128k(ospi.env.backup),1m(ospi.sysfw),64k(pru0-fw),64k(pru1-fw),64k(rtu0-fw),64k(rtu1-fw),-@8m(ospi.rootfs) rootwait"


### PR DESCRIPTION
I think this is simpler than the so far officially documented (https://support.industry.siemens.com/tf/ww/en/posts/how-to-install-example-image-to-emmc/238947/?page=0&pageSize=10) pattern to use two media or to boot one first (to expand it, install the image into it, and then run the transfer manually.