### PR TITLE
u-boot:HACK: arm: mach-k3: am6_init: Prioritize MSMC traffic

### DIFF
--- a/recipes-bsp/u-boot/files/0001-arm-dts-Add-IOT2050-device-tree-files.patch
+++ b/recipes-bsp/u-boot/files/0001-arm-dts-Add-IOT2050-device-tree-files.patch
@@ -1,7 +1,7 @@
-From 18f619ebcf67ffbd2fdcdb465d1467a99e39afe0 Mon Sep 17 00:00:00 2001
+From c0a576015307dfc62a4b8b00368917744568d215 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 30 Nov 2020 10:13:04 +0100
-Subject: [PATCH 01/27] arm: dts: Add IOT2050 device tree files
+Subject: [PATCH 01/28] arm: dts: Add IOT2050 device tree files
 
 Prepares for the addition of the IOT2050 board which is based on the TI
 AM65x. The board comes in two variants, Basic and Advanced, so there are

--- a/recipes-bsp/u-boot/files/0002-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
+++ b/recipes-bsp/u-boot/files/0002-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
@@ -1,7 +1,7 @@
-From a8e3110ce60e5cc4bec87ac72217b1c6507b4921 Mon Sep 17 00:00:00 2001
+From 398065421505447f62d2a1795d8b529ee5799799 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 11 May 2020 20:10:16 +0200
-Subject: [PATCH 02/27] board: siemens: Add support for SIMATIC IOT2050 devices
+Subject: [PATCH 02/28] board: siemens: Add support for SIMATIC IOT2050 devices
 
 This adds support for the IOT2050 Basic and Advanced devices. The Basic
 used the dual-core AM6528 GP processor, the Advanced one the AM6548 HS

--- a/recipes-bsp/u-boot/files/0003-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
+++ b/recipes-bsp/u-boot/files/0003-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
@@ -1,7 +1,7 @@
-From 40cefcab97b3988afd415e0bf8974eeaab5ff62f Mon Sep 17 00:00:00 2001
+From 0aaa4d8af44b24813d385da1c57e8551a2a2c0e4 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 21 Jun 2020 09:04:30 +0200
-Subject: [PATCH 03/27] watchdog: rti_wdt: Add support for loading firmware
+Subject: [PATCH 03/28] watchdog: rti_wdt: Add support for loading firmware
 
 To avoid the need of extra boot scripting on AM65x for loading a
 watchdog firmware, add the required rproc init and loading logic for the

--- a/recipes-bsp/u-boot/files/0004-net-eth-uclass-eth_get_dev-based-on-SEQ_ALIAS-instea.patch
+++ b/recipes-bsp/u-boot/files/0004-net-eth-uclass-eth_get_dev-based-on-SEQ_ALIAS-instea.patch
@@ -1,7 +1,7 @@
-From 33006d9673f3480fa3280f7c1e365d2152242ed7 Mon Sep 17 00:00:00 2001
+From 1c2af4090dc9eff8be38c8f6d87ecc06589e8721 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:53 +0530
-Subject: [PATCH 04/27] net: eth-uclass: eth_get_dev based on SEQ_ALIAS instead
+Subject: [PATCH 04/28] net: eth-uclass: eth_get_dev based on SEQ_ALIAS instead
  of probe order
 
 In case of multiple eth interfaces currently eth_get_dev

--- a/recipes-bsp/u-boot/files/0005-net-eth-uclass-call-stop-only-for-active-devices.patch
+++ b/recipes-bsp/u-boot/files/0005-net-eth-uclass-call-stop-only-for-active-devices.patch
@@ -1,7 +1,7 @@
-From 20fc36760d914cc87dccb86637f34b6c45517171 Mon Sep 17 00:00:00 2001
+From 47a4e6255573296fa0d105cd7fcce0326daccb10 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:54 +0530
-Subject: [PATCH 05/27] net: eth-uclass: call stop only for active devices
+Subject: [PATCH 05/28] net: eth-uclass: call stop only for active devices
 
 Currently stop is being called unconditionally without even
 checking if start is called which will result in crash where

