### PR TITLE
kernel:dts:remove the extra sdhci configuration

### DIFF
--- a/recipes-kernel/linux/files/5.x-kernel/0001-iot2050-add-iot2050-platform-support.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0001-iot2050-add-iot2050-platform-support.patch
@@ -1,4 +1,4 @@
-From 654ea81a97520f4422584408cfb93bdc5eeda59a Mon Sep 17 00:00:00 2001
+From 7937c5ec6edd061191cfa2965a7f80afa5176ae5 Mon Sep 17 00:00:00 2001
 From: Le Jin <le.jin@siemens.com>
 Date: Mon, 18 Nov 2019 17:58:08 +0800
 Subject: [PATCH 01/11] iot2050: add iot2050 platform support
@@ -9,10 +9,10 @@ Signed-off-by: le.jin <le.jin@siemens.com>
 Signed-off-by: chao zeng <chao.zeng@siemens.com>
 ---
  arch/arm64/boot/dts/ti/Makefile               |   3 +
- arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi   | 790 ++++++++++++++++++
+ arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi   | 789 ++++++++++++++++++
  .../boot/dts/ti/k3-am6528-iot2050-basic.dts   |  52 ++
  .../dts/ti/k3-am6548-iot2050-advanced.dts     |  53 ++
- 4 files changed, 898 insertions(+)
+ 4 files changed, 897 insertions(+)
  create mode 100644 arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
  create mode 100644 arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts
  create mode 100644 arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts
@@ -33,10 +33,10 @@ index 12d72851f94d..941c4e257150 100644
  				   k3-j7200-common-proc-board.dtb \
 diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
 new file mode 100644
-index 000000000000..5ffcbd9641b7
+index 000000000000..fd78c3de12ef
 --- /dev/null
 +++ b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
-@@ -0,0 +1,790 @@
+@@ -0,0 +1,789 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * (C) Copyright 2019 Siemens AG
@@ -673,7 +673,6 @@ index 000000000000..5ffcbd9641b7
 +	pinctrl-0 = <&main_mmc1_pins_default>;
 +	ti,driver-strength-ohm = <50>;
 +	disable-wp;
