### PR TITLE
systemd: Patch to fix watchdog issue

### DIFF
--- a/recipes-core/images/iot2050-image-base.bb
+++ b/recipes-core/images/iot2050-image-base.bb
@@ -16,6 +16,9 @@ IMAGE_INSTALL += "u-boot-iot2050-config"
 IMAGE_INSTALL += "iot2050-firmware"
 IMAGE_INSTALL += "customizations-base"
 
+# needed to pull systemd with watchdog fix
+IMAGE_INSTALL += "systemd"
+
 IMAGE_PREINSTALL += "libubootenv-tool"
 
 python aggregate_mainline_apt_sources () {

--- a/recipes-core/systemd/files/0001-shared-watchdog-Account-for-watchdogs-that-do-not-su.patch
+++ b/recipes-core/systemd/files/0001-shared-watchdog-Account-for-watchdogs-that-do-not-su.patch
@@ -1,0 +1,44 @@
+From 5a44fefc75f964a2784a5fe4ae7dba7486d6a2e5 Mon Sep 17 00:00:00 2001
+From: Jan Kiszka <jan.kiszka@siemens.com>
+Date: Thu, 9 Sep 2021 16:36:03 +0200
+Subject: [PATCH] shared/watchdog: Account for watchdogs that do not support
+ WDIOC_SETTIMEOUT
+
+Not all watchdog drivers support WDIOC_SETTIMEOUT (e.g. rti-wdt). Those
+are generally configured upfront, outside of the systemd's control.
+
+Allow driving them as well by checking if the user-configured timeout
+is in line with pre-programmed one, skipping the setting if that is the
+case. If both values deviate, we continue to program and then also fail
+with such watchdogs.
+
+Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
+---
+ src/shared/watchdog.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/shared/watchdog.c b/src/shared/watchdog.c
+index d33acafe64..9fce6a4adc 100644
+--- a/src/shared/watchdog.c
++++ b/src/shared/watchdog.c
+@@ -33,12 +33,15 @@ static int update_timeout(void) {
+                         return log_warning_errno(errno, "Failed to disable hardware watchdog: %m");
+         } else {
+                 char buf[FORMAT_TIMESPAN_MAX];
+-                int sec, flags;
++                int sec, current_timeout, flags;
+                 usec_t t;
+ 
++                if (ioctl(watchdog_fd, WDIOC_GETTIMEOUT, &current_timeout) < 0)
++                        current_timeout = -1;
++
+                 t = DIV_ROUND_UP(watchdog_timeout, USEC_PER_SEC);
+                 sec = (int) t >= INT_MAX ? INT_MAX : t; /* Saturate */
+-                if (ioctl(watchdog_fd, WDIOC_SETTIMEOUT, &sec) < 0)
++                if (sec != current_timeout && ioctl(watchdog_fd, WDIOC_SETTIMEOUT, &sec) < 0)
+                         return log_warning_errno(errno, "Failed to set timeout to %is: %m", sec);
+ 
+                 watchdog_timeout = (usec_t) sec * USEC_PER_SEC;
+-- 
+2.31.1
+

--- a/recipes-core/systemd/systemd_247.x.bb
+++ b/recipes-core/systemd/systemd_247.x.bb
@@ -1,0 +1,29 @@
+#
+# Copyright (c) Siemens AG, 2021
+#
+# Authors:
+#  Jan Kiszka <jan.kiszka@siemens.com>
+#
+# SPDX-License-Identifier: MIT
+
+inherit dpkg
+
+SRC_URI = " \
+    apt://${PN}/${BASE_DISTRO_CODENAME} \
+    file://0001-shared-watchdog-Account-for-watchdogs-that-do-not-su.patch;apply=no \
+    "
+CHANGELOG_V="<orig-version>+iot2050"
+
+KEEP_INSTALLED_ON_CLEAN = "1"
+
+do_prepare_build() {
+	deb_add_changelog
+
+	cd ${S}
+	quilt import ${WORKDIR}/*.patch
+	quilt push -a
+
+	# fix cross-build issue (see also https://salsa.debian.org/systemd-team/systemd/-/merge_requests/130)
+	sed -i 's/python3-pyparsing /python3-pyparsing:native /' ${S}/debian/control
+	sed -i 's/python3-evdev /python3-evdev:native /' ${S}/debian/control
+}


### PR DESCRIPTION
Still waiting for feedback, specifically from systemd folks.

It's not optimal at all having to patch: security updates of system will break the watchdog again, systemd package that we install are now with a custom version and also other systemd packages that have a hard version dependency cannot be installed by the users, unless they build their own image.