--- a/recipes-bsp/u-boot/files/0006-misc-uclass-Introduce-misc_init_by_ofnode.patch
+++ b/recipes-bsp/u-boot/files/0006-misc-uclass-Introduce-misc_init_by_ofnode.patch
@@ -1,7 +1,7 @@
-From 9d88384812028ea4fb478529fa2be4f85293d957 Mon Sep 17 00:00:00 2001
+From 4353a9378fdb62247159fc333f9dd05dd0408519 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:55 +0530
-Subject: [PATCH 06/27] misc: uclass: Introduce misc_init_by_ofnode
+Subject: [PATCH 06/28] misc: uclass: Introduce misc_init_by_ofnode
 
 Introduce misc_init_by_ofnode to probe a misc device
 using its ofnode.

--- a/recipes-bsp/u-boot/files/0007-soc-ti-pruss-add-a-misc-driver-for-PRUSS-in-TI-SoCs.patch
+++ b/recipes-bsp/u-boot/files/0007-soc-ti-pruss-add-a-misc-driver-for-PRUSS-in-TI-SoCs.patch
@@ -1,7 +1,7 @@
-From 0ce2c45f1bc439584aa70ee6590bdb571df9acb9 Mon Sep 17 00:00:00 2001
+From 3f216b5db455de4a0510ce1076d37fdcdff94fe3 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:56 +0530
-Subject: [PATCH 07/27] soc: ti: pruss: add a misc driver for PRUSS in TI SoCs
+Subject: [PATCH 07/28] soc: ti: pruss: add a misc driver for PRUSS in TI SoCs
 
 The Programmable Real-Time Unit - Industrial Communication
 Subsystem (PRU-ICSS) is present of various TI SoCs such as

--- a/recipes-bsp/u-boot/files/0008-remoteproc-pruss-add-PRU-remoteproc-driver.patch
+++ b/recipes-bsp/u-boot/files/0008-remoteproc-pruss-add-PRU-remoteproc-driver.patch
@@ -1,7 +1,7 @@
-From b75f08541fcc452ad513a45ee55a4c2e92b81989 Mon Sep 17 00:00:00 2001
+From 4d135c24c0f2a85eff78c8399a43e25d8f9c9512 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:57 +0530
-Subject: [PATCH 08/27] remoteproc: pruss: add PRU remoteproc driver
+Subject: [PATCH 08/28] remoteproc: pruss: add PRU remoteproc driver
 
 The Programmable Real-Time Unit Subsystem (PRUSS) consists of
 dual 32-bit RISC cores (Programmable Real-Time Units, or PRUs)

--- a/recipes-bsp/u-boot/files/0009-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
+++ b/recipes-bsp/u-boot/files/0009-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
@@ -1,7 +1,7 @@
-From 974666246b172323d885ed5c17f6e706c4267788 Mon Sep 17 00:00:00 2001
+From 6634486026580147d10c9ff6ecbc098cb347af2a Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:58 +0530
-Subject: [PATCH 09/27] net: ti: icssg-prueth: Add ICSSG ethernet driver
+Subject: [PATCH 09/28] net: ti: icssg-prueth: Add ICSSG ethernet driver
 
 This is the Ethernet driver for TI SoCs with the
 ICSSG PRU Sub-system running EMAC firmware.

--- a/recipes-bsp/u-boot/files/0010-arm-dts-k3-am65-main-Add-msmc_ram-node.patch
+++ b/recipes-bsp/u-boot/files/0010-arm-dts-k3-am65-main-Add-msmc_ram-node.patch
@@ -1,7 +1,7 @@
-From 6263bcf593e55737f6e03f7bf19efb0cc4f9815d Mon Sep 17 00:00:00 2001
+From 695d900fc7ebb87119b4bf872068bbc9bfb9e8ae Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:48:59 +0530
-Subject: [PATCH 10/27] arm: dts: k3-am65-main: Add msmc_ram node
+Subject: [PATCH 10/28] arm: dts: k3-am65-main: Add msmc_ram node
 
 Add msmc_ram node needed for prueth
 

