### PR TITLE
linux-iot2050: Add patch that fixed UART IRQ storm possibility

### DIFF
--- a/recipes-kernel/linux/files/0001-iot2050-add-iot2050-platform-support.patch
+++ b/recipes-kernel/linux/files/0001-iot2050-add-iot2050-platform-support.patch
@@ -1,7 +1,7 @@
 From 3d82ab21200c49d730a1db49aea551061dda4751 Mon Sep 17 00:00:00 2001
 From: Le Jin <le.jin@siemens.com>
 Date: Mon, 18 Nov 2019 17:58:08 +0800
-Subject: [PATCH 01/13] iot2050: add iot2050 platform support
+Subject: [PATCH 01/14] iot2050: add iot2050 platform support
 
 Add support for two iot2050 variants, BASIC and ADVANCED.
 Also add support for fixed gpio number naming.

--- a/recipes-kernel/linux/files/0002-Add-support-for-U9300C-TD-LTE-module.patch
+++ b/recipes-kernel/linux/files/0002-Add-support-for-U9300C-TD-LTE-module.patch
@@ -1,7 +1,7 @@
 From 0119ef2888c7cc3c9edd9525bfea2411594eea5c Mon Sep 17 00:00:00 2001
 From: Su Bao Cheng <baocheng.su@siemens.com>
 Date: Tue, 23 Apr 2019 10:07:17 +0800
-Subject: [PATCH 02/13] Add support for U9300C TD-LTE module
+Subject: [PATCH 02/14] Add support for U9300C TD-LTE module
 
 Author: Gao Nian  <nian.gao@siemens.com>
 Signed-off-by: Su Bao Cheng <baocheng.su@siemens.com>

--- a/recipes-kernel/linux/files/0003-feat-Add-CP210x-driver-support-to-software-flow-cont.patch
+++ b/recipes-kernel/linux/files/0003-feat-Add-CP210x-driver-support-to-software-flow-cont.patch
@@ -1,7 +1,7 @@
 From 85c049cb1a9f5408f81543919d7c452e9c43d6f0 Mon Sep 17 00:00:00 2001
 From: Su Bao Cheng <baocheng.su@siemens.com>
 Date: Mon, 15 Jul 2019 15:46:09 +0800
-Subject: [PATCH 03/13] feat: Add CP210x driver support to software flow
+Subject: [PATCH 03/14] feat: Add CP210x driver support to software flow
  control
 
 Signed-off-by: Wang Sheng Long <shenglong.wang.ext@siemens.com>

--- a/recipes-kernel/linux/files/0004-fix-disable-usb-lpm-to-fix-usb-device-reset.patch
+++ b/recipes-kernel/linux/files/0004-fix-disable-usb-lpm-to-fix-usb-device-reset.patch
@@ -1,7 +1,7 @@
 From f76426af440ba70cdabad0ac13b217616b6f344d Mon Sep 17 00:00:00 2001
 From: Sheng Long Wang <shenglong.wang.ext@siemens.com>
 Date: Tue, 13 Aug 2019 09:30:38 +0800
-Subject: [PATCH 04/13] fix: disable usb lpm to fix usb device reset
+Subject: [PATCH 04/14] fix: disable usb lpm to fix usb device reset
 
 ---
  drivers/usb/core/hub.c | 2 +-

--- a/recipes-kernel/linux/files/0005-Fix-DP-maybe-not-display-problem.patch
+++ b/recipes-kernel/linux/files/0005-Fix-DP-maybe-not-display-problem.patch
@@ -1,7 +1,7 @@
 From d38df3c4cb87e306307b3d1b91a981581c704b73 Mon Sep 17 00:00:00 2001
 From: Sheng Long Wang <shenglong.wang.ext@siemens.com>
 Date: Tue, 13 Aug 2019 10:27:44 +0800
-Subject: [PATCH 05/13] Fix: DP maybe not display problem.
+Subject: [PATCH 05/14] Fix: DP maybe not display problem.
 
 Three reasons:
 	1. No entry link training phase

--- a/recipes-kernel/linux/files/0006-fix-fix-the-hardware-flow-function-of-cp2102n24.patch
+++ b/recipes-kernel/linux/files/0006-fix-fix-the-hardware-flow-function-of-cp2102n24.patch
@@ -1,7 +1,7 @@
 From 0a0750ce140190017241f235b07e519a38a29fa7 Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Wed, 21 Aug 2019 16:22:30 +0800
-Subject: [PATCH 06/13] fix:fix the hardware flow function of cp2102n24
+Subject: [PATCH 06/14] fix:fix the hardware flow function of cp2102n24
 
 Signed-off-by: Gao Nian <nian.gao@siemens.com>
 ---

