### PR TITLE
dts: reconfigure pcie node

### DIFF
--- a/recipes-kernel/linux/files/5.x-kernel/0001-iot2050-add-iot2050-platform-support.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0001-iot2050-add-iot2050-platform-support.patch
@@ -1,7 +1,7 @@
 From 654ea81a97520f4422584408cfb93bdc5eeda59a Mon Sep 17 00:00:00 2001
 From: Le Jin <le.jin@siemens.com>
 Date: Mon, 18 Nov 2019 17:58:08 +0800
-Subject: [PATCH 01/10] iot2050: add iot2050 platform support
+Subject: [PATCH 01/11] iot2050: add iot2050 platform support
 
 Add support for two iot2050 variants, BASIC and ADVANCED.
 
@@ -946,5 +946,5 @@ index 000000000000..00700dff77a8
 +};
 \ No newline at end of file
 -- 
-2.30.0
+2.31.1
 

--- a/recipes-kernel/linux/files/5.x-kernel/0002-Workaround-to-correct-DP-clock-to-154MHZ.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0002-Workaround-to-correct-DP-clock-to-154MHZ.patch
@@ -1,7 +1,7 @@
 From e337999155209ab2a209ec7868921e8f2f5d3d8a Mon Sep 17 00:00:00 2001
 From: Chao Zeng <chao.zeng@siemens.com>
 Date: Wed, 6 Jan 2021 15:51:18 +0800
-Subject: [PATCH 02/10] Workaround to correct DP clock to 154MHZ.
+Subject: [PATCH 02/11] Workaround to correct DP clock to 154MHZ.
 
 BUG: as the default DPI source should be DPI_1_IN_CLK
      but seems the DSS input clk swap the DPI0 and DPI1
@@ -31,5 +31,5 @@ index 5ffcbd9641b7..0dba4e95ca90 100644
  
  &dss_ports {
 -- 
-2.30.0
+2.31.1
 

--- a/recipes-kernel/linux/files/5.x-kernel/0003-setting-the-RJ45-port-led-behavior.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0003-setting-the-RJ45-port-led-behavior.patch
@@ -1,7 +1,7 @@
 From 91cf92289785c05e8400cc30ac506aababa7202a Mon Sep 17 00:00:00 2001
 From: zengchao <chao.zeng@siemens.com>
 Date: Wed, 6 Nov 2019 11:21:49 +0800
-Subject: [PATCH 03/10] setting the RJ45 port led behavior
+Subject: [PATCH 03/11] setting the RJ45 port led behavior
 
 Signed-off-by: zengchao <chao.zeng@siemens.com>
 ---
@@ -34,5 +34,5 @@ index 1b65c8a94e8c..3bdb3862a310 100644
  }
  
 -- 
-2.30.0
+2.31.1
 

--- a/recipes-kernel/linux/files/5.x-kernel/0004-feat-Add-CP210x-driver-support-to-software-flow-cont.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0004-feat-Add-CP210x-driver-support-to-software-flow-cont.patch
@@ -1,7 +1,7 @@
 From b4ec660bd9d80d4cde44ac8003d0b3ed25d7cc76 Mon Sep 17 00:00:00 2001
 From: Su Bao Cheng <baocheng.su@siemens.com>
 Date: Mon, 15 Jul 2019 15:46:09 +0800
-Subject: [PATCH 04/10] feat: Add CP210x driver support to software flow
+Subject: [PATCH 04/11] feat: Add CP210x driver support to software flow
  control
 
 Signed-off-by: Wang Sheng Long <shenglong.wang.ext@siemens.com>