-+	no-1-8-v;// for SR1 board,needed to be removed for sr2
 +};
 +
 +&gpu {

--- a/recipes-kernel/linux/files/5.x-kernel/0002-Workaround-to-correct-DP-clock-to-154MHZ.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0002-Workaround-to-correct-DP-clock-to-154MHZ.patch
@@ -1,4 +1,4 @@
-From e337999155209ab2a209ec7868921e8f2f5d3d8a Mon Sep 17 00:00:00 2001
+From 59e4f1a48f65a535685d6737ea42a2ef23d69a6f Mon Sep 17 00:00:00 2001
 From: Chao Zeng <chao.zeng@siemens.com>
 Date: Wed, 6 Jan 2021 15:51:18 +0800
 Subject: [PATCH 02/11] Workaround to correct DP clock to 154MHZ.
@@ -14,10 +14,10 @@ Signed-off-by: Chao Zeng <chao.zeng@siemens.com>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
-index 5ffcbd9641b7..0dba4e95ca90 100644
+index fd78c3de12ef..594070b19fc4 100644
 --- a/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
 +++ b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
-@@ -729,9 +729,9 @@
+@@ -728,9 +728,9 @@
  
  	pinctrl-names = "default";
  	pinctrl-0 = <&dss_vout1_pins_default>;

--- a/recipes-kernel/linux/files/5.x-kernel/0003-setting-the-RJ45-port-led-behavior.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0003-setting-the-RJ45-port-led-behavior.patch
@@ -1,4 +1,4 @@
-From 91cf92289785c05e8400cc30ac506aababa7202a Mon Sep 17 00:00:00 2001
+From 884b3df434728ab7468040328b5161369c06ca5f Mon Sep 17 00:00:00 2001
 From: zengchao <chao.zeng@siemens.com>
 Date: Wed, 6 Nov 2019 11:21:49 +0800
 Subject: [PATCH 03/11] setting the RJ45 port led behavior

--- a/recipes-kernel/linux/files/5.x-kernel/0004-feat-Add-CP210x-driver-support-to-software-flow-cont.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0004-feat-Add-CP210x-driver-support-to-software-flow-cont.patch
@@ -1,4 +1,4 @@
-From b4ec660bd9d80d4cde44ac8003d0b3ed25d7cc76 Mon Sep 17 00:00:00 2001
+From 0c80b0d90ae37633302a68c384f271932cdb1bd0 Mon Sep 17 00:00:00 2001
 From: Su Bao Cheng <baocheng.su@siemens.com>
 Date: Mon, 15 Jul 2019 15:46:09 +0800
 Subject: [PATCH 04/11] feat: Add CP210x driver support to software flow

--- a/recipes-kernel/linux/files/5.x-kernel/0005-feat-add-io-expander-pcal9535-support.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0005-feat-add-io-expander-pcal9535-support.patch
@@ -1,4 +1,4 @@
-From 81e7cc4494b19b262b3704b7a364be45a47cab87 Mon Sep 17 00:00:00 2001
+From fb31b2219ef355046be9e0ebf7368451717ded2a Mon Sep 17 00:00:00 2001
 From: "le.jin" <le.jin@siemens.com>
 Date: Wed, 9 Oct 2019 17:08:43 +0800
 Subject: [PATCH 05/11] feat:add io expander pcal9535 support

--- a/recipes-kernel/linux/files/5.x-kernel/0006-feat-extend-led-panic-indicator-on-and-off.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0006-feat-extend-led-panic-indicator-on-and-off.patch
@@ -1,4 +1,4 @@
-From d3d472450266bdf1310651fafd14ea961cbf1730 Mon Sep 17 00:00:00 2001
+From 820884dcab40f14bd1d5f79970f8fe7d3d74dbab Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Fri, 3 Jan 2020 14:50:16 +0800
 Subject: [PATCH 06/11] feat:extend led panic-indicator on and off
@@ -13,7 +13,7 @@ Signed-off-by: Gao Nian <nian.gao@siemens.com>
  5 files changed, 30 insertions(+), 6 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
-index 0dba4e95ca90..4ceac8f55cd8 100644
+index 594070b19fc4..a6490d0d784e 100644
 --- a/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
 +++ b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
 @@ -137,6 +137,7 @@

--- a/recipes-kernel/linux/files/5.x-kernel/0007-Add-support-for-U9300C-TD-LTE-module.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0007-Add-support-for-U9300C-TD-LTE-module.patch
@@ -1,4 +1,4 @@
-From 987b6c369843733104021c781a543a8d3c79cfa2 Mon Sep 17 00:00:00 2001
+From 91f2b44f729dddebc9743de9af6b6f782d551843 Mon Sep 17 00:00:00 2001
 From: Su Bao Cheng <baocheng.su@siemens.com>
 Date: Tue, 23 Apr 2019 10:07:17 +0800
 Subject: [PATCH 07/11] Add support for U9300C TD-LTE module

--- a/recipes-kernel/linux/files/5.x-kernel/0008-feat-change-mmc-order-using-alias-in-dts.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0008-feat-change-mmc-order-using-alias-in-dts.patch
@@ -1,4 +1,4 @@
-From 8a8f643e2e8abc6a3d44efd7b4082394d87dfc47 Mon Sep 17 00:00:00 2001
+From d8e452460ec51899ab27456180cadc58570d1425 Mon Sep 17 00:00:00 2001
 From: "le.jin" <le.jin@siemens.com>
 Date: Wed, 9 Oct 2019 15:22:09 +0800
 Subject: [PATCH 08/11] feat:change mmc order using alias in dts

--- a/recipes-kernel/linux/files/5.x-kernel/0009-dts-add-the-usb3.0-support.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0009-dts-add-the-usb3.0-support.patch
@@ -1,4 +1,4 @@
-From a3ecd89a1aa5b697270142366e7eaa9ad6a731c0 Mon Sep 17 00:00:00 2001
+From f05f4df713c6adf7a080fcd3e1aa3098d4a62caa Mon Sep 17 00:00:00 2001
 From: Chao Zeng <chao.zeng@siemens.com>
 Date: Fri, 19 Mar 2021 14:40:24 +0800
 Subject: [PATCH 09/11] dts: add the usb3.0 support
@@ -11,10 +11,10 @@ Signed-off-by: Chao Zeng <chao.zeng@siemens.com>
  1 file changed, 13 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
-index 4ceac8f55cd8..efe9ef73bc0d 100644
+index a6490d0d784e..f17b36b1d814 100644
 --- a/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
 +++ b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
-@@ -642,8 +642,18 @@
+@@ -641,8 +641,18 @@
  	status = "okay";
  };
  
