### PR TITLE
customizations-example: Make Ethernet renaming rule more robust

### DIFF
--- a/recipes-core/customizations-example/files/20-assign-ethernet-names.rules
+++ b/recipes-core/customizations-example/files/20-assign-ethernet-names.rules
@@ -1,2 +1,2 @@
-KERNEL=="eth0", ACTION=="add", SUBSYSTEM=="net", KERNELS=="pruss0_eth", SUBSYSTEMS=="platform", NAME="eno2"
-KERNEL=="eth1", ACTION=="add", SUBSYSTEM=="net", KERNELS=="pruss0_eth", SUBSYSTEMS=="platform", NAME="eno1"
+ACTION=="add", SUBSYSTEM=="net", KERNELS=="pruss0_eth", SUBSYSTEMS=="platform", ATTR{phys_port_name}=="p1", NAME="eno2"
+ACTION=="add", SUBSYSTEM=="net", KERNELS=="pruss0_eth", SUBSYSTEMS=="platform", ATTR{phys_port_name}=="p2", NAME="eno1"


### PR DESCRIPTION
Use phys_port_name as reliable attribute to tell the different ports of
prueth apart.
