### PR TITLE
iot2050setup: Fix cleanup in case of exceptions

### DIFF
--- a/recipes-app/iot2050setup/files/iot2050setup.py
+++ b/recipes-app/iot2050setup/files/iot2050setup.py
@@ -591,14 +591,14 @@ class PeripheralsMenu:
 
 
 def main():
+    mainwindow = TopMenu()
     try:
-        mainwindow = TopMenu()
         mainwindow.show()
-    except:
-        pass
-    finally:
+    except Exception as e:
         mainwindow.close()
-        return ''
+        raise e
+
+    mainwindow.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
mainwindow initialization must be out of the try block, and we should
not swallow exceptions, rather close the window first and then dump them
properly.
