### PR TITLE
u-boot: fix the string compare for the board name

### DIFF
--- a/recipes-bsp/u-boot/files/0003-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
+++ b/recipes-bsp/u-boot/files/0003-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
@@ -1,4 +1,4 @@
-From 1462d08d4e3753a58ced2dfb98779414786bf844 Mon Sep 17 00:00:00 2001
+From fa3ba2612198610ed008354227adca643766846e Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 11 May 2020 20:10:16 +0200
 Subject: [PATCH 3/8] board: siemens: Add support for SIMATIC IOT2050 devices
@@ -123,7 +123,7 @@ index 0000000000..619594ab8e
 +obj-y += board.o
 diff --git a/board/siemens/iot2050/board.c b/board/siemens/iot2050/board.c
 new file mode 100644
-index 0000000000..e636aea0aa
+index 0000000000..07e7370d08
 --- /dev/null
 +++ b/board/siemens/iot2050/board.c
 @@ -0,0 +1,284 @@
@@ -181,7 +181,7 @@ index 0000000000..e636aea0aa
 +	struct iot2050_info *info = IOT2050_INFO_DATA;
 +
 +	return info->magic == IOT2050_INFO_MAGIC &&
-+		!strcmp((char *)info->name, "IOT2050-ADVANCED");
++		strstr((char *)info->name, "IOT2050-ADVANCED") != NULL;
 +}
 +
 +static bool board_is_sr1(void)

--- a/recipes-bsp/u-boot/files/0004-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
+++ b/recipes-bsp/u-boot/files/0004-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
@@ -1,4 +1,4 @@
-From 891631c65e8ce90ffccd93b2bfb8105a714d1f92 Mon Sep 17 00:00:00 2001
+From 27a7fdfb81c4348d5457a5d55bd7369154c75274 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 27 Jun 2020 07:58:01 +0200
 Subject: [PATCH 4/8] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry

--- a/recipes-bsp/u-boot/files/0005-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
+++ b/recipes-bsp/u-boot/files/0005-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
@@ -1,4 +1,4 @@
-From 318f62e69f35cd1e86094b309e888171aebd72b6 Mon Sep 17 00:00:00 2001
+From 41c8877104f451c3b5e2019c5b57faba0f89d20c Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 21 Jun 2020 09:04:30 +0200
 Subject: [PATCH 5/8] watchdog: rti_wdt: Add support for loading firmware

--- a/recipes-bsp/u-boot/files/0006-watchdog-Allow-to-use-CONFIG_WDT-without-starting-wa.patch
+++ b/recipes-bsp/u-boot/files/0006-watchdog-Allow-to-use-CONFIG_WDT-without-starting-wa.patch
@@ -1,4 +1,4 @@
-From 075a23ddc098ba4cdc1c1029aea596c879949447 Mon Sep 17 00:00:00 2001
+From 4c6d980059525ed26cca2b08681ea069015231e6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
 Date: Tue, 9 Mar 2021 14:26:56 +0100
 Subject: [PATCH 6/8] watchdog: Allow to use CONFIG_WDT without starting

--- a/recipes-bsp/u-boot/files/0007-iot2050-Enable-watchdog-support-but-do-not-auto-star.patch
+++ b/recipes-bsp/u-boot/files/0007-iot2050-Enable-watchdog-support-but-do-not-auto-star.patch
@@ -1,4 +1,4 @@
-From 66c5d0139447b7e1ff43f61801283d04af5ff0a5 Mon Sep 17 00:00:00 2001
+From 2bab35be7fe49e99341f6addbc290702aa4becbc Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 19 Jun 2020 08:56:35 +0200
 Subject: [PATCH 7/8] iot2050: Enable watchdog support, but do not auto-start

--- a/recipes-bsp/u-boot/files/0008-sf-Querying-write-protect-status-before-operating-th.patch
+++ b/recipes-bsp/u-boot/files/0008-sf-Querying-write-protect-status-before-operating-th.patch
@@ -1,4 +1,4 @@
-From f70970781deb528e6bfa08bb8fcabbb55847c8ec Mon Sep 17 00:00:00 2001
+From 69c91ee960fcb5c543c37c1ecf210209f0a1e7cc Mon Sep 17 00:00:00 2001
 From: Chao Zeng <chao.zeng@siemens.com>
 Date: Tue, 22 Jun 2021 13:21:26 +0800
 Subject: [PATCH 8/8] sf: Querying write-protect status before operating the


### PR DESCRIPTION
Use strncmp to compare the board name to check if the board is
advanced or not.

Signed-off-by: Su Bao Cheng <baocheng.su@siemens.com>