@@ -186,5 +186,5 @@ index a90801ef0055..e123ce635c37 100644
  
  static int cp210x_tiocmset(struct tty_struct *tty,
 -- 
-2.30.0
+2.31.1
 

--- a/recipes-kernel/linux/files/5.x-kernel/0005-feat-add-io-expander-pcal9535-support.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0005-feat-add-io-expander-pcal9535-support.patch
@@ -1,7 +1,7 @@
 From 81e7cc4494b19b262b3704b7a364be45a47cab87 Mon Sep 17 00:00:00 2001
 From: "le.jin" <le.jin@siemens.com>
 Date: Wed, 9 Oct 2019 17:08:43 +0800
-Subject: [PATCH 05/10] feat:add io expander pcal9535 support
+Subject: [PATCH 05/11] feat:add io expander pcal9535 support
 
 Signed-off-by: le.jin <le.jin@siemens.com>
 Signed-off-by: Chao Zeng <chao.zeng@siemens.com>
@@ -406,5 +406,5 @@ index 5dd9c982e2cb..dd9dbdad1cea 100644
  						unsigned offset);
  
 -- 
-2.30.0
+2.31.1
 

--- a/recipes-kernel/linux/files/5.x-kernel/0006-feat-extend-led-panic-indicator-on-and-off.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0006-feat-extend-led-panic-indicator-on-and-off.patch
@@ -1,7 +1,7 @@
 From d3d472450266bdf1310651fafd14ea961cbf1730 Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Fri, 3 Jan 2020 14:50:16 +0800
-Subject: [PATCH 06/10] feat:extend led panic-indicator on and off
+Subject: [PATCH 06/11] feat:extend led panic-indicator on and off
 
 Signed-off-by: Gao Nian <nian.gao@siemens.com>
 ---
@@ -133,5 +133,5 @@ index 52889b50eb44..b5cc5dcdd67c 100644
  	int 		num_leds;
  	const struct gpio_led *leds;
 -- 
-2.30.0
+2.31.1
 

--- a/recipes-kernel/linux/files/5.x-kernel/0007-Add-support-for-U9300C-TD-LTE-module.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0007-Add-support-for-U9300C-TD-LTE-module.patch
@@ -1,7 +1,7 @@
 From 987b6c369843733104021c781a543a8d3c79cfa2 Mon Sep 17 00:00:00 2001
 From: Su Bao Cheng <baocheng.su@siemens.com>
 Date: Tue, 23 Apr 2019 10:07:17 +0800
-Subject: [PATCH 07/10] Add support for U9300C TD-LTE module
+Subject: [PATCH 07/11] Add support for U9300C TD-LTE module
 
 Author: Gao Nian  <nian.gao@siemens.com>
 Signed-off-by: Su Bao Cheng <baocheng.su@siemens.com>
@@ -32,5 +32,5 @@ index eb5538a44ee9..defcba6e0ed2 100644
  	{ USB_DEVICE_AND_INTERFACE_INFO(HAIER_VENDOR_ID, HAIER_PRODUCT_CE81B, 0xff, 0xff, 0xff) },
  	/* Pirelli  */
 -- 
-2.30.0
+2.31.1
 

--- a/recipes-kernel/linux/files/5.x-kernel/0008-feat-change-mmc-order-using-alias-in-dts.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0008-feat-change-mmc-order-using-alias-in-dts.patch
@@ -1,7 +1,7 @@
 From 8a8f643e2e8abc6a3d44efd7b4082394d87dfc47 Mon Sep 17 00:00:00 2001
 From: "le.jin" <le.jin@siemens.com>
 Date: Wed, 9 Oct 2019 15:22:09 +0800
-Subject: [PATCH 08/10] feat:change mmc order using alias in dts
+Subject: [PATCH 08/11] feat:change mmc order using alias in dts
 
 1. modify kernel to support mmc alias in dts
 2. change SD to mmc0 and EMMC to mmc1 via alias in dts
@@ -75,5 +75,5 @@ index b3484def0a8b..bd5dbf863c3a 100644
  
  	host->parent = dev;
 -- 
-2.30.0
+2.31.1
 

--- a/recipes-kernel/linux/files/5.x-kernel/0009-dts-add-the-usb3.0-support.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0009-dts-add-the-usb3.0-support.patch
@@ -1,7 +1,7 @@
 From a3ecd89a1aa5b697270142366e7eaa9ad6a731c0 Mon Sep 17 00:00:00 2001
 From: Chao Zeng <chao.zeng@siemens.com>
 Date: Fri, 19 Mar 2021 14:40:24 +0800