--- a/recipes-bsp/u-boot/files/0011-arm-dts-k3-am654-base-board-u-boot-Add-icssg-specifi.patch
+++ b/recipes-bsp/u-boot/files/0011-arm-dts-k3-am654-base-board-u-boot-Add-icssg-specifi.patch
@@ -1,7 +1,7 @@
-From 418c6fbc6ac427c243c89ca399a32b00e2553b6c Mon Sep 17 00:00:00 2001
+From 746fc72339a963be278a5c9ef2d31337be3b6fa3 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:49:00 +0530
-Subject: [PATCH 11/27] arm: dts: k3-am654-base-board-u-boot: Add icssg
+Subject: [PATCH 11/28] arm: dts: k3-am654-base-board-u-boot: Add icssg
  specific msmc_ram carveout nodes
 
 Add icssg specific msmc_ram carveout nodes

--- a/recipes-bsp/u-boot/files/0012-arm-dts-k3-am65-main-Add-pruss-nodes-for-ICSSG2.patch
+++ b/recipes-bsp/u-boot/files/0012-arm-dts-k3-am65-main-Add-pruss-nodes-for-ICSSG2.patch
@@ -1,7 +1,7 @@
-From 2a7912246940cb039b1c6a8f09df9c4d4cd28e04 Mon Sep 17 00:00:00 2001
+From 76fecbfc60a69c9b9ff2d85f32e9d8491f64a40f Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 30 Apr 2020 12:10:17 +0530
-Subject: [PATCH 12/27] arm: dts: k3-am65-main: Add pruss nodes for ICSSG2
+Subject: [PATCH 12/28] arm: dts: k3-am65-main: Add pruss nodes for ICSSG2
 
 Add pruss nodes. This is based 4.19 DT with interrupt properties
 removed from pur/rtu nodes.

--- a/recipes-bsp/u-boot/files/0013-arm64-dts-ti-am654-base-board-add-ICSSG2-Ethernet-su.patch
+++ b/recipes-bsp/u-boot/files/0013-arm64-dts-ti-am654-base-board-add-ICSSG2-Ethernet-su.patch
@@ -1,7 +1,7 @@
-From cdaffd9dd78174ab92178918f937fb5d2d89e460 Mon Sep 17 00:00:00 2001
+From 7fc72de0992d9b564b793b5dfadae7520d9a8d4e Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 9 Jan 2020 10:49:03 +0530
-Subject: [PATCH 13/27] arm64: dts: ti: am654-base-board: add ICSSG2 Ethernet
+Subject: [PATCH 13/28] arm64: dts: ti: am654-base-board: add ICSSG2 Ethernet
  support
 
 ICSSG2 provide dual Gigabit Ethernet support.

--- a/recipes-bsp/u-boot/files/0014-configs-am65x_evm_a53_defconfig-Enable-prueth-config.patch
+++ b/recipes-bsp/u-boot/files/0014-configs-am65x_evm_a53_defconfig-Enable-prueth-config.patch
@@ -1,7 +1,7 @@
-From 7e23fd63c9ef6db6e36966aeab9bd226262490dd Mon Sep 17 00:00:00 2001
+From bb9af68169b8ec12304119f4c2d4b4f09f0ce658 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Thu, 30 Apr 2020 12:17:50 +0530
-Subject: [PATCH 14/27] configs: am65x_evm_a53_defconfig: Enable prueth configs
+Subject: [PATCH 14/28] configs: am65x_evm_a53_defconfig: Enable prueth configs
 
 Enable prueth configs
 

--- a/recipes-bsp/u-boot/files/0015-net-ti-icssg-prueth-Drop-unsupported-modes-from-the-.patch
+++ b/recipes-bsp/u-boot/files/0015-net-ti-icssg-prueth-Drop-unsupported-modes-from-the-.patch
@@ -1,7 +1,7 @@
-From c032a8f84e1442a7e5e3965d015dd5e3f2ef523c Mon Sep 17 00:00:00 2001
+From 7f3841c7682ef4b8e4f9e4c8202771f64a1146b7 Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:30 +0000
-Subject: [PATCH 15/27] net: ti: icssg-prueth: Drop unsupported modes from the
+Subject: [PATCH 15/28] net: ti: icssg-prueth: Drop unsupported modes from the
  PHY
 
 Currently driver supports only 100M and 1G Full duplex modes and

