### PR TITLE
sf:Query the write protect status before operating the device,

### DIFF
--- a/recipes-bsp/u-boot/files/upstream/0001-arm-dts-Add-IOT2050-device-tree-files.patch
+++ b/recipes-bsp/u-boot/files/upstream/0001-arm-dts-Add-IOT2050-device-tree-files.patch
@@ -1,7 +1,7 @@
-From dd26adb4f5bcb900a499a946cfeefee41901775b Mon Sep 17 00:00:00 2001
+From 252a7eb7b40cdab0f4c5bf21aad8d7e3c66a58bd Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 30 Nov 2020 10:13:04 +0100
-Subject: [PATCH 01/24] arm: dts: Add IOT2050 device tree files
+Subject: [PATCH 01/25] arm: dts: Add IOT2050 device tree files
 
 Prepares for the addition of the IOT2050 board which is based on the TI
 AM65x. The board comes in two variants, Basic and Advanced, so there are
@@ -848,5 +848,5 @@ index 0000000000..80c56df0b9
 +	status = "disabled";
 +};
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0002-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
+++ b/recipes-bsp/u-boot/files/upstream/0002-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
@@ -1,7 +1,7 @@
-From 975430e2bda2b69909375d1b307527ed4619526e Mon Sep 17 00:00:00 2001
+From 04573ef2f5d8da69aeaa23435832acb0af568197 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 11 May 2020 20:10:16 +0200
-Subject: [PATCH 02/24] board: siemens: Add support for SIMATIC IOT2050 devices
+Subject: [PATCH 02/25] board: siemens: Add support for SIMATIC IOT2050 devices
 
 This adds support for the IOT2050 Basic and Advanced devices. The Basic
 used the dual-core AM6528 GP processor, the Advanced one the AM6548 HS
@@ -697,5 +697,5 @@ index 0000000000..2d1b1b1150
 +
 +#endif /* __CONFIG_IOT2050_H */
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0003-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
+++ b/recipes-bsp/u-boot/files/upstream/0003-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
@@ -1,7 +1,7 @@
-From 9b6834f6fcd46f07c70f82f81efa7cf148c75116 Mon Sep 17 00:00:00 2001
+From a9d5ca365dc36812bfa185c245af5d730dcc4f61 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 21 Jun 2020 09:04:30 +0200
-Subject: [PATCH 03/24] watchdog: rti_wdt: Add support for loading firmware
+Subject: [PATCH 03/25] watchdog: rti_wdt: Add support for loading firmware
 
 To avoid the need of extra boot scripting on AM65x for loading a
 watchdog firmware, add the required rproc init and loading logic for the
@@ -183,5 +183,5 @@ index 0000000000..78d99ff9f2
 +rti_wdt_fw_size:
 +.int rti_wdt_fw_end - rti_wdt_fw
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0004-net-eth-uclass-eth_get_dev-based-on-SEQ_ALIAS-instea.patch
+++ b/recipes-bsp/u-boot/files/upstream/0004-net-eth-uclass-eth_get_dev-based-on-SEQ_ALIAS-instea.patch
@@ -1,7 +1,7 @@
-From c461b61c04675f52614901c3ce422a966dab02ed Mon Sep 17 00:00:00 2001
+From b7872ddc5e4e7f9c0ef82877f32f859d4e0e6b62 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:53 +0530
-Subject: [PATCH 04/24] net: eth-uclass: eth_get_dev based on SEQ_ALIAS instead
+Subject: [PATCH 04/25] net: eth-uclass: eth_get_dev based on SEQ_ALIAS instead
  of probe order
 
 In case of multiple eth interfaces currently eth_get_dev
@@ -36,5 +36,5 @@ index 34ca731d1e..ea97c3f0e2 100644
  }
  
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0005-net-eth-uclass-call-stop-only-for-active-devices.patch
+++ b/recipes-bsp/u-boot/files/upstream/0005-net-eth-uclass-call-stop-only-for-active-devices.patch
@@ -1,7 +1,7 @@
-From 19d98951f0b65a85b79c6cfac9275d7718a54280 Mon Sep 17 00:00:00 2001
+From 863d9e88b01f0c135404445da5fc8e54ff0d820b Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:54 +0530
-Subject: [PATCH 05/24] net: eth-uclass: call stop only for active devices
+Subject: [PATCH 05/25] net: eth-uclass: call stop only for active devices
 
 Currently stop is being called unconditionally without even
 checking if start is called which will result in crash where
