### PR TITLE
tcf-agent: Switch URL to git.eclipse.org

### DIFF
--- a/recipes-app/tcf-agent/tcf-agent.bb
+++ b/recipes-app/tcf-agent/tcf-agent.bb
@@ -13,7 +13,7 @@ inherit dpkg
 
 PV = "1.7.0-22568cb1"
 SRC_URI = " \
-    git://github.com/eclipse/tcf.agent.git;protocol=https \
+    git://git.eclipse.org/r/tcf/org.eclipse.tcf.agent.git;protocol=https \
     file://debian"
 SRCREV = "22568cb1bfa11888d788eb01e7b386dde3010969"
 


### PR DESCRIPTION
The github repo has been removed, for whatever reasons, and the
git.eclipse.org repo seems to be the official one. But it took quite
some guesswork to find this undocumented URL. What a mess.