--- a/recipes-bsp/u-boot/files/0016-net-ti-icssg-prueth-use-constants-instead-of-hardcod.patch
+++ b/recipes-bsp/u-boot/files/0016-net-ti-icssg-prueth-use-constants-instead-of-hardcod.patch
@@ -1,7 +1,7 @@
-From 0b8c631d4470a7c4352ce864d7dc60bb725a5eed Mon Sep 17 00:00:00 2001
+From dd1d5b126df3bc3a81e4c09e3dcf5011ac7bb3a3 Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:31 +0000
-Subject: [PATCH 16/27] net: ti: icssg-prueth: use constants instead of
+Subject: [PATCH 16/28] net: ti: icssg-prueth: use constants instead of
  hardcoded values
 
 Use existing constants for speed and duplex values instead of

--- a/recipes-bsp/u-boot/files/0017-net-ti-icssg-prueth-use-a-single-chn_name-variable-i.patch
+++ b/recipes-bsp/u-boot/files/0017-net-ti-icssg-prueth-use-a-single-chn_name-variable-i.patch
@@ -1,7 +1,7 @@
-From e1bfa9a628de884f68c1c48ca8269657a7c9c11a Mon Sep 17 00:00:00 2001
+From 8063fc0a56bb6e73104bf5c95ae9b1af8cae3b9a Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:32 +0000
-Subject: [PATCH 17/27] net: ti: icssg-prueth: use a single chn_name variable
+Subject: [PATCH 17/28] net: ti: icssg-prueth: use a single chn_name variable
  in prueth_start()
 
 Use a single array variable for chn_name in prueth_start() by re-arranging

--- a/recipes-bsp/u-boot/files/0018-net-ti-icssg-prueth-Add-port-speed-duplex-command.patch
+++ b/recipes-bsp/u-boot/files/0018-net-ti-icssg-prueth-Add-port-speed-duplex-command.patch
@@ -1,7 +1,7 @@
-From eb5e7adaea5b42296925c5a5e4bba76f28c2c977 Mon Sep 17 00:00:00 2001
+From ce8852688a92286852e7046867d1d3011430af2b Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:33 +0000
-Subject: [PATCH 18/27] net: ti: icssg-prueth: Add port speed/duplex command
+Subject: [PATCH 18/28] net: ti: icssg-prueth: Add port speed/duplex command
 
 This patch adds port speed/duplex command to firmware once
 the link is up. ICSSG firmware uses default of 10M Half duplex

--- a/recipes-bsp/u-boot/files/0019-net-ti-icssg-prueth-Add-shutdown-command.patch
+++ b/recipes-bsp/u-boot/files/0019-net-ti-icssg-prueth-Add-shutdown-command.patch
@@ -1,7 +1,7 @@
-From b5b74c0e5e62240444e642667ab349b871787465 Mon Sep 17 00:00:00 2001
+From 3d4bae4778514f41f47b41d6ddf1a46592b3be93 Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Wed, 4 Mar 2020 23:33:34 +0000
-Subject: [PATCH 19/27] net: ti: icssg-prueth: Add shutdown command
+Subject: [PATCH 19/28] net: ti: icssg-prueth: Add shutdown command
 
 As part of prueth_stop(), stop the firmware packet processing
 by issuing a shutdown command so that interface is taken down

--- a/recipes-bsp/u-boot/files/0020-net-ti-icssg-prueth-Auto-start-PRU-and-RTU-when-star.patch
+++ b/recipes-bsp/u-boot/files/0020-net-ti-icssg-prueth-Auto-start-PRU-and-RTU-when-star.patch
@@ -1,7 +1,7 @@
-From 0580d67852787c3f07eec15111098e5663337fbd Mon Sep 17 00:00:00 2001
+From a3b84fa82d1b148aec3bf41a5349aac8289c1f4a Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 19 May 2020 17:07:44 +0200
-Subject: [PATCH 20/27] net: ti: icssg-prueth: Auto-start PRU and RTU when
+Subject: [PATCH 20/28] net: ti: icssg-prueth: Auto-start PRU and RTU when
  starting the interface
 
 This avoids having to do that explicitly on every usage, allowing to