@@ -28,5 +28,5 @@ index ea97c3f0e2..58a2cbe187 100644
  	/* clear the MAC address */
  	memset(pdata->enetaddr, 0, ARP_HLEN);
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0006-misc-uclass-Introduce-misc_init_by_ofnode.patch
+++ b/recipes-bsp/u-boot/files/upstream/0006-misc-uclass-Introduce-misc_init_by_ofnode.patch
@@ -1,7 +1,7 @@
-From 53fa3deb803904351708214faea6bcb9481b06af Mon Sep 17 00:00:00 2001
+From ec62d13517e41907e0980d62d0da4964f73f697f Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:55 +0530
-Subject: [PATCH 06/24] misc: uclass: Introduce misc_init_by_ofnode
+Subject: [PATCH 06/25] misc: uclass: Introduce misc_init_by_ofnode
 
 Introduce misc_init_by_ofnode to probe a misc device
 using its ofnode.
@@ -80,5 +80,5 @@ index 82ec2ce793..173a5f1278 100644
   * struct misc_ops - Driver model Misc operations
   *
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0007-soc-ti-pruss-add-a-misc-driver-for-PRUSS-in-TI-SoCs.patch
+++ b/recipes-bsp/u-boot/files/upstream/0007-soc-ti-pruss-add-a-misc-driver-for-PRUSS-in-TI-SoCs.patch
@@ -1,7 +1,7 @@
-From 6a443aeab747d09a73be5c070b41b85428b2f738 Mon Sep 17 00:00:00 2001
+From 73ba6e12fe49c2c3a5913a0a5300e9e7601d1838 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:56 +0530
-Subject: [PATCH 07/24] soc: ti: pruss: add a misc driver for PRUSS in TI SoCs
+Subject: [PATCH 07/25] soc: ti: pruss: add a misc driver for PRUSS in TI SoCs
 
 The Programmable Real-Time Unit - Industrial Communication
 Subsystem (PRU-ICSS) is present of various TI SoCs such as
@@ -240,5 +240,5 @@ index 0000000000..9eadeef172
 +int pruss_request_shrmem_region(struct udevice *dev, phys_addr_t *loc);
 +int pruss_request_tm_region(struct udevice *dev, phys_addr_t *loc);
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0008-remoteproc-pruss-add-PRU-remoteproc-driver.patch
+++ b/recipes-bsp/u-boot/files/upstream/0008-remoteproc-pruss-add-PRU-remoteproc-driver.patch
@@ -1,7 +1,7 @@
-From a38213bedbef2df271248b0724bb03123d8c3e2d Mon Sep 17 00:00:00 2001
+From 2f86661d433132ebcd5986491618424fd3d8baea Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:57 +0530
-Subject: [PATCH 08/24] remoteproc: pruss: add PRU remoteproc driver
+Subject: [PATCH 08/25] remoteproc: pruss: add PRU remoteproc driver
 
 The Programmable Real-Time Unit Subsystem (PRUSS) consists of
 dual 32-bit RISC cores (Programmable Real-Time Units, or PRUs)
@@ -461,5 +461,5 @@ index 0000000000..ae596135bf
 +	.priv_auto = sizeof(struct pru_privdata),
 +};
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0009-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
+++ b/recipes-bsp/u-boot/files/upstream/0009-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
@@ -1,7 +1,7 @@
-From 9f099dff79966052b9f08d38a87f89f931701f80 Mon Sep 17 00:00:00 2001
+From 3b8ac1789bb919abe4f5ca63f49601b7e8c0ab4b Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:58 +0530
-Subject: [PATCH 09/24] net: ti: icssg-prueth: Add ICSSG ethernet driver
+Subject: [PATCH 09/25] net: ti: icssg-prueth: Add ICSSG ethernet driver
 
 This is the Ethernet driver for TI SoCs with the
 ICSSG PRU Sub-system running EMAC firmware.
