### PR TITLE
linux-iot2050: Fix device tree in 4.19 queue

### DIFF
--- a/recipes-kernel/linux/files/0001-iot2050-add-iot2050-platform-support.patch
+++ b/recipes-kernel/linux/files/0001-iot2050-add-iot2050-platform-support.patch
@@ -1,4 +1,4 @@
-From 489cbda8aebb79187c21a6d5a400b9270c33327f Mon Sep 17 00:00:00 2001
+From 3d82ab21200c49d730a1db49aea551061dda4751 Mon Sep 17 00:00:00 2001
 From: Le Jin <le.jin@siemens.com>
 Date: Mon, 18 Nov 2019 17:58:08 +0800
 Subject: [PATCH 01/13] iot2050: add iot2050 platform support
@@ -73,7 +73,7 @@ index 000000000000..93b53d63ef60
 +};
 diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
 new file mode 100644
-index 000000000000..54abaac9de45
+index 000000000000..deed46d71aad
 --- /dev/null
 +++ b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
 @@ -0,0 +1,793 @@
@@ -102,7 +102,7 @@ index 000000000000..54abaac9de45
 +		bootargs = "earlycon=ns16550a,mmio32,0x02800000";
 +	};
 +
-+	reserved_memory {
++	reserved-memory {
 +		#address-cells = <2>;
 +		#size-cells = <2>;
 +		ranges;
@@ -838,7 +838,7 @@ index 000000000000..54abaac9de45
 +
 +	phys = <&serdes1 PHY_TYPE_PCIE 0>;
 +	phy-names = "pcie-phy0";
-+	reset-gpios = <&wkup_gpio0 27 GPIO_ACTIVE_HIGH>;
++	reset-gpio = <&wkup_gpio0 27 GPIO_ACTIVE_HIGH>;
 +	status = "okay";
 +};
 +

--- a/recipes-kernel/linux/files/0002-Add-support-for-U9300C-TD-LTE-module.patch
+++ b/recipes-kernel/linux/files/0002-Add-support-for-U9300C-TD-LTE-module.patch
@@ -1,4 +1,4 @@
-From ad0dcd6ff71b61afc69491e749b6c7d0245f7637 Mon Sep 17 00:00:00 2001
+From 0119ef2888c7cc3c9edd9525bfea2411594eea5c Mon Sep 17 00:00:00 2001
 From: Su Bao Cheng <baocheng.su@siemens.com>
 Date: Tue, 23 Apr 2019 10:07:17 +0800
 Subject: [PATCH 02/13] Add support for U9300C TD-LTE module

--- a/recipes-kernel/linux/files/0003-feat-Add-CP210x-driver-support-to-software-flow-cont.patch
+++ b/recipes-kernel/linux/files/0003-feat-Add-CP210x-driver-support-to-software-flow-cont.patch
@@ -1,4 +1,4 @@
-From 405c56d63ef7fee1f8ee72337819cd88f254ce48 Mon Sep 17 00:00:00 2001
+From 85c049cb1a9f5408f81543919d7c452e9c43d6f0 Mon Sep 17 00:00:00 2001
 From: Su Bao Cheng <baocheng.su@siemens.com>
 Date: Mon, 15 Jul 2019 15:46:09 +0800
 Subject: [PATCH 03/13] feat: Add CP210x driver support to software flow

--- a/recipes-kernel/linux/files/0004-fix-disable-usb-lpm-to-fix-usb-device-reset.patch
+++ b/recipes-kernel/linux/files/0004-fix-disable-usb-lpm-to-fix-usb-device-reset.patch
@@ -1,4 +1,4 @@
-From 16d805c8ae99afbd001efc5865e32acb16988468 Mon Sep 17 00:00:00 2001
+From f76426af440ba70cdabad0ac13b217616b6f344d Mon Sep 17 00:00:00 2001
 From: Sheng Long Wang <shenglong.wang.ext@siemens.com>
 Date: Tue, 13 Aug 2019 09:30:38 +0800
 Subject: [PATCH 04/13] fix: disable usb lpm to fix usb device reset

--- a/recipes-kernel/linux/files/0005-Fix-DP-maybe-not-display-problem.patch
+++ b/recipes-kernel/linux/files/0005-Fix-DP-maybe-not-display-problem.patch
@@ -1,4 +1,4 @@
-From 51369b01ab127a00906d54e5f0cf425695364ede Mon Sep 17 00:00:00 2001
+From d38df3c4cb87e306307b3d1b91a981581c704b73 Mon Sep 17 00:00:00 2001
 From: Sheng Long Wang <shenglong.wang.ext@siemens.com>
 Date: Tue, 13 Aug 2019 10:27:44 +0800
 Subject: [PATCH 05/13] Fix: DP maybe not display problem.

--- a/recipes-kernel/linux/files/0006-fix-fix-the-hardware-flow-function-of-cp2102n24.patch
+++ b/recipes-kernel/linux/files/0006-fix-fix-the-hardware-flow-function-of-cp2102n24.patch
@@ -1,4 +1,4 @@
-From 744554e3d2dc3b94b1572e76b81e33fa23bda4bb Mon Sep 17 00:00:00 2001
+From 0a0750ce140190017241f235b07e519a38a29fa7 Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Wed, 21 Aug 2019 16:22:30 +0800
 Subject: [PATCH 06/13] fix:fix the hardware flow function of cp2102n24

--- a/recipes-kernel/linux/files/0007-feat-add-io-expander-pcal9535-support.patch
+++ b/recipes-kernel/linux/files/0007-feat-add-io-expander-pcal9535-support.patch
@@ -1,4 +1,4 @@
-From fe7178d923f72ed6ac4df970b635ca9c2570e5ba Mon Sep 17 00:00:00 2001
+From 00a426b081267ea958916fa9cfad707e87c172ef Mon Sep 17 00:00:00 2001
 From: "le.jin" <le.jin@siemens.com>
 Date: Wed, 9 Oct 2019 17:08:43 +0800
 Subject: [PATCH 07/13] feat:add io expander pcal9535 support

--- a/recipes-kernel/linux/files/0008-setting-the-RJ45-port-led-behavior.patch
+++ b/recipes-kernel/linux/files/0008-setting-the-RJ45-port-led-behavior.patch
@@ -1,4 +1,4 @@
-From 82fe3b6113452a14db4ef87690e1c9aa16ff3675 Mon Sep 17 00:00:00 2001
+From bd8c62c33aca5c94bc54c79fdef7c6c96ef57671 Mon Sep 17 00:00:00 2001
 From: zengchao <chao.zeng@siemens.com>
 Date: Wed, 6 Nov 2019 11:21:49 +0800
 Subject: [PATCH 08/13] setting the RJ45 port led behavior

--- a/recipes-kernel/linux/files/0009-fix-clear-the-cycle-buffer-of-serial.patch
+++ b/recipes-kernel/linux/files/0009-fix-clear-the-cycle-buffer-of-serial.patch
@@ -1,4 +1,4 @@
-From 8cc25bd59ac7f3b2149145d3029fdb8710314a7c Mon Sep 17 00:00:00 2001
+From 1ab25d6688f4299e1e527705f6673c6bce4c8215 Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Tue, 26 Nov 2019 09:05:56 +0800
 Subject: [PATCH 09/13] fix:clear the cycle buffer of serial

--- a/recipes-kernel/linux/files/0010-feat-extend-led-panic-indicator-on-and-off.patch
+++ b/recipes-kernel/linux/files/0010-feat-extend-led-panic-indicator-on-and-off.patch
@@ -1,4 +1,4 @@
-From 5db98fae663d8ad67676666738f36c8fc903955e Mon Sep 17 00:00:00 2001
+From a499ed39ac706359c0fdf495dab2ec57989c7a19 Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Tue, 22 Dec 2020 15:05:56 +0800
 Subject: [PATCH 10/13] feat:extend led panic-indicator on and off

--- a/recipes-kernel/linux/files/0011-fix-can-not-auto-negotiate-to-100M-with-4-wire.patch
+++ b/recipes-kernel/linux/files/0011-fix-can-not-auto-negotiate-to-100M-with-4-wire.patch
@@ -1,4 +1,4 @@
-From 4045af3c7f8673216e44909943494ae93a83e28e Mon Sep 17 00:00:00 2001
+From 187c1dab4f3190fd90be9f5ba5b58d367c5ce14d Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Tue, 4 Feb 2020 22:03:52 +0800
 Subject: [PATCH 11/13] fix:can not auto negotiate to 100M with 4-wire

--- a/recipes-kernel/linux/files/0012-feat-change-mmc-order-using-alias-in-dts.patch
+++ b/recipes-kernel/linux/files/0012-feat-change-mmc-order-using-alias-in-dts.patch
@@ -1,4 +1,4 @@
-From 5b519c2caac683e350590902c77eeda3d8749adb Mon Sep 17 00:00:00 2001
+From 5df72a0aa9663094988a20fb731c07680b931a97 Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Tue, 22 Dec 2020 15:08:17 +0800
 Subject: [PATCH 12/13] feat:change mmc order using alias in dts

--- a/recipes-kernel/linux/files/0013-fix-PLL4_DCO-freq-over-range-cause-DP-not-display.patch
+++ b/recipes-kernel/linux/files/0013-fix-PLL4_DCO-freq-over-range-cause-DP-not-display.patch
@@ -1,4 +1,4 @@
-From 5873553f79ba8208f7028bbc5b695db9c2fa29cd Mon Sep 17 00:00:00 2001
+From 1a555ebfb54b4241be9df6a46a4c2110c171959f Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Fri, 11 Dec 2020 17:20:12 +0800
 Subject: [PATCH 13/13] fix:PLL4_DCO freq over range cause DP not display


### PR DESCRIPTION
This addresses two issues:

reserved_memory -> reserved-memory, resolving the overwrite of unsecured
secure TEE memory (the fact that is unsecured is another issue, but of
the firmware)

reset-gpios -> reset-gpio, aligning to the binding specification of the
underlying Synopsys DesignWare PCIe (was papered over by
devm_gpiod_get_optional so far, accepting both)

Fixes #112 (well, not truly)
Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>