### PR TITLE
u-boot:sf:get the permission before operating the device

### DIFF
--- a/recipes-bsp/u-boot/files/0001-arm-mach-k3-am6_init-Prioritize-MSMC-traffic-over-DD.patch
+++ b/recipes-bsp/u-boot/files/0001-arm-mach-k3-am6_init-Prioritize-MSMC-traffic-over-DD.patch
@@ -1,7 +1,7 @@
-From 9df7c3c562514af966b3d27a873e10468031af82 Mon Sep 17 00:00:00 2001
+From c35d2927a658d8d36cfccfe9036c14645e677410 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Wed, 8 Sep 2021 22:28:59 +0200
-Subject: [PATCH 1/7] arm: mach-k3: am6_init: Prioritize MSMC traffic over DDR
+Subject: [PATCH 1/8] arm: mach-k3: am6_init: Prioritize MSMC traffic over DDR
  in NAVSS Northbridge
 
 NB0 is bridge to SRAM and NB1 is bridge to DDR.
@@ -87,5 +87,5 @@ index 1908a13f0f..f533e22e06 100644
 +
  #endif /* __ASM_ARCH_AM6_HARDWARE_H */
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-bsp/u-boot/files/0002-arm-dts-Add-IOT2050-device-tree-files.patch
+++ b/recipes-bsp/u-boot/files/0002-arm-dts-Add-IOT2050-device-tree-files.patch
@@ -1,7 +1,7 @@
-From 605cf79343bb34c53b3315f1b7610aefcb100af3 Mon Sep 17 00:00:00 2001
+From 0ea4f05b970730365f93dc5b0fd68c78c7fe43b0 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 30 Nov 2020 10:13:04 +0100
-Subject: [PATCH 2/7] arm: dts: Add IOT2050 device tree files
+Subject: [PATCH 2/8] arm: dts: Add IOT2050 device tree files
 
 Prepares for the addition of the IOT2050 board which is based on the TI
 AM65x. The board comes in four variants, Basic and Advanced, each as
@@ -1381,5 +1381,5 @@ index 0000000000..7ee5e4942c
 +	model = "SIMATIC IOT2050 Advanced";
 +};
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-bsp/u-boot/files/0003-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
+++ b/recipes-bsp/u-boot/files/0003-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
@@ -1,7 +1,7 @@
-From 1462d08d4e3753a58ced2dfb98779414786bf844 Mon Sep 17 00:00:00 2001
+From 5378caccf4238dc439b5e13792c6985f18298165 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 11 May 2020 20:10:16 +0200
-Subject: [PATCH 3/7] board: siemens: Add support for SIMATIC IOT2050 devices
+Subject: [PATCH 3/8] board: siemens: Add support for SIMATIC IOT2050 devices
 
 This adds support for the IOT2050 Basic and Advanced devices. The Basic
 used the dual-core AM6528 GP processor, the Advanced one the AM6548 HS
@@ -748,5 +748,5 @@ index 0000000000..ddb4cfcc8e
 +
 +#endif /* __CONFIG_IOT2050_H */
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-bsp/u-boot/files/0004-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
+++ b/recipes-bsp/u-boot/files/0004-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
@@ -1,7 +1,7 @@
-From 891631c65e8ce90ffccd93b2bfb8105a714d1f92 Mon Sep 17 00:00:00 2001
+From 51c04616f23bbfc9e330a2b4731472fb36f29f65 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 27 Jun 2020 07:58:01 +0200
-Subject: [PATCH 4/7] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
+Subject: [PATCH 4/8] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
 
 Add the DT entry for a watchdog based on RTI1. It requires additional
 firmware on the MCU R5F cores to handle the expiry, e.g.
@@ -35,5 +35,5 @@ index 7454c8cec0..903796bf7d 100644
 +	};
  };
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-bsp/u-boot/files/0005-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
+++ b/recipes-bsp/u-boot/files/0005-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
@@ -1,7 +1,7 @@
-From 318f62e69f35cd1e86094b309e888171aebd72b6 Mon Sep 17 00:00:00 2001
+From 347a9a85f50fcf95d8fddc5e85d3c2b3f443e960 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 21 Jun 2020 09:04:30 +0200
-Subject: [PATCH 5/7] watchdog: rti_wdt: Add support for loading firmware
+Subject: [PATCH 5/8] watchdog: rti_wdt: Add support for loading firmware
 
 To avoid the need of extra boot scripting on AM65x for loading a
 watchdog firmware, add the required rproc init and loading logic for the
@@ -170,5 +170,5 @@ index 8335b20ae8..253286d349 100644
  	timer_margin >>= WDT_PRELOAD_SHIFT;
  	if (timer_margin > WDT_PRELOAD_MAX)
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-bsp/u-boot/files/0006-watchdog-Allow-to-use-CONFIG_WDT-without-starting-wa.patch
+++ b/recipes-bsp/u-boot/files/0006-watchdog-Allow-to-use-CONFIG_WDT-without-starting-wa.patch
@@ -1,7 +1,7 @@
-From 075a23ddc098ba4cdc1c1029aea596c879949447 Mon Sep 17 00:00:00 2001
+From 5f7ffdf5aae06fd150f2bbe14ee067b53770df38 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
 Date: Tue, 9 Mar 2021 14:26:56 +0100