-Subject: [PATCH 09/10] dts: add the usb3.0 support
+Subject: [PATCH 09/11] dts: add the usb3.0 support
 
 enable serdes0 and add the clock configuration
 
@@ -44,5 +44,5 @@ index 4ceac8f55cd8..efe9ef73bc0d 100644
  
  &dwc3_1 {
 -- 
-2.30.0
+2.31.1
 

--- a/recipes-kernel/linux/files/5.x-kernel/0010-dts-add-the-cp2102n-reset-pin-defination.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0010-dts-add-the-cp2102n-reset-pin-defination.patch
@@ -1,7 +1,7 @@
 From 4be77f522174487c35a3ff5810e1d92c2db9b233 Mon Sep 17 00:00:00 2001
 From: Chao Zeng <chao.zeng@siemens.com>
 Date: Mon, 22 Mar 2021 13:34:18 +0800
-Subject: [PATCH 10/10] dts : add the cp2102n reset pin defination
+Subject: [PATCH 10/11] dts : add the cp2102n reset pin defination
 
 configure the cp2102n reset pin and named lines to control cp2102n reset function
 
@@ -50,5 +50,5 @@ index efe9ef73bc0d..112bc9bc8722 100644
  	pinctrl-names = "default";
  	pinctrl-0 = <&arduino_io_d2_to_d3_pins_default
 -- 
-2.30.0
+2.31.1
 

--- a/recipes-kernel/linux/files/5.x-kernel/0011-dts-reconfigure-pcie-node.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0011-dts-reconfigure-pcie-node.patch
@@ -1,0 +1,47 @@
+From 92320a70bee4a2a116e13db24192f5e964cbe43b Mon Sep 17 00:00:00 2001
+From: Chao Zeng <chao.zeng@siemens.com>
+Date: Mon, 19 Apr 2021 10:34:08 +0800
+Subject: [PATCH 11/11] dts: reconfigure pcie node
+
+as lack of property:num-lanes,there is no any phy link,the board can not
+detect pcie devices.
+
+Signed-off-by: Chao Zeng <chao.zeng@siemens.com>
+---
+ arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
+index 112bc9bc8722..b846fe38b902 100644
+--- a/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
++++ b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
+@@ -808,13 +808,25 @@
+ &pcie1_rc {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&minipcie_pins_default>;
+-
++	num-lanes = <1>;
+ 	phys = <&serdes1 PHY_TYPE_PCIE 0>;
+ 	phy-names = "pcie-phy0";
+ 	reset-gpios = <&wkup_gpio0 27 GPIO_ACTIVE_HIGH>;
+ 	status = "okay";
+ };
+ 
++&pcie1_ep {
++	status = "disabled";
++};
++
++&pcie0_rc {
++	status = "disabled";
++};
++
++&pcie0_ep {
++	status = "disabled";
++};
++
+ /* Disable crypto and eip76d_trng temporarily, because the HS system firmware has taken them up */
+ &crypto {
+       status = "disabled";
+-- 
+2.31.1
+

--- a/recipes-kernel/linux/linux-iot2050_5.4.74+.bb
+++ b/recipes-kernel/linux/linux-iot2050_5.4.74+.bb
@@ -21,7 +21,8 @@ SRC_URI += " \
     file://5.x-kernel/0007-Add-support-for-U9300C-TD-LTE-module.patch \
     file://5.x-kernel/0008-feat-change-mmc-order-using-alias-in-dts.patch \
     file://5.x-kernel/0009-dts-add-the-usb3.0-support.patch \
-    file://5.x-kernel/0010-dts-add-the-cp2102n-reset-pin-defination.patch"
+    file://5.x-kernel/0010-dts-add-the-cp2102n-reset-pin-defination.patch \
+    file://5.x-kernel/0011-dts-reconfigure-pcie-node.patch"
 
 SRC_URI += " \
     file://${KERNEL_DEFCONFIG} \


### PR DESCRIPTION
as lack of property:num-lanes,there is no any phy link,the board can not
detect pcie devices.

Signed-off-by: Chao Zeng <chao.zeng@siemens.com>