@@ -1154,5 +1154,5 @@ index 0000000000..2af14ed5b2
 +	regmap_write(miig_rt, offs[slice].mac1, mac1);
 +}
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0010-arm-dts-k3-am65-main-Add-msmc_ram-node.patch
+++ b/recipes-bsp/u-boot/files/upstream/0010-arm-dts-k3-am65-main-Add-msmc_ram-node.patch
@@ -1,7 +1,7 @@
-From f1b76e78e736ef0d57e61577e47d12310563e471 Mon Sep 17 00:00:00 2001
+From 3770187955b08b61571306bce92b5e75feddd28a Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:59 +0530
-Subject: [PATCH 10/24] arm: dts: k3-am65-main: Add msmc_ram node
+Subject: [PATCH 10/25] arm: dts: k3-am65-main: Add msmc_ram node
 
 Add msmc_ram node needed for prueth
 
@@ -25,5 +25,5 @@ index cabdba85e0..1b19ec5ea7 100644
  		atf-sram@0 {
  			reg = <0x0 0x20000>;
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0011-arm-dts-k3-am654-base-board-u-boot-Add-icssg-specifi.patch
+++ b/recipes-bsp/u-boot/files/upstream/0011-arm-dts-k3-am654-base-board-u-boot-Add-icssg-specifi.patch
@@ -1,7 +1,7 @@
-From 640b7807dae59f168fdc82190597a48a109d484c Mon Sep 17 00:00:00 2001
+From 0c7ac008e06af84eeadca7c00497a93e7c62f2af Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:49:00 +0530
-Subject: [PATCH 11/24] arm: dts: k3-am654-base-board-u-boot: Add icssg
+Subject: [PATCH 11/25] arm: dts: k3-am654-base-board-u-boot: Add icssg
  specific msmc_ram carveout nodes
 
 Add icssg specific msmc_ram carveout nodes
@@ -32,5 +32,5 @@ index b0602d1dad..ded2321209 100644
 +	};
 +};
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0012-arm-dts-k3-am65-main-Add-pruss-nodes-for-ICSSG2.patch
+++ b/recipes-bsp/u-boot/files/upstream/0012-arm-dts-k3-am65-main-Add-pruss-nodes-for-ICSSG2.patch
@@ -1,7 +1,7 @@
-From 24dd8d007be48e5e453a5e6eaa553f80069c05d1 Mon Sep 17 00:00:00 2001
+From 5c69218ba865fb179f99e77217725165df06a755 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 30 Apr 2020 12:10:17 +0530
-Subject: [PATCH 12/24] arm: dts: k3-am65-main: Add pruss nodes for ICSSG2
+Subject: [PATCH 12/25] arm: dts: k3-am65-main: Add pruss nodes for ICSSG2
 
 Add pruss nodes. This is based 4.19 DT with interrupt properties
 removed from pur/rtu nodes.
@@ -114,5 +114,5 @@ index 1b19ec5ea7..c52068bed0 100644
 +	};
  };
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0013-arm64-dts-ti-am654-base-board-add-ICSSG2-Ethernet-su.patch
+++ b/recipes-bsp/u-boot/files/upstream/0013-arm64-dts-ti-am654-base-board-add-ICSSG2-Ethernet-su.patch
@@ -1,7 +1,7 @@
-From 7fcf067a62b3a27b697c3acb7cb86fef7d1a6e25 Mon Sep 17 00:00:00 2001
+From 8ee259f45696c751ed28ee076554e3814770fbf6 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:49:03 +0530
-Subject: [PATCH 13/24] arm64: dts: ti: am654-base-board: add ICSSG2 Ethernet
+Subject: [PATCH 13/25] arm64: dts: ti: am654-base-board: add ICSSG2 Ethernet
  support
 
 ICSSG2 provide dual Gigabit Ethernet support.
@@ -160,5 +160,5 @@ index ded2321209..682ec47a13 100644
 +	};
 +};
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0014-configs-am65x_evm_a53_defconfig-Enable-prueth-config.patch
+++ b/recipes-bsp/u-boot/files/upstream/0014-configs-am65x_evm_a53_defconfig-Enable-prueth-config.patch
@@ -1,7 +1,7 @@
-From c20d52025bbe74e55f8767fc7d95c11fd57ac784 Mon Sep 17 00:00:00 2001
+From 9134dfdf51e06d49b3ad258b55b7340f06c87683 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 30 Apr 2020 12:17:50 +0530
-Subject: [PATCH 14/24] configs: am65x_evm_a53_defconfig: Enable prueth configs
+Subject: [PATCH 14/25] configs: am65x_evm_a53_defconfig: Enable prueth configs
 
 Enable prueth configs
 
