### PR TITLE
customizations-example: Resolve renaming race when swapping eth0/eth1

### DIFF
--- a/recipes-core/customizations-example/customizations-example_0.1-iot2050-debian.bb
+++ b/recipes-core/customizations-example/customizations-example_0.1-iot2050-debian.bb
@@ -24,8 +24,8 @@ SRC_URI = " \
     file://board-configuration.json \
     file://10-globally-managed-devices.conf \
     file://cellular-4g \
-    file://eth0-default \
-    file://20-swap-ethernet-port.rules"
+    file://eno1-default \
+    file://20-assign-ethernet-names.rules"
 
 do_install() {
     # add board status led service
@@ -47,11 +47,10 @@ do_install() {
     install -v -d ${D}/etc/NetworkManager/system-connections/
     install -v -m 600 ${WORKDIR}/cellular-4g ${D}/etc/NetworkManager/system-connections/
 
-    # add eth0 default ip configuration
-    install -v -m 600 ${WORKDIR}/eth0-default ${D}/etc/NetworkManager/system-connections/
+    # add eno1 default ip configuration
+    install -v -m 600 ${WORKDIR}/eno1-default ${D}/etc/NetworkManager/system-connections/
 
     # swap ethernet port
     install -v -d  ${D}/etc/udev/rules.d/
-    install -v -m 644 ${WORKDIR}/20-swap-ethernet-port.rules ${D}/etc/udev/rules.d/
-
+    install -v -m 644 ${WORKDIR}/20-assign-ethernet-names.rules ${D}/etc/udev/rules.d/
 }

--- a/recipes-core/customizations-example/files/20-assign-ethernet-names.rules
+++ b/recipes-core/customizations-example/files/20-assign-ethernet-names.rules
@@ -1,0 +1,2 @@
+KERNEL=="eth0", ACTION=="add", SUBSYSTEM=="net", KERNELS=="pruss0_eth", SUBSYSTEMS=="platform", NAME="eno2"
+KERNEL=="eth1", ACTION=="add", SUBSYSTEM=="net", KERNELS=="pruss0_eth", SUBSYSTEMS=="platform", NAME="eno1"

--- a/recipes-core/customizations-example/files/20-swap-ethernet-port.rules
+++ b/recipes-core/customizations-example/files/20-swap-ethernet-port.rules
@@ -1,2 +1,0 @@
-KERNEL=="eth0",SUBSYSTEM=="net",KERNELS=="pruss0_eth",SUBSYSTEMS=="platform",NAME="eth1"
-KERNEL=="eth1",SUBSYSTEM=="net",KERNELS=="pruss0_eth",SUBSYSTEMS=="platform",NAME="eth0"

--- a/recipes-core/customizations-example/files/eno1-default
+++ b/recipes-core/customizations-example/files/eno1-default
@@ -1,8 +1,8 @@
 [connection]
-id=eth0-default
+id=eno1-default
 uuid=2f479c0e-43f7-3460-958d-4d44617ae118
 type=ethernet
-interface-name=eth0
+interface-name=eno1
 
 [ipv4]
 address1=192.168.200.1/24

--- a/recipes-core/customizations-example/files/postinst
+++ b/recipes-core/customizations-example/files/postinst
@@ -23,7 +23,7 @@ ln -s /etc/systemd/system/tcf-agent.service  /etc/systemd/system/multi-user.targ
 systemctl disable systemd-networkd.service
 systemctl enable NetworkManager.service
 chmod 600 /etc/NetworkManager/system-connections/cellular-4g
-chmod 600 /etc/NetworkManager/system-connections/eth0-default
+chmod 600 /etc/NetworkManager/system-connections/eno1-default
 if ! grep -q "wifi.scan-rand-mac-address=no" /etc/NetworkManager/NetworkManager.conf; then
 	echo "\n\n[device]\nwifi.scan-rand-mac-address=no" >> /etc/NetworkManager/NetworkManager.conf
 fi


### PR DESCRIPTION
I think this should go in before the release, to avoid renaming twice.