### PR TITLE
fix apt preferences

### DIFF
--- a/conf/distro/iot2050-debian.conf
+++ b/conf/distro/iot2050-debian.conf
@@ -53,9 +53,6 @@ HOST_DISTRO_APT_SOURCES_remove_packages-snapshot = "${DISTRO_APT_SOURCES_MAINLIN
 # Required as long as openssl is not rebuilt for the host arch
 HOST_DISTRO_APT_PREFERENCES += "conf/distro/preferences.upstream-libssl"
 
-# ModemManager buster-backports
-HOST_DISTRO_APT_PREFERENCES += "conf/distro/preferences.modemmanager-backport"
-
 SDK_INSTALL += "linux-headers-${KERNEL_NAME} mraa"
 SDK_PREINSTALL += "zlib1g-dev:${DISTRO_ARCH} libjson-c-dev:${DISTRO_ARCH}"
 

--- a/conf/distro/preferences.npm-backport
+++ b/conf/distro/preferences.npm-backport
@@ -3,9 +3,9 @@ Pin: release n=buster
 Pin-Priority: 802
 
 Package: npm gyp node-*
-Pin: release n=bullseye
+Pin: release n=bullseye*
 Pin-Priority: 801
 
 Package: *
-Pin: release n=bullseye
+Pin: release n=bullseye*
 Pin-Priority: -1


### PR DESCRIPTION
Urgent, fixes the currently broken build. See also https://support.industry.siemens.com/tf/ww/en/posts/cant-build-meta-iot2050-image-anymore/266848/?page=0&pageSize=10.