### PR TITLE
install-on-emmc: Fix partition table update after image writing

### DIFF
--- a/recipes-core/install-on-emmc/files/install-on-emmc.sh
+++ b/recipes-core/install-on-emmc/files/install-on-emmc.sh
@@ -128,7 +128,15 @@ dd if=${BOOT_DEV} of=${EMMC_DEV} count=${SECTORS}
 sync
 
 echo "Updating partition UUID of eMMC rootfs"
-partx -u ${EMMC_DEV}
+partx -a ${EMMC_DEV}
+udevadm settle
+if ! test -b ${EMMC_DEV}p1; then
+	echo "Waiting for ${EMMC_DEV}p1 to appear"
+	while ! test -b ${EMMC_DEV}p1; do
+		echo -n "."
+		sleep 1
+	done
+fi
 mount ${EMMC_DEV}p1 /mnt
 mount -o bind /dev /mnt/dev
 mount -t proc proc /mnt/proc


### PR DESCRIPTION
partx -a is recommended to inform the kernel about new partitions now
visible when rescanning the device. But that seems to be only one piece.
It may take some time for the device node to show up. So wait until that
happened. This should fix errors like

install-on-emmc.sh[175]: Updating partition UUID of eMMC rootfs
install-on-emmc.sh[175]: partx: specified range <1:0> does not make sense
install-on-emmc.sh[175]: mount: /mnt: special device /dev/mmcblk1p1 does not exist.

While I'm still waiting for the reporter's feedback (https://support.industry.siemens.com/tf/ww/en/posts/cannot-boot-from-emmc/264499), I think it's better to merge this for the next release.