-Subject: [PATCH 6/7] watchdog: Allow to use CONFIG_WDT without starting
+Subject: [PATCH 6/8] watchdog: Allow to use CONFIG_WDT without starting
  watchdog
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -68,5 +68,5 @@ index 28f7918c46..01e5fa47e8 100644
  	gd->flags |= GD_FLG_WDT_READY;
  	printf("WDT:   Started with%s servicing (%ds timeout)\n",
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-bsp/u-boot/files/0007-iot2050-Enable-watchdog-support-but-do-not-auto-star.patch
+++ b/recipes-bsp/u-boot/files/0007-iot2050-Enable-watchdog-support-but-do-not-auto-star.patch
@@ -1,7 +1,7 @@
-From 66c5d0139447b7e1ff43f61801283d04af5ff0a5 Mon Sep 17 00:00:00 2001
+From 1885b5e4c003cd9cf1af8dd07b0c8fa1d413e21f Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 19 Jun 2020 08:56:35 +0200
-Subject: [PATCH 7/7] iot2050: Enable watchdog support, but do not auto-start
+Subject: [PATCH 7/8] iot2050: Enable watchdog support, but do not auto-start
  it
 
 This allows to use the watchdog in custom scripts but does not enforce
@@ -94,5 +94,5 @@ index 4bc6fa63e2..9dfbdd4a7f 100644
 +CONFIG_WDT_K3_RTI_LOAD_FW=y
  CONFIG_OF_LIBFDT_OVERLAY=y
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-bsp/u-boot/files/0008-sf-query-the-write-protect-status-before-operating-t.patch
+++ b/recipes-bsp/u-boot/files/0008-sf-query-the-write-protect-status-before-operating-t.patch
@@ -1,0 +1,45 @@
+From 967e79b7cfaacfdf463b865b33433029aff0f9d6 Mon Sep 17 00:00:00 2001
+From: Chao Zeng <chao.zeng@siemens.com>
+Date: Thu, 27 May 2021 10:09:04 +0800
+Subject: [PATCH 8/8] sf: query the write protect status before operating the
+ device
+
+We need to query the write protect status before operating the device,
+and if not permit, return a prompt.
+
+Signed-off-by: Chao Zeng <chao.zeng@siemens.com>
+---
+ drivers/mtd/spi/sf_probe.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/drivers/mtd/spi/sf_probe.c b/drivers/mtd/spi/sf_probe.c
+index 6c87434867..4224439ee8 100644
+--- a/drivers/mtd/spi/sf_probe.c
++++ b/drivers/mtd/spi/sf_probe.c
+@@ -109,6 +109,11 @@ static int spi_flash_std_write(struct udevice *dev, u32 offset, size_t len,
+ 	struct mtd_info *mtd = &flash->mtd;
+ 	size_t retlen;
+ 
++	if(flash->flash_is_locked && flash->flash_is_locked(flash,offset,len)) {
++		debug("SF: Write protection is enable\n");
++		return -ENOPROTOOPT;
++	}
++
+ 	return mtd->_write(mtd, offset, len, &retlen, buf);
+ }
+ 
+@@ -127,6 +132,11 @@ static int spi_flash_std_erase(struct udevice *dev, u32 offset, size_t len)
+ 	instr.addr = offset;
+ 	instr.len = len;
+ 
++	if(flash->flash_is_locked && flash->flash_is_locked(flash,offset,len)) {
++		debug("SF: Write protection is enable\n");
++		return -ENOPROTOOPT;
++	}	
++
+ 	return mtd->_erase(mtd, &instr);
+ }
+ 
+-- 
+2.32.0
+

--- a/recipes-bsp/u-boot/u-boot-iot2050_2021.04.bb
+++ b/recipes-bsp/u-boot/u-boot-iot2050_2021.04.bb
@@ -19,6 +19,7 @@ SRC_URI += " \
     file://0005-watchdog-rti_wdt-Add-support-for-loading-firmware.patch \
     file://0006-watchdog-Allow-to-use-CONFIG_WDT-without-starting-wa.patch \
     file://0007-iot2050-Enable-watchdog-support-but-do-not-auto-star.patch \
+    file://0008-sf-query-the-write-protect-status-before-operating-t.patch \
     "
 
 SRC_URI[sha256sum] = "0d438b1bb5cceb57a18ea2de4a0d51f7be5b05b98717df05938636e0aadfe11a"


### PR DESCRIPTION
When flash protect is enable,write or erase the flash would not reminder any error.
It would show "erase Ok",but actually erasing the flash is not success

Check the write protection status before operating the device

Signed-off-by: Chao Zeng <chao.zeng@siemens.com>