--- a/recipes-kernel/linux/files/0007-feat-add-io-expander-pcal9535-support.patch
+++ b/recipes-kernel/linux/files/0007-feat-add-io-expander-pcal9535-support.patch
@@ -1,7 +1,7 @@
 From 00a426b081267ea958916fa9cfad707e87c172ef Mon Sep 17 00:00:00 2001
 From: "le.jin" <le.jin@siemens.com>
 Date: Wed, 9 Oct 2019 17:08:43 +0800
-Subject: [PATCH 07/13] feat:add io expander pcal9535 support
+Subject: [PATCH 07/14] feat:add io expander pcal9535 support
 
 Signed-off-by: le.jin <le.jin@siemens.com>
 ---

--- a/recipes-kernel/linux/files/0008-setting-the-RJ45-port-led-behavior.patch
+++ b/recipes-kernel/linux/files/0008-setting-the-RJ45-port-led-behavior.patch
@@ -1,7 +1,7 @@
 From bd8c62c33aca5c94bc54c79fdef7c6c96ef57671 Mon Sep 17 00:00:00 2001
 From: zengchao <chao.zeng@siemens.com>
 Date: Wed, 6 Nov 2019 11:21:49 +0800
-Subject: [PATCH 08/13] setting the RJ45 port led behavior
+Subject: [PATCH 08/14] setting the RJ45 port led behavior
 
 Signed-off-by: zengchao <chao.zeng@siemens.com>
 ---

--- a/recipes-kernel/linux/files/0009-fix-clear-the-cycle-buffer-of-serial.patch
+++ b/recipes-kernel/linux/files/0009-fix-clear-the-cycle-buffer-of-serial.patch
@@ -1,7 +1,7 @@
 From 1ab25d6688f4299e1e527705f6673c6bce4c8215 Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Tue, 26 Nov 2019 09:05:56 +0800
-Subject: [PATCH 09/13] fix:clear the cycle buffer of serial
+Subject: [PATCH 09/14] fix:clear the cycle buffer of serial
 
 1.the last residual data will be sent next time
 

--- a/recipes-kernel/linux/files/0010-feat-extend-led-panic-indicator-on-and-off.patch
+++ b/recipes-kernel/linux/files/0010-feat-extend-led-panic-indicator-on-and-off.patch
@@ -1,7 +1,7 @@
 From a499ed39ac706359c0fdf495dab2ec57989c7a19 Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Tue, 22 Dec 2020 15:05:56 +0800
-Subject: [PATCH 10/13] feat:extend led panic-indicator on and off
+Subject: [PATCH 10/14] feat:extend led panic-indicator on and off
 
 Signed-off-by: Gao Nian <nian.gao@siemens.com>
 ---

--- a/recipes-kernel/linux/files/0011-fix-can-not-auto-negotiate-to-100M-with-4-wire.patch
+++ b/recipes-kernel/linux/files/0011-fix-can-not-auto-negotiate-to-100M-with-4-wire.patch
@@ -1,7 +1,7 @@
 From 187c1dab4f3190fd90be9f5ba5b58d367c5ce14d Mon Sep 17 00:00:00 2001
 From: Gao Nian <nian.gao@siemens.com>
 Date: Tue, 4 Feb 2020 22:03:52 +0800
-Subject: [PATCH 11/13] fix:can not auto negotiate to 100M with 4-wire
+Subject: [PATCH 11/14] fix:can not auto negotiate to 100M with 4-wire
 
 Signed-off-by: Gao Nian <nian.gao@siemens.com>
 ---

--- a/recipes-kernel/linux/files/0012-feat-change-mmc-order-using-alias-in-dts.patch
+++ b/recipes-kernel/linux/files/0012-feat-change-mmc-order-using-alias-in-dts.patch
@@ -1,7 +1,7 @@
 From 5df72a0aa9663094988a20fb731c07680b931a97 Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Tue, 22 Dec 2020 15:08:17 +0800
-Subject: [PATCH 12/13] feat:change mmc order using alias in dts
+Subject: [PATCH 12/14] feat:change mmc order using alias in dts
 
 1. modify kernel to support mmc alias in dts
 2. change SD to mmc0 and EMMC to mmc1 via alias in dts

--- a/recipes-kernel/linux/files/0013-fix-PLL4_DCO-freq-over-range-cause-DP-not-display.patch
+++ b/recipes-kernel/linux/files/0013-fix-PLL4_DCO-freq-over-range-cause-DP-not-display.patch
@@ -1,7 +1,7 @@
 From 1a555ebfb54b4241be9df6a46a4c2110c171959f Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Fri, 11 Dec 2020 17:20:12 +0800
