### PR TITLE
Add swupdate

### DIFF
--- a/.github/workflows/free-disk-space/action.yml
+++ b/.github/workflows/free-disk-space/action.yml
@@ -1,0 +1,8 @@
+name: 'Free Disk Space'
+description: 'Remove content of the provided image to free disk space for the build'
+runs:
+  using: "composite"
+  steps:
+      - name: Remove /usr/local/* to free disk space
+        run:  sudo rm -rf /usr/local/*
+        shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,22 @@ jobs:
             build/tmp/deploy/images/iot2050/iot2050-image-example-iot2050-debian-iot2050.wic.img
             build/tmp/deploy/images/iot2050/iot2050-image-example-iot2050-debian-iot2050.wic.img.bmap
 
+  debian-swupdate-image:
+    name: Debian SWUpdate image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build image
+        run: ./kas-container build kas-iot2050-swupdate.yml
+      - name: Upload image
+        uses: actions/upload-artifact@v2
+        with:
+          name: iot2050-swupdate-image
+          path: |
+            build/tmp/deploy/images/iot2050/iot2050-image-swu-example-iot2050-debian-iot2050.wic.img
+            build/tmp/deploy/images/iot2050/iot2050-image-swu-example-iot2050-debian-iot2050.wic.img.bmap
+
   bootloaders:
     name: Bootloaders for both PG1 and PG2
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Free Disk Space
+        uses: ./.github/workflows/free-disk-space
       - name: Build image
         run: ./kas-container build kas-iot2050-example.yml
       - name: Upload image
@@ -25,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Free Disk Space
+        uses: ./.github/workflows/free-disk-space
       - name: Build image
         run: ./kas-container build kas-iot2050-example.yml:kas/opt/preempt-rt.yml
       - name: Upload image
@@ -41,6 +45,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Free Disk Space
+        uses: ./.github/workflows/free-disk-space
       - name: Build image
         run: ./kas-container build kas-iot2050-swupdate.yml
       - name: Upload image
@@ -57,6 +63,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Free Disk Space
+        uses: ./.github/workflows/free-disk-space
       - name: Build bootloader image for PG1
         run: ./kas-container build kas-iot2050-boot-pg1.yml
       - name: Build bootloader image for PG2

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
 isar/
+/cip-core
 recipes-core/customizations-base/local.inc
 .config.yaml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@ all:
 
     - kas build kas-iot2050-example.yml
     - kas build kas-iot2050-example.yml:kas/opt/preempt-rt.yml
+    - kas build kas-iot2050-swupdate.yml
     - sudo rm -rf build/tmp
     - kas build kas-iot2050-boot-pg1.yml
     - sudo rm -rf build/tmp

--- a/Kconfig
+++ b/Kconfig
@@ -30,6 +30,12 @@ config IMAGE_LXDE
 	  Based on the example image, this adds an LXDE-based graphical user
 	  interface.
 
+config IMAGE_SWUPDATE
+	bool "Example image with SWUpdate support"
+	help
+	  Based on the example image, this adds SWUpdate and changes the
+	  partition layout to an A/B rootfs.
+
 config IMAGE_BOOT_PG1
 	bool "Firmware image for PG1 devices"
 	help
@@ -55,11 +61,12 @@ endchoice
 config KAS_INCLUDE_MAIN
 	string
 	default "kas-iot2050-example.yml" if IMAGE_EXAMPLE
+	default "kas-iot2050-swupdate.yml" if IMAGE_SWUPDATE
 	default "kas-iot2050-lxde.yml" if IMAGE_LXDE
 	default "kas-iot2050-boot-pg1.yml" if IMAGE_BOOT_PG1
 	default "kas-iot2050-boot-pg2.yml" if IMAGE_BOOT_PG2
 
-if IMAGE_EXAMPLE || IMAGE_LXDE
+if IMAGE_EXAMPLE || IMAGE_LXDE || IMAGE_SWUPDATE
 
 comment "Image features"
 

--- a/conf/machine/iot2050.conf
+++ b/conf/machine/iot2050.conf
@@ -20,3 +20,9 @@ IMAGE_FSTYPES ?= "wic-img"
 WKS_FILE ?= "iot2050.wks.in"
 
 IMAGE_INSTALL += "u-boot-script"
+
+#swupdate
+SWUPDATE_BOOTLOADER = "u-boot"
+U_BOOT_CONFIG_PACKAGE = "1"
+PREFERRED_PROVIDER_u-boot-config ?= "u-boot-iot2050-pg2"
+PREFERRED_PROVIDER_u-boot-${MACHINE}-config ?= "u-boot-iot2050-pg2"

--- a/kas-iot2050-swupdate.yml
+++ b/kas-iot2050-swupdate.yml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) Siemens AG, 2021
+#
+# This file is subject to the terms and conditions of the MIT License.  See
+# COPYING.MIT file in the top-level directory.
+#
+
+header:
+  version: 10
+  includes:
+   - kas-iot2050-example.yml
+
+target: iot2050-image-swu-example
+
+# wic-swu-img extracts a partition and generates a cpio image for
+# updating with swupdate
+local_conf_header:
+  generate-swu: |
+    IMAGE_FSTYPES = "wic-swu-img"

--- a/kas-iot2050-swupdate.yml
+++ b/kas-iot2050-swupdate.yml
@@ -10,6 +10,8 @@ header:
   includes:
    - kas-iot2050-example.yml
 
+build_system: isar
+
 target: iot2050-image-swu-example
 
 # wic-swu-img extracts a partition and generates a cpio image for

--- a/kas/iot2050.yml
+++ b/kas/iot2050.yml
@@ -31,6 +31,10 @@ repos:
     layers:
       meta:
 
+  cip-core:
+    url: https://gitlab.com/cip-project/cip-core/isar-cip-core.git
+    refspec: 0feddaa6dd65c5a1b56ff6fcb18b4e748e53972f
+
 bblayers_conf_header:
   standard: |
     LCONF_VERSION = "6"

--- a/recipes-bsp/patch-u-boot-env/files/patch-u-boot-env.config
+++ b/recipes-bsp/patch-u-boot-env/files/patch-u-boot-env.config
@@ -5,5 +5,5 @@ toggle_active=echo 'Switching active partition ...'; if test $sysselect = 1;then
 update_sysselect=if env exists ustate && env exists sysselect; then if test $ustate = 0; then echo SWUpdate: no update pending.; elif test $ustate = 1; then echo SWUpdate: ustate = INSTALLED ; setenv ustate 2; run toggle_active; saveenv; elif test $ustate = 2; then echo SWUpdate: ustate = FAILED; setenv ustate 3; run toggle_active; saveenv; elif test $ustate = 3; then echo SWUpdate: still in FAILED; else echo SWUpdate: invalid ustate; fi; setenv distro_bootpart ${sysselect}; if fstype ${devtype} ${devnum}:${distro_bootpart} bootfstype; then run scan_dev_for_boot; fi; else echo SWUpdate: some variables are missing!; fi
 
 scan_dev_for_boot_part_fallback=part list ${devtype} ${devnum} -bootable devplist; env exists devplist || setenv devplist 1; for distro_bootpart in ${devplist}; do if fstype ${devtype} ${devnum}:${distro_bootpart} bootfstype; then run scan_dev_for_boot; fi; done; setenv devplist
-
-scan_dev_for_boot_part=if env exists sysselect; then run update_sysselect; else run scan_dev_for_boot_part_fallback; fi
+start_watchdog=wdt dev rti@4061000; wdt start
+scan_dev_for_boot_part=if env exists sysselect; then run start_watchdog; run update_sysselect; else run scan_dev_for_boot_part_fallback; fi

--- a/recipes-bsp/patch-u-boot-env/files/patch-u-boot-env.config
+++ b/recipes-bsp/patch-u-boot-env/files/patch-u-boot-env.config
@@ -1,0 +1,9 @@
+ustate=0
+sysselect=1
+toggle_active=echo 'Switching active partition ...'; if test $sysselect = 1;then setenv sysselect 2; else setenv sysselect 1; fi; echo Active system is now $sysselect;
+
+update_sysselect=if env exists ustate && env exists sysselect; then if test $ustate = 0; then echo SWUpdate: no update pending.; elif test $ustate = 1; then echo SWUpdate: ustate = INSTALLED ; setenv ustate 2; run toggle_active; saveenv; elif test $ustate = 2; then echo SWUpdate: ustate = FAILED; setenv ustate 3; run toggle_active; saveenv; elif test $ustate = 3; then echo SWUpdate: still in FAILED; else echo SWUpdate: invalid ustate; fi; setenv distro_bootpart ${sysselect}; if fstype ${devtype} ${devnum}:${distro_bootpart} bootfstype; then run scan_dev_for_boot; fi; else echo SWUpdate: some variables are missing!; fi
+
+scan_dev_for_boot_part_fallback=part list ${devtype} ${devnum} -bootable devplist; env exists devplist || setenv devplist 1; for distro_bootpart in ${devplist}; do if fstype ${devtype} ${devnum}:${distro_bootpart} bootfstype; then run scan_dev_for_boot; fi; done; setenv devplist
+
+scan_dev_for_boot_part=if env exists sysselect; then run update_sysselect; else run scan_dev_for_boot_part_fallback; fi

--- a/recipes-bsp/patch-u-boot-env/files/patch-u-boot-env.service
+++ b/recipes-bsp/patch-u-boot-env/files/patch-u-boot-env.service
@@ -1,0 +1,20 @@
+#
+# Copyright (c) Siemens AG, 2021
+#
+# Authors:
+#  Quirin Gylstorff <quirin.gylstorff@siemens.com>
+#
+# SPDX-License-Identifier: MIT
+
+[Unit]
+Description=update u-boot environment for swupdate
+Conflicts=shutdown.target
+Before=swupdate.service shutdown.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/share/u-boot-env/patch-u-boot-env.sh /usr/share/u-boot-env/patch-u-boot-env.config
+ExecStartPost=-/bin/systemctl disable patch-u-boot-env.service
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-bsp/patch-u-boot-env/files/patch-u-boot-env.sh
+++ b/recipes-bsp/patch-u-boot-env/files/patch-u-boot-env.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) Siemens AG, 2021
+#
+# Authors:
+#  Quirin Gylstorff <quirin.gylstorff@siemens.com>
+#
+# SPDX-License-Identifier: MIT
+SCRIPT="$1"
+# use grep and cut to strip away environment status and get the value
+# of sysselect
+key="sysselect"
+sysselect_value=$(fw_printenv "${key}" | grep "${key}" | cut -d= -f2)
+
+if [ -z "${sysselect_value}" ]; then
+    if ! fw_setenv -s "${SCRIPT}"; then
+        echo "$0: could not patch u-boot firmware"
+        exit 1
+    fi
+fi

--- a/recipes-bsp/patch-u-boot-env/files/postinst
+++ b/recipes-bsp/patch-u-boot-env/files/postinst
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# Copyright (c) Siemens AG, 2021
+#
+# Authors:
+#  Quirin Gylstorff <quirin.gylstorff@siemens.com>
+#
+# SPDX-License-Identifier: MIT
+
+deb-systemd-helper enable patch-u-boot-env.service || true

--- a/recipes-bsp/patch-u-boot-env/patch-u-boot-env_0.1.bb
+++ b/recipes-bsp/patch-u-boot-env/patch-u-boot-env_0.1.bb
@@ -1,0 +1,27 @@
+#
+# Copyright (c) Siemens AG, 2021
+#
+# Authors:
+#  Quirin Gylstorff <quirin.gylstorff@siemens.com>
+#
+# SPDX-License-Identifier: MIT
+
+inherit dpkg-raw
+
+DESCRIPTION = "prepare u-boot environment for swupdate"
+
+DEBIAN_DEPENDS = "libubootenv-tool"
+
+SRC_URI += "file://postinst \
+            file://patch-u-boot-env.config \
+            file://patch-u-boot-env.sh \
+            file://patch-u-boot-env.service"
+
+do_install () {
+  install -v -d ${D}/usr/share/u-boot-env
+  install -v -m 640 ${WORKDIR}/patch-u-boot-env.config ${D}/usr/share/u-boot-env/patch-u-boot-env.config
+  install -v -m 755 ${WORKDIR}/patch-u-boot-env.sh ${D}/usr/share/u-boot-env/patch-u-boot-env.sh
+
+  install -v -d ${D}/usr/lib/systemd/system
+  install -v -m 666 ${WORKDIR}/patch-u-boot-env.service ${D}/usr/lib/systemd/system/patch-u-boot-env.service
+}

--- a/recipes-core/data-partition/data-partition_0.1.bb
+++ b/recipes-core/data-partition/data-partition_0.1.bb
@@ -1,0 +1,31 @@
+#
+# Copyright (c) Siemens AG, 2021
+#
+# Authors:
+#  Quirin Gylstorff <quirin.gylstorff@siemens.com>
+#
+# SPDX-License-Identifier: MIT
+
+DESCRIPTION = "data systemd-mount"
+
+DEBIAN_DEPENDS = "systemd"
+
+SRC_URI = "file://postinst \
+           file://data.mount.tmpl"
+
+FS_COMMIT_INTERVAL ?= "20"
+TEMPLATE_VARS  += "FS_COMMIT_INTERVAL"
+TEMPLATE_FILES += "data.mount.tmpl"
+
+inherit dpkg-raw
+
+do_install() {
+    install -m 0755 -d ${D}/data
+    touch ${D}/data/.keep
+
+    TARGET=${D}/lib/systemd/system
+    install -m 0755 -d ${TARGET}
+    install -m 0644 ${WORKDIR}/data.mount ${TARGET}/data.mount
+}
+
+addtask do_install after do_transform_template

--- a/recipes-core/data-partition/files/data.mount.tmpl
+++ b/recipes-core/data-partition/files/data.mount.tmpl
@@ -1,0 +1,12 @@
+[Unit]
+Description=Mount /data partition
+After=expand-on-first-boot.service
+
+[Mount]
+What=/dev/disk/by-partlabel/data
+Where=/data
+Type=ext4
+Options=data=journal,noatime,nodiratime,nodelalloc,commit=${FS_COMMIT_INTERVAL}
+
+[Install]
+WantedBy=local-fs.target

--- a/recipes-core/data-partition/files/postinst
+++ b/recipes-core/data-partition/files/postinst
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+deb-systemd-helper enable data.mount || true

--- a/recipes-core/images/files/sw-description.tmpl
+++ b/recipes-core/images/files/sw-description.tmpl
@@ -1,0 +1,25 @@
+#
+# Copyright (c) Siemens AG, 2021
+#
+# Authors:
+#  Quirin Gylstorff <quirin.gylstorff@siemens.com>
+#
+# This file is subject to the terms and conditions of the MIT License.  See
+# COPYING.MIT file in the top-level directory.
+#
+
+software =
+{
+    version = "0.1";
+    name = "iot2050 update image"
+    images: ({
+            filename = "${ROOTFS_PARTITION_NAME}";
+            device = "rootfs1,rootfs2";
+            type = "roundrobin";
+            compressed = "zlib";
+            filesystem = "ext4";
+            properties: {
+                        subtype = "image";
+            };
+    });
+}

--- a/recipes-core/images/iot2050-image-swu-example.bb
+++ b/recipes-core/images/iot2050-image-swu-example.bb
@@ -15,6 +15,7 @@ WKS_FILE = "iot2050-swu.wks.in"
 IMAGE_INSTALL += "swupdate"
 IMAGE_INSTALL += "swupdate-handler-roundrobin"
 IMAGE_INSTALL += "swupdate-complete-update-helper"
+IMAGE_INSTALL += "iot2050-watchdog"
 
 IMAGE_INSTALL += "data-partition"
 

--- a/recipes-core/images/iot2050-image-swu-example.bb
+++ b/recipes-core/images/iot2050-image-swu-example.bb
@@ -1,0 +1,28 @@
+#
+# Copyright (c) Siemens AG, 2021
+#
+# Authors:
+#  Quirin Gylstorff <quirin.gylstorff@siemens.com>
+#
+# This file is subject to the terms and conditions of the MIT License.  See
+# COPYING.MIT file in the top-level directory.
+#
+
+require recipes-core/images/iot2050-image-example.bb
+
+WKS_FILE = "iot2050-swu.wks.in"
+
+IMAGE_INSTALL += "swupdate"
+IMAGE_INSTALL += "swupdate-handler-roundrobin"
+
+
+FILESPATH_prepend := "${THISDIR}/files:"
+
+EXTRACT_PARTITIONS = "img1"
+ROOTFS_PARTITION_NAME = "${EXTRACT_PARTITIONS}.gz"
+
+# Variables for swupdate image creation:
+SRC_URI += "file://sw-description.tmpl"
+TEMPLATE_FILES += "sw-description.tmpl"
+TEMPLATE_VARS += "ROOTFS_PARTITION_NAME"
+SWU_ADDITIONAL_FILES += "${ROOTFS_PARTITION_NAME}"

--- a/recipes-core/images/iot2050-image-swu-example.bb
+++ b/recipes-core/images/iot2050-image-swu-example.bb
@@ -16,6 +16,8 @@ IMAGE_INSTALL += "swupdate"
 IMAGE_INSTALL += "swupdate-handler-roundrobin"
 IMAGE_INSTALL += "swupdate-complete-update-helper"
 
+IMAGE_INSTALL += "data-partition"
+
 FILESPATH_prepend := "${THISDIR}/files:"
 
 EXTRACT_PARTITIONS = "img1"

--- a/recipes-core/images/iot2050-image-swu-example.bb
+++ b/recipes-core/images/iot2050-image-swu-example.bb
@@ -14,7 +14,7 @@ WKS_FILE = "iot2050-swu.wks.in"
 
 IMAGE_INSTALL += "swupdate"
 IMAGE_INSTALL += "swupdate-handler-roundrobin"
-
+IMAGE_INSTALL += "swupdate-complete-update-helper"
 
 FILESPATH_prepend := "${THISDIR}/files:"
 

--- a/recipes-core/swupdate-complete-update-helper/files/complete_update.sh
+++ b/recipes-core/swupdate-complete-update-helper/files/complete_update.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# Copyright (c) Siemens AG, 2021
+#
+# Authors:
+#  Quirin Gylstorff <quirin.gylstorff@siemens.com>
+#
+# SPDX-License-Identifier: MIT
+
+set -e
+
+USTATE="$(fw_printenv -n ustate | tail -1)"
+if [ -z "$USTATE" ]; then
+    echo "$0: ustate is not set - abort!"
+    exit 1
+fi
+
+case "$1" in
+    success)
+        case "$USTATE" in
+            0)
+                # If no update was pending, ignore this
+                exit 0
+                ;;
+            2)
+                fw_setenv ustate 0
+                exit 0
+                ;;
+            *)
+                echo "$0: attempt to acknowledge while in wrong state('$USTATE' instead of '0')" >&2
+                exit 1
+                ;;
+        esac
+    ;;
+    failed)
+        case "$USTATE" in
+            3)
+                fw_setenv ustate 0
+                exit 0
+                ;;
+            *)
+                echo "$0: attempt to acknowledge failure while in wrong state('$USTATE' instead of '3')" >&2
+                exit 1
+                ;;
+        esac
+        ;;
+    *)
+        echo "usage: $0 <action>" >&2
+        echo "" >&2
+        echo "<action>: 'success', 'failed' " >&2
+        exit 1
+        ;;
+esac

--- a/recipes-core/swupdate-complete-update-helper/swupdate-complete-update-helper_0.1.bb
+++ b/recipes-core/swupdate-complete-update-helper/swupdate-complete-update-helper_0.1.bb
@@ -1,0 +1,18 @@
+#
+# Copyright (c) Siemens AG, 2021
+#
+# Authors:
+#  Quirin Gylstorff <quirin.gylstorff@siemens.com>
+#
+# SPDX-License-Identifier: MIT
+
+inherit dpkg-raw
+DESCRIPTION = "Add script to confirm update"
+
+SRC_URI = "file://complete_update.sh"
+
+do_install() {
+    # add board status led service
+    install -v -d ${D}/usr/bin
+    install -v -m 644 ${WORKDIR}/complete_update.sh ${D}/usr/bin/complete_update.sh
+}

--- a/recipes-core/swupdate-handler-roundrobin/files/swupdate.handler.u-boot.ini
+++ b/recipes-core/swupdate-handler-roundrobin/files/swupdate.handler.u-boot.ini
@@ -1,0 +1,9 @@
+[image]
+chainhandler=raw
+
+[image.selector]
+method=cmdline_rr
+key=root
+
+[image.bootenv]
+ustate=1

--- a/recipes-core/swupdate-handler-roundrobin/swupdate-handler-roundrobin_%.bbappend
+++ b/recipes-core/swupdate-handler-roundrobin/swupdate-handler-roundrobin_%.bbappend
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Siemens AG, 2021
+#
+# Authors:
+#  Quirin Gylstorff <quirin.gylstorff@siemens.com>
+#
+# SPDX-License-Identifier: MIT
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://swupdate.handler.u-boot.ini"

--- a/recipes-core/swupdate-handler-roundrobin/swupdate-handler-roundrobin_%.bbappend
+++ b/recipes-core/swupdate-handler-roundrobin/swupdate-handler-roundrobin_%.bbappend
@@ -8,4 +8,7 @@
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
+DEPENDS += "patch-u-boot-env"
+DEBIAN_DEPENDS += "patch-u-boot-env"
+
 SRC_URI += "file://swupdate.handler.u-boot.ini"

--- a/recipes-core/swupdate/swupdate_%.bbappend
+++ b/recipes-core/swupdate/swupdate_%.bbappend
@@ -1,0 +1,14 @@
+#
+# Copyright (c) Siemens AG, 2021
+#
+# Authors:
+#  Quirin Gylstorff <quirin.gylstorff@siemens.com>
+#
+# SPDX-License-Identifier: MIT
+
+# Set pacakge build options
+# cross: for crosscompiling
+# nodocs: for no documentation
+# nocheck: do not build test
+# pkg.swupdate.bpo: Avoid mtd read errors during swupdate processing
+SWUPDATE_BUILD_PROFILES += "cross nodoc nocheck pkg.swupdate.bpo"

--- a/recipes-core/watchdog/files/99-watchdog.conf
+++ b/recipes-core/watchdog/files/99-watchdog.conf
@@ -1,0 +1,6 @@
+[Manager]
+# The watchdog driver rti_wdt.c doesn't support updating
+# the timeout after start. If this value is changed it
+# will lead to periodic reboots.
+RuntimeWatchdogSec=60s
+ShutdownWatchdogSec=60s

--- a/recipes-core/watchdog/iot2050-watchdog.bb
+++ b/recipes-core/watchdog/iot2050-watchdog.bb
@@ -1,0 +1,18 @@
+#
+# Copyright (c) Siemens AG, 2021
+#
+# Authors:
+#  Quirin Gylstorff <quirin.gylstorff@siemens.com>
+#
+# SPDX-License-Identifier: MIT
+inherit dpkg-raw
+
+DEPENDS += "patch-u-boot-env"
+DEBIAN_DEPENDS += "patch-u-boot-env"
+
+SRC_URI += "file://99-watchdog.conf"
+
+do_install[cleandirs] = "${D}/usr/lib/systemd/system.conf.d"
+do_install() {
+    install -m 0644 "${WORKDIR}/99-watchdog.conf" "${D}/usr/lib/systemd/system.conf.d"
+}

--- a/wic/iot2050-swu.wks.in
+++ b/wic/iot2050-swu.wks.in
@@ -1,0 +1,18 @@
+#
+# Copyright (c) Siemens AG, 2021
+#
+# Authors:
+#  Quirin Gylstorff <quirin.gylstorff@siemens.com>
+#
+# This file is subject to the terms and conditions of the MIT License.  See
+# COPYING.MIT file in the top-level directory.
+#
+
+bootloader --ptable gpt --append "console=ttyS3,115200n8 earlycon=ns16550a,mmio32,0x02810000 mtdparts=47040000.spi.0:512k(ospi.tiboot3),2m(ospi.tispl),4m(ospi.u-boot),128k(ospi.env),128k(ospi.env.backup),1m(ospi.sysfw),64k(pru0-fw),64k(pru1-fw),64k(rtu0-fw),64k(rtu1-fw),-@8m(ospi.rootfs) rootwait ${EXTRA_KERNEL_PARAMS}"
+
+# rootfs 1
+part --source rootfs-u-boot --sourceparams="no_initrd=yes,script_prepend=env exists sysselect || setenv sysselect 1,root=PARTLABEL=rootfs\"\$\{sysselect\}\"" --fixed-size 4G --fstype ext4 --label rootfs1 --align 1024
+
+# rootfs 2
+part --source rootfs-u-boot --sourceparams="no_initrd=yes,script_prepend=env exists sysselect || setenv sysselect 1,root=PARTLABEL=rootfs\"\$\{sysselect\}\"" --fixed-size 4G --fstype ext4 --label rootfs2 --align 1024
+

--- a/wic/iot2050-swu.wks.in
+++ b/wic/iot2050-swu.wks.in
@@ -16,3 +16,5 @@ part --source rootfs-u-boot --sourceparams="no_initrd=yes,script_prepend=env exi
 # rootfs 2
 part --source rootfs-u-boot --sourceparams="no_initrd=yes,script_prepend=env exists sysselect || setenv sysselect 1,root=PARTLABEL=rootfs\"\$\{sysselect\}\"" --fixed-size 4G --fstype ext4 --label rootfs2 --align 1024
 
+# data partition
+part --size 512M --fstype ext4 --label data --align 1024


### PR DESCRIPTION
This PR adds a swupdate configuration to meta-iot2050. It uses [isar-cip-core](https://gitlab.com/cip-project/cip-core/isar-cip-core) as base.

To build the image use:

```shell
./kas-container build kas-iot2050-example.yml:kas/opt/swupdate-example.yml
```

This image will modify the u-boot-environment during first-boot to add the necessary variable for swupdate.

This fixes Issue #50.