@@ -38,5 +38,5 @@ index 1f2d78d1ac..2310bad31c 100644
  CONFIG_DM_SPI=y
  CONFIG_CADENCE_QSPI=y
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0015-net-ti-icssg-prueth-Drop-unsupported-modes-from-the-.patch
+++ b/recipes-bsp/u-boot/files/upstream/0015-net-ti-icssg-prueth-Drop-unsupported-modes-from-the-.patch
@@ -1,7 +1,7 @@
-From 3fa26aff717d4db4c4fc4adb003a75acfae9fe19 Mon Sep 17 00:00:00 2001
+From ff6fda797cfa63afb4ec0e1a0648a4ab7a215936 Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:30 +0000
-Subject: [PATCH 15/24] net: ti: icssg-prueth: Drop unsupported modes from the
+Subject: [PATCH 15/25] net: ti: icssg-prueth: Drop unsupported modes from the
  PHY
 
 Currently driver supports only 100M and 1G Full duplex modes and
@@ -33,5 +33,5 @@ index 87a85b29ca..5ad598045c 100644
  	phydev->advertising = phydev->supported;
  
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0016-net-ti-icssg-prueth-use-constants-instead-of-hardcod.patch
+++ b/recipes-bsp/u-boot/files/upstream/0016-net-ti-icssg-prueth-use-constants-instead-of-hardcod.patch
@@ -1,7 +1,7 @@
-From c0b637c05a0fdc2d76d88febe836f86deddc0a3f Mon Sep 17 00:00:00 2001
+From 7ef9f989193a8dc426f0aec727354abe0985333e Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:31 +0000
-Subject: [PATCH 16/24] net: ti: icssg-prueth: use constants instead of
+Subject: [PATCH 16/25] net: ti: icssg-prueth: use constants instead of
  hardcoded values
 
 Use existing constants for speed and duplex values instead of
@@ -34,5 +34,5 @@ index 5ad598045c..8e25ddd3ec 100644
  		icssg_update_rgmii_cfg(priv->miig_rt, gig_en, full_duplex,
  				       priv->slice);
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0017-net-ti-icssg-prueth-use-a-single-chn_name-variable-i.patch
+++ b/recipes-bsp/u-boot/files/upstream/0017-net-ti-icssg-prueth-use-a-single-chn_name-variable-i.patch
@@ -1,7 +1,7 @@
-From 98d29c0623a4976aa0178418daf57a3c04473ad6 Mon Sep 17 00:00:00 2001
+From 1daca87b2f2ea92d24e5fdcfc5c4dd3716ef2e41 Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:32 +0000
-Subject: [PATCH 17/24] net: ti: icssg-prueth: use a single chn_name variable
+Subject: [PATCH 17/25] net: ti: icssg-prueth: use a single chn_name variable
  in prueth_start()
 
 Use a single array variable for chn_name in prueth_start() by re-arranging
@@ -46,5 +46,5 @@ index 8e25ddd3ec..99f38ac36b 100644
  		dev_err(dev, "RX dma get failed %d\n", ret);
  
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0018-net-ti-icssg-prueth-Add-port-speed-duplex-command.patch
+++ b/recipes-bsp/u-boot/files/upstream/0018-net-ti-icssg-prueth-Add-port-speed-duplex-command.patch
@@ -1,7 +1,7 @@
-From 567c9f758331198f448aef2f8d98bedcfc091251 Mon Sep 17 00:00:00 2001
+From 63e29430602d77e8d4b3228083a8a9e1c02b2f59 Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:33 +0000
-Subject: [PATCH 18/24] net: ti: icssg-prueth: Add port speed/duplex command
+Subject: [PATCH 18/25] net: ti: icssg-prueth: Add port speed/duplex command
 
 This patch adds port speed/duplex command to firmware once
 the link is up. ICSSG firmware uses default of 10M Half duplex