@@ -33,7 +33,7 @@ index 4ceac8f55cd8..efe9ef73bc0d 100644
  };
  
  &usb0_phy {
-@@ -654,6 +664,9 @@
+@@ -653,6 +663,9 @@
  	pinctrl-names = "default";
  	pinctrl-0 = <&usb0_pins_default>;
  	dr_mode = "host";

--- a/recipes-kernel/linux/files/5.x-kernel/0010-dts-add-the-cp2102n-reset-pin-defination.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0010-dts-add-the-cp2102n-reset-pin-defination.patch
@@ -1,4 +1,4 @@
-From 4be77f522174487c35a3ff5810e1d92c2db9b233 Mon Sep 17 00:00:00 2001
+From 668de021cead4cc5622df2decca78b4107577216 Mon Sep 17 00:00:00 2001
 From: Chao Zeng <chao.zeng@siemens.com>
 Date: Mon, 22 Mar 2021 13:34:18 +0800
 Subject: [PATCH 10/11] dts : add the cp2102n reset pin defination
@@ -11,7 +11,7 @@ Signed-off-by: Chao Zeng <chao.zeng@siemens.com>
  1 file changed, 21 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
-index efe9ef73bc0d..112bc9bc8722 100644
+index f17b36b1d814..ee00cec6ec23 100644
 --- a/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
 +++ b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
 @@ -407,6 +407,12 @@

--- a/recipes-kernel/linux/files/5.x-kernel/0011-dts-reconfigure-pcie-node.patch
+++ b/recipes-kernel/linux/files/5.x-kernel/0011-dts-reconfigure-pcie-node.patch
@@ -1,4 +1,4 @@
-From 92320a70bee4a2a116e13db24192f5e964cbe43b Mon Sep 17 00:00:00 2001
+From e542bf5ccb9fcaa317c2898bb3ff86b31bdfdee7 Mon Sep 17 00:00:00 2001
 From: Chao Zeng <chao.zeng@siemens.com>
 Date: Mon, 19 Apr 2021 10:34:08 +0800
 Subject: [PATCH 11/11] dts: reconfigure pcie node
@@ -12,10 +12,10 @@ Signed-off-by: Chao Zeng <chao.zeng@siemens.com>
  1 file changed, 13 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
-index 112bc9bc8722..b846fe38b902 100644
+index ee00cec6ec23..023923268e71 100644
 --- a/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
 +++ b/arch/arm64/boot/dts/ti/k3-am65-iot2050.dtsi
-@@ -808,13 +808,25 @@
+@@ -807,13 +807,25 @@
  &pcie1_rc {
  	pinctrl-names = "default";
  	pinctrl-0 = <&minipcie_pins_default>;


### PR DESCRIPTION
remove the extra sdhci configuration for PG2

Signed-off-by: Chao Zeng <chao.zeng@siemens.com>