--- a/recipes-bsp/u-boot/files/0021-config_distro_bootcmd-Add-platform-start-script-hook.patch
+++ b/recipes-bsp/u-boot/files/0021-config_distro_bootcmd-Add-platform-start-script-hook.patch
@@ -1,7 +1,7 @@
-From a48999023dacdb1d3bd40c977729dea1bcbd3896 Mon Sep 17 00:00:00 2001
+From 10d64755028cef1bb89683a6b568435760471870 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 19 May 2020 17:10:27 +0200
-Subject: [PATCH 21/27] config_distro_bootcmd: Add platform start script hook
+Subject: [PATCH 21/28] config_distro_bootcmd: Add platform start script hook
  for networking
 
 This can be used by boards to inject start commands needed for platform

--- a/recipes-bsp/u-boot/files/0022-arm-dts-k3-am65-main-Add-ICSSG0-1-nodes.patch
+++ b/recipes-bsp/u-boot/files/0022-arm-dts-k3-am65-main-Add-ICSSG0-1-nodes.patch
@@ -1,7 +1,7 @@
-From 1b4d75dbe69b6a880d13d1c139c320e0559dcfdd Mon Sep 17 00:00:00 2001
+From f9a705f3316a61d06d3cde31fe44bfc569aea8f1 Mon Sep 17 00:00:00 2001
 From: Keerthy <j-keerthy@ti.com>
 Date: Mon, 10 Feb 2020 16:59:29 +0530
-Subject: [PATCH 22/27] arm: dts: k3-am65-main: Add ICSSG0/1 nodes
+Subject: [PATCH 22/28] arm: dts: k3-am65-main: Add ICSSG0/1 nodes
 
 Add the ICCSG0/1 and child nodes.
 

--- a/recipes-bsp/u-boot/files/0023-iot2050-Add-ICSSG0-Ethernet-support.patch
+++ b/recipes-bsp/u-boot/files/0023-iot2050-Add-ICSSG0-Ethernet-support.patch
@@ -1,7 +1,7 @@
-From e3ce9fbbfb8d5b3e0e4b3f0ed09bf95e8e5c2280 Mon Sep 17 00:00:00 2001
+From 0a8dac806eeb4cd654fe3e60af0b4b52354bc496 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 17 May 2020 20:10:30 +0200
-Subject: [PATCH 23/27] iot2050: Add ICSSG0 Ethernet support
+Subject: [PATCH 23/28] iot2050: Add ICSSG0 Ethernet support
 
 Analogously to the am654-base-board, this adds support for the dual
 Gigabit Ethernet on IOT2050. Here it is connected to ICSSG0. Either mii0

--- a/recipes-bsp/u-boot/files/0024-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
+++ b/recipes-bsp/u-boot/files/0024-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
@@ -1,7 +1,7 @@
-From 4f07de38b77c2758fee6feff4f6c187b599ea55b Mon Sep 17 00:00:00 2001
+From 183b7be295bc272355c25b285b329dc32589bdd5 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 27 Jun 2020 07:58:01 +0200
-Subject: [PATCH 24/27] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
+Subject: [PATCH 24/28] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
 
 Add the DT entry for a watchdog based on RTI1. It requires additional
 firmware on the MCU R5F cores to handle the expiry, e.g.

--- a/recipes-bsp/u-boot/files/0025-arm-dts-update-flash-layout.patch
+++ b/recipes-bsp/u-boot/files/0025-arm-dts-update-flash-layout.patch
@@ -1,7 +1,7 @@
-From 5c3b2724e48b381fb6e13b03daa37370a6caa92b Mon Sep 17 00:00:00 2001
+From ffb36cd81ee584e3acbab3cc5a4afff7a5bcac6b Mon Sep 17 00:00:00 2001
 From: Chao Zeng <chao.zeng@siemens.com>
 Date: Thu, 3 Jun 2021 11:45:01 +0800