@@ -265,5 +265,5 @@ index 99f38ac36b..f730d324e7 100644
  	for (i = 8; i < 16; i++)
  		config->tx_buf_sz[i] = cpu_to_le32(0x1800);
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0019-net-ti-icssg-prueth-Add-shutdown-command.patch
+++ b/recipes-bsp/u-boot/files/upstream/0019-net-ti-icssg-prueth-Add-shutdown-command.patch
@@ -1,7 +1,7 @@
-From ac84cace41ef0b4a415767d2c70d9d7438282249 Mon Sep 17 00:00:00 2001
+From f5a3034cf6148b3480fb66604ccf64ffd7a9a9a8 Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:34 +0000
-Subject: [PATCH 19/24] net: ti: icssg-prueth: Add shutdown command
+Subject: [PATCH 19/25] net: ti: icssg-prueth: Add shutdown command
 
 As part of prueth_stop(), stop the firmware packet processing
 by issuing a shutdown command so that interface is taken down
@@ -42,5 +42,5 @@ index f730d324e7..ab9138ebd5 100644
  
  	dma_disable(&priv->dma_tx);
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0020-net-ti-icssg-prueth-Auto-start-PRU-and-RTU-when-star.patch
+++ b/recipes-bsp/u-boot/files/upstream/0020-net-ti-icssg-prueth-Auto-start-PRU-and-RTU-when-star.patch
@@ -1,7 +1,7 @@
-From 24bfa559d233dbd2b5a95fec0d2a5c52938d8405 Mon Sep 17 00:00:00 2001
+From 7b39b78858c8a7b947b45f97c2a384a2f4198f0d Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 19 May 2020 17:07:44 +0200
-Subject: [PATCH 20/24] net: ti: icssg-prueth: Auto-start PRU and RTU when
+Subject: [PATCH 20/25] net: ti: icssg-prueth: Auto-start PRU and RTU when
  starting the interface
 
 This avoids having to do that explicitly on every usage, allowing to
@@ -71,5 +71,5 @@ index ab9138ebd5..18c8d7a4ce 100644
  				 (u8 *)pdata->enetaddr);
  	icssg_class_default(priv->miig_rt, priv->slice);
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0021-config_distro_bootcmd-Add-platform-start-script-hook.patch
+++ b/recipes-bsp/u-boot/files/upstream/0021-config_distro_bootcmd-Add-platform-start-script-hook.patch
@@ -1,7 +1,7 @@
-From 5bdf7b42580cfb2744a56f088737422a10685033 Mon Sep 17 00:00:00 2001
+From 224706aa41123ef7aca61588a4ac01bf7a0fa4d5 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 19 May 2020 17:10:27 +0200
-Subject: [PATCH 21/24] config_distro_bootcmd: Add platform start script hook
+Subject: [PATCH 21/25] config_distro_bootcmd: Add platform start script hook
  for networking
 
 This can be used by boards to inject start commands needed for platform
@@ -44,5 +44,5 @@ index 2627c2a6a5..6f9b6fda67 100644
  		"if pxe get; then " \
  			"pxe boot; " \
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0022-arm-dts-k3-am65-main-Add-ICSSG0-1-nodes.patch
+++ b/recipes-bsp/u-boot/files/upstream/0022-arm-dts-k3-am65-main-Add-ICSSG0-1-nodes.patch
@@ -1,7 +1,7 @@
-From cabf57f41676898e1ef3d707933422f37108028e Mon Sep 17 00:00:00 2001
+From 73184e0aca4fc7a73e979ffcdbdcff869d181121 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Mon, 10 Feb 2020 16:59:29 +0530
-Subject: [PATCH 22/24] arm: dts: k3-am65-main: Add ICSSG0/1 nodes
+Subject: [PATCH 22/25] arm: dts: k3-am65-main: Add ICSSG0/1 nodes
 
 Add the ICCSG0/1 and child nodes.
 
@@ -228,5 +228,5 @@ index c52068bed0..48051f9304 100644
  		compatible = "ti,am654-icssg";
  		power-domains = <&k3_pds 64 TI_SCI_PD_EXCLUSIVE>;
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0023-iot2050-Add-ICSSG0-Ethernet-support.patch
+++ b/recipes-bsp/u-boot/files/upstream/0023-iot2050-Add-ICSSG0-Ethernet-support.patch
@@ -1,7 +1,7 @@
-From 0d4e9ecbf42d1b165573de91e9ee9962855debc3 Mon Sep 17 00:00:00 2001
+From 3eca189eeb5f5173f92fd92275195ae606fee235 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 17 May 2020 20:10:30 +0200
-Subject: [PATCH 23/24] iot2050: Add ICSSG0 Ethernet support
+Subject: [PATCH 23/25] iot2050: Add ICSSG0 Ethernet support
 
 Analogously to the am654-base-board, this adds support for the dual
 Gigabit Ethernet on IOT2050. Here it is connected to ICSSG0. Either mii0