-Subject: [PATCH 13/13] fix:PLL4_DCO freq over range cause DP not display
+Subject: [PATCH 13/14] fix:PLL4_DCO freq over range cause DP not display
 
   1.some DP may be can not display.
   2.reason: TI sysfw can not correct set PLL4 some frequency

--- a/recipes-kernel/linux/files/0014-serial-8250-8250_omap-Fix-possible-interrupt-storm.patch
+++ b/recipes-kernel/linux/files/0014-serial-8250-8250_omap-Fix-possible-interrupt-storm.patch
@@ -1,0 +1,50 @@
+From 0f8e6c87938ac6d58e4eef3b2e17c94f24db4225 Mon Sep 17 00:00:00 2001
+From: Vignesh Raghavendra <vigneshr@ti.com>
+Date: Tue, 11 May 2021 17:19:55 +0200
+Subject: [PATCH 14/14] serial: 8250: 8250_omap: Fix possible interrupt storm
+
+It is possible that RX TIMEOUT is signalled after RX FIFO has been
+drained, in which case a dummy read of RX FIFO is required to clear RX
+TIMEOUT condition. Otherwise, RX TIMEOUT condition is not cleared
+leading to an interrupt storm
+
+Cc: stable@vger.kernel.org
+Reported-by: Jan Kiszka <jan.kiszka@siemens.com>
+Signed-off-by: Vignesh Raghavendra <vigneshr@ti.com>
+---
+ drivers/tty/serial/8250/8250_omap.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/drivers/tty/serial/8250/8250_omap.c b/drivers/tty/serial/8250/8250_omap.c
+index 47d90ed7e96e..0562d12a7677 100644
+--- a/drivers/tty/serial/8250/8250_omap.c
++++ b/drivers/tty/serial/8250/8250_omap.c
+@@ -98,6 +98,9 @@
+ #define UART_OMAP_EFR2			0x23
+ #define UART_OMAP_EFR2_TIMEOUT_BEHAVE	BIT(6)
+ 
++/* RX FIFO occupancy indicator */
++#define UART_OMAP_RX_LVL		0x64
++
+ struct omap8250_priv {
+ 	int line;
+ 	u8 habit;
+@@ -607,6 +610,15 @@ static irqreturn_t omap8250_irq(int irq, void *dev_id)
+ 	serial8250_rpm_get(up);
+ 	iir = serial_port_in(port, UART_IIR);
+ 	ret = serial8250_handle_irq(port, iir);
++	/*
++	 * It is possible that RX TIMEOUT is signalled after FIFO
++	 * has been drained, in which case a dummy read of RX FIFO is
++	 * required to clear RX TIMEOUT condition.
++	 */
++	if ((iir & UART_IIR_RX_TIMEOUT) == UART_IIR_RX_TIMEOUT) {
++		if (serial_port_in(port, UART_OMAP_RX_LVL) == 0)
++			serial_port_in(port, UART_RX);
++	}
+ 	serial8250_rpm_put(up);
+ 
+ 	return IRQ_RETVAL(ret);
+-- 
+2.26.2
+

--- a/recipes-kernel/linux/linux-iot2050_4.19.94+.bb
+++ b/recipes-kernel/linux/linux-iot2050_4.19.94+.bb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) Siemens AG, 2018
+# Copyright (c) Siemens AG, 2018-2021
 #
 # This file is subject to the terms and conditions of the MIT License.  See
 # COPYING.MIT file in the top-level directory.
@@ -25,7 +25,9 @@ SRC_URI += " \
     file://0010-feat-extend-led-panic-indicator-on-and-off.patch \
     file://0011-fix-can-not-auto-negotiate-to-100M-with-4-wire.patch \
     file://0012-feat-change-mmc-order-using-alias-in-dts.patch \
-    file://0013-fix-PLL4_DCO-freq-over-range-cause-DP-not-display.patch"
+    file://0013-fix-PLL4_DCO-freq-over-range-cause-DP-not-display.patch \
+    file://0014-serial-8250-8250_omap-Fix-possible-interrupt-storm.patch \
+    "
 
 KERNEL_BRANCH = "am6-abi-ti-linux-4.19.y"
 KERNEL_REV = "c7a3b610edfb5a0ee0313e1432bf328362269d05"


### PR DESCRIPTION
Pending upstream: https://lkml.org/lkml/2021/5/11/717. Seen so far only
on the MCU (Arduino) UART under synthetic test-case load.