-Subject: [PATCH 25/27] arm:dts:update flash layout
+Subject: [PATCH 25/28] arm:dts:update flash layout
 
 extend flash layout,keep the pg1 and pg2 sysfw on the flash
 to unify uboot and retain 64k * 6 for pg2 prufw in the future

--- a/recipes-bsp/u-boot/files/0026-Modify-the-icssg0-pru1-and-rtu1-loadaddress.patch
+++ b/recipes-bsp/u-boot/files/0026-Modify-the-icssg0-pru1-and-rtu1-loadaddress.patch
@@ -1,7 +1,7 @@
-From f3af6adb61e19883083782924587f34968006a70 Mon Sep 17 00:00:00 2001
+From 6fdce1e4daf4eb8811bdeac4d264ce801230f932 Mon Sep 17 00:00:00 2001
 From: Chao Zeng <chao.zeng@siemens.com>
 Date: Tue, 8 Jun 2021 10:40:33 +0800
-Subject: [PATCH 26/27] Modify the icssg0 pru1 and rtu1 loadaddress
+Subject: [PATCH 26/28] Modify the icssg0 pru1 and rtu1 loadaddress
 
 As flash layout has changed,so needed to adjust pru and rtu loadaddr
 according to the latest flash layout

--- a/recipes-bsp/u-boot/files/0027-board-siemens-Add-support-to-select-pg1-and-pg2-boar.patch
+++ b/recipes-bsp/u-boot/files/0027-board-siemens-Add-support-to-select-pg1-and-pg2-boar.patch
@@ -1,7 +1,7 @@
-From dc633f401b9584e0a058037487c66da2f35a8c23 Mon Sep 17 00:00:00 2001
+From 6bf0aebdac6a36ecf89411fe974f50c5f2c99902 Mon Sep 17 00:00:00 2001
 From: Chao Zeng <chao.zeng@siemens.com>
 Date: Wed, 9 Jun 2021 15:09:18 +0800
-Subject: [PATCH 27/27] board:siemens:Add support to select pg1 and pg2 board
+Subject: [PATCH 27/28] board:siemens:Add support to select pg1 and pg2 board
  corresponding dtb
 
 There are different dts for pg1 and pg2 board,so need to judge the board type