@@ -322,5 +322,5 @@ index 2d1b1b1150..7c0d340f6b 100644
  #include <config_distro_bootcmd.h>
  
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0024-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
+++ b/recipes-bsp/u-boot/files/upstream/0024-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
@@ -1,7 +1,7 @@
-From e1413f334a784be1702a5510cb54365302fac223 Mon Sep 17 00:00:00 2001
+From 35f68b0bdb43601bb8c0f344825c6d9c8f3fb791 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 27 Jun 2020 07:58:01 +0200
-Subject: [PATCH 24/24] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
+Subject: [PATCH 24/25] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
 
 Add the DT entry for a watchdog based on RTI1. It requires additional
 firmware on the MCU R5F cores to handle the expiry, e.g.
@@ -33,5 +33,5 @@ index 7454c8cec0..903796bf7d 100644
 +	};
  };
 -- 
-2.26.2
+2.31.1
 

--- a/recipes-bsp/u-boot/files/upstream/0025-sf-query-the-write-protect-status-before-operating-t.patch
+++ b/recipes-bsp/u-boot/files/upstream/0025-sf-query-the-write-protect-status-before-operating-t.patch
@@ -1,0 +1,45 @@
+From 668897ec69510b2b3dcc21ed458fb2ca11d97854 Mon Sep 17 00:00:00 2001
+From: Chao Zeng <chao.zeng@siemens.com>
+Date: Thu, 27 May 2021 10:09:04 +0800
+Subject: [PATCH 25/25] sf: query the write protect status before operating the
+ device
+
+We need to query the write protect status before operating the device,
+and if not permit, return a prompt.
+
+Signed-off-by: Chao Zeng <chao.zeng@siemens.com>
+---
+ drivers/mtd/spi/sf_probe.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/drivers/mtd/spi/sf_probe.c b/drivers/mtd/spi/sf_probe.c
+index 6c87434867..4224439ee8 100644
+--- a/drivers/mtd/spi/sf_probe.c
++++ b/drivers/mtd/spi/sf_probe.c
+@@ -109,6 +109,11 @@ static int spi_flash_std_write(struct udevice *dev, u32 offset, size_t len,
+ 	struct mtd_info *mtd = &flash->mtd;
+ 	size_t retlen;
+ 
++	if(flash->flash_is_locked && flash->flash_is_locked(flash,offset,len)) {
++		debug("SF: Write protection is enable\n");
++		return -ENOPROTOOPT;
++	}
++
+ 	return mtd->_write(mtd, offset, len, &retlen, buf);
+ }
+ 
+@@ -127,6 +132,11 @@ static int spi_flash_std_erase(struct udevice *dev, u32 offset, size_t len)
+ 	instr.addr = offset;
+ 	instr.len = len;
+ 
++	if(flash->flash_is_locked && flash->flash_is_locked(flash,offset,len)) {
++		debug("SF: Write protection is enable\n");
++		return -ENOPROTOOPT;
++	}	
++
+ 	return mtd->_erase(mtd, &instr);
+ }
+ 
+-- 
+2.31.1
+

--- a/recipes-bsp/u-boot/u-boot-iot2050_2021.04.bb
+++ b/recipes-bsp/u-boot/u-boot-iot2050_2021.04.bb
@@ -36,6 +36,7 @@ SRC_URI += " \
     file://upstream/0022-arm-dts-k3-am65-main-Add-ICSSG0-1-nodes.patch \
     file://upstream/0023-iot2050-Add-ICSSG0-Ethernet-support.patch \
     file://upstream/0024-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch \
+    file://upstream/0025-sf-query-the-write-protect-status-before-operating-t.patch \
     "
 
 U_BOOT_CONFIG = "iot2050_defconfig"


### PR DESCRIPTION
and if not permit, return a prompt

When flash protect is enable,write or erase the flash would not reminder any error.
It would show "erase Ok",but actually erasing the flash is not success

Check the write protection status before operating the device

Signed-off-by: Chao Zeng <chao.zeng@siemens.com>