--- a/recipes-bsp/u-boot/files/0028-HACK-arm-mach-k3-am6_init-Prioritize-MSMC-traffic-ov.patch
+++ b/recipes-bsp/u-boot/files/0028-HACK-arm-mach-k3-am6_init-Prioritize-MSMC-traffic-ov.patch
@@ -1,0 +1,79 @@
+From e13ec19b3b137d3745f93093b7eb3d80075e2aac Mon Sep 17 00:00:00 2001
+From: Roger Quadros <rogerq@ti.com>
+Date: Wed, 23 Jun 2021 18:19:45 +0530
+Subject: [PATCH 28/28] HACK: arm: mach-k3: am6_init: Prioritize MSMC traffic
+ over DDR in NAVSS Northbridge
+
+NB0 is bridge to SRAM and NB1 is bridge to DDR.
+
+To ensure that SRAM transfers are not stalled due to
+delays during DDR refreshes, SRAM traffic should be higher
+priority (threadmap=2) than DDR traffic (threadmap=0).
+
+This patch does just that.
+
+This is required to fix ICSSG TX lock-ups due to delays in
+MSMC transfers due to incorrect Northbridge configuration.
+
+Signed-off-by: Roger Quadros <rogerq@ti.com>
+Acked-by: Andrew F. Davis <afd@ti.com>
+Acked-by: Tomi Valkeinen <tomi.valkeinen@ti.com>
+Acked-by: Benoit Parrot <bparrot@ti.com>
+Signed-off-by: Lokesh Vutla <lokeshvutla@ti.com>
+---
+ arch/arm/mach-k3/am6_init.c                  | 15 +++++++++++++++
+ arch/arm/mach-k3/include/mach/am6_hardware.h |  7 +++++++
+ 2 files changed, 22 insertions(+)
+
+diff --git a/arch/arm/mach-k3/am6_init.c b/arch/arm/mach-k3/am6_init.c
+index d78d2b8751..ae780d3ed1 100644
+--- a/arch/arm/mach-k3/am6_init.c
++++ b/arch/arm/mach-k3/am6_init.c
+@@ -151,6 +151,19 @@ int fdtdec_board_setup(const void *fdt_blob)
+ 	return fixup_usb_boot();
+ }
+ #endif
++
++static void setup_am654_navss_northbridge(void)
++{
++	/*
++	 * NB0 is bridge to SRAM and NB1 is bridge to DDR.
++	 * To ensure that SRAM transfers are not stalled due to
++	 * delays during DDR refreshes, SRAM traffic should be higher
++	 * priority (threadmap=2) than DDR traffic (threadmap=0).
++	 */
++	writel(0x2, NAVSS0_NBSS_NB0_CFG_BASE + NAVSS_NBSS_THREADMAP);
++	writel(0x0, NAVSS0_NBSS_NB1_CFG_BASE + NAVSS_NBSS_THREADMAP);
++}
++
+ void board_init_f(ulong dummy)
+ {
+ #if defined(CONFIG_K3_LOAD_SYSFW) || defined(CONFIG_K3_AM654_DDRSS)
+@@ -168,6 +181,8 @@ void board_init_f(ulong dummy)
+ 	/* Make all control module registers accessible */
+ 	ctrl_mmr_unlock();
+ 
++	setup_am654_navss_northbridge();
++
+ #ifdef CONFIG_CPU_V7R
+ 	disable_linefill_optimization();
+ 	setup_k3_mpu_regions();
+diff --git a/arch/arm/mach-k3/include/mach/am6_hardware.h b/arch/arm/mach-k3/include/mach/am6_hardware.h
+index 1908a13f0f..0d88b1fd85 100644
+--- a/arch/arm/mach-k3/include/mach/am6_hardware.h
++++ b/arch/arm/mach-k3/include/mach/am6_hardware.h
+@@ -52,4 +52,11 @@
+ /* MCU SCRATCHPAD usage */
+ #define TI_SRAM_SCRATCH_BOARD_EEPROM_START CONFIG_SYS_K3_MCU_SCRATCHPAD_BASE
+ 
++/* NAVSS Northbridge config */
++#define	NAVSS0_NBSS_NB0_CFG_BASE	0x03802000
++#define	NAVSS0_NBSS_NB1_CFG_BASE	0x03803000
++
++#define	NAVSS_NBSS_PID		0x0
++#define	NAVSS_NBSS_THREADMAP	0x10
++
+ #endif /* __ASM_ARCH_AM6_HARDWARE_H */
+-- 
+2.32.0
+

--- a/recipes-bsp/u-boot/u-boot-iot2050_2021.04.bb
+++ b/recipes-bsp/u-boot/u-boot-iot2050_2021.04.bb
@@ -39,6 +39,7 @@ SRC_URI += " \
     file://0025-arm-dts-update-flash-layout.patch \
     file://0026-Modify-the-icssg0-pru1-and-rtu1-loadaddress.patch \
     file://0027-board-siemens-Add-support-to-select-pg1-and-pg2-boar.patch \
+    file://0028-HACK-arm-mach-k3-am6_init-Prioritize-MSMC-traffic-ov.patch \
     "
 
 SRC_URI[sha256sum] = "0d438b1bb5cceb57a18ea2de4a0d51f7be5b05b98717df05938636e0aadfe11a"


### PR DESCRIPTION
As we found when using iperf to test the ethernet.transitonal kernel with sysfw3.x firmware
 would has some tcp protocol error(zero bits)

As the transitonal kernel would compatible with sysfw2.x and sysfw3.x.
Inclued this patch to fix ethernet related problem.

Signed-off-by: Chao Zeng <chao.zeng@siemens.com>