### PR TITLE
Work around systemd watchdog

### DIFF
--- a/recipes-kernel/linux/files/patches-5.10/0001-dmaengine-ti-k3-udma-glue-Add-function-to-get-device.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0001-dmaengine-ti-k3-udma-glue-Add-function-to-get-device.patch
@@ -1,7 +1,7 @@
 From 7a3f7901ac78495fd2deeae885f91cfc784d015f Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Tue, 8 Dec 2020 11:04:24 +0200
-Subject: [PATCH 001/103] dmaengine: ti: k3-udma-glue: Add function to get
+Subject: [PATCH 001/104] dmaengine: ti: k3-udma-glue: Add function to get
  device pointer for DMA API
 
 Glue layer users should use the device of the DMA for DMA mapping and

--- a/recipes-kernel/linux/files/patches-5.10/0001-dmaengine-ti-k3-udma-glue-Add-function-to-get-device.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0001-dmaengine-ti-k3-udma-glue-Add-function-to-get-device.patch
@@ -1,4 +1,4 @@
-From b52cce59b807c7cf42c27943a0f40a331c28cef9 Mon Sep 17 00:00:00 2001
+From 7a3f7901ac78495fd2deeae885f91cfc784d015f Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Tue, 8 Dec 2020 11:04:24 +0200
 Subject: [PATCH 001/103] dmaengine: ti: k3-udma-glue: Add function to get

--- a/recipes-kernel/linux/files/patches-5.10/0002-arm64-dts-ti-k3-am65-ringacc-drop-ti-dma-ring-reset-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0002-arm64-dts-ti-k3-am65-ringacc-drop-ti-dma-ring-reset-.patch
@@ -1,7 +1,7 @@
 From 96fa6368bb1f631e3f0007332f3b3e1c9b87acc3 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Sat, 29 Aug 2020 21:41:39 +0300
-Subject: [PATCH 002/103] arm64: dts: ti: k3-am65: ringacc: drop ti,
+Subject: [PATCH 002/104] arm64: dts: ti: k3-am65: ringacc: drop ti,
  dma-ring-reset-quirk
 
 Remove obsolete "ti,dma-ring-reset-quirk" Ringacc DT property.

--- a/recipes-kernel/linux/files/patches-5.10/0002-arm64-dts-ti-k3-am65-ringacc-drop-ti-dma-ring-reset-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0002-arm64-dts-ti-k3-am65-ringacc-drop-ti-dma-ring-reset-.patch
@@ -1,4 +1,4 @@
-From 7adb92e1c4c21904e81b9244fd3b1140f21b341b Mon Sep 17 00:00:00 2001
+From 96fa6368bb1f631e3f0007332f3b3e1c9b87acc3 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Sat, 29 Aug 2020 21:41:39 +0300
 Subject: [PATCH 002/103] arm64: dts: ti: k3-am65: ringacc: drop ti,

--- a/recipes-kernel/linux/files/patches-5.10/0003-arm64-dts-ti-k3-am65-mcu-Add-MCU-domain-R5F-cluster-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0003-arm64-dts-ti-k3-am65-mcu-Add-MCU-domain-R5F-cluster-.patch
@@ -1,7 +1,7 @@
 From abb99fe6362ea754030fefbb1132fe178b4f3de6 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 28 Oct 2020 22:37:55 -0500
-Subject: [PATCH 003/103] arm64: dts: ti: k3-am65-mcu: Add MCU domain R5F
+Subject: [PATCH 003/104] arm64: dts: ti: k3-am65-mcu: Add MCU domain R5F
  cluster node
 
 The AM65x SoCs have a single dual-core Arm Cortex-R5F processor (R5FSS)

--- a/recipes-kernel/linux/files/patches-5.10/0003-arm64-dts-ti-k3-am65-mcu-Add-MCU-domain-R5F-cluster-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0003-arm64-dts-ti-k3-am65-mcu-Add-MCU-domain-R5F-cluster-.patch
@@ -1,4 +1,4 @@
-From b433994db7df1e2472a98df910f93e31c2483ba9 Mon Sep 17 00:00:00 2001
+From abb99fe6362ea754030fefbb1132fe178b4f3de6 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 28 Oct 2020 22:37:55 -0500
 Subject: [PATCH 003/103] arm64: dts: ti: k3-am65-mcu: Add MCU domain R5F

--- a/recipes-kernel/linux/files/patches-5.10/0004-arm64-dts-ti-k3-am65-Cleanup-disabled-nodes-at-SoC-d.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0004-arm64-dts-ti-k3-am65-Cleanup-disabled-nodes-at-SoC-d.patch
@@ -1,7 +1,7 @@
 From 4302aec87ffcd04b3b427cf2c6dd7329e16cd639 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Fri, 13 Nov 2020 15:18:22 -0600
-Subject: [PATCH 004/103] arm64: dts: ti: k3-am65*: Cleanup disabled nodes at
+Subject: [PATCH 004/104] arm64: dts: ti: k3-am65*: Cleanup disabled nodes at
  SoC dtsi level
 
 The device tree standard states that when the status property is

--- a/recipes-kernel/linux/files/patches-5.10/0004-arm64-dts-ti-k3-am65-Cleanup-disabled-nodes-at-SoC-d.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0004-arm64-dts-ti-k3-am65-Cleanup-disabled-nodes-at-SoC-d.patch
@@ -1,4 +1,4 @@
-From 193d8bf531f6e5fba654d8c58b19d737e2c94ec3 Mon Sep 17 00:00:00 2001
+From 4302aec87ffcd04b3b427cf2c6dd7329e16cd639 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Fri, 13 Nov 2020 15:18:22 -0600
 Subject: [PATCH 004/103] arm64: dts: ti: k3-am65*: Cleanup disabled nodes at

--- a/recipes-kernel/linux/files/patches-5.10/0005-arm64-dts-ti-am65-j721e-Fix-up-un-necessary-status-s.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0005-arm64-dts-ti-am65-j721e-Fix-up-un-necessary-status-s.patch
@@ -1,7 +1,7 @@
 From 7e6d0d38dbb9ecaec40c6bd114a190c3c70db701 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Fri, 13 Nov 2020 15:18:24 -0600
-Subject: [PATCH 005/103] arm64: dts: ti: am65/j721e: Fix up un-necessary
+Subject: [PATCH 005/104] arm64: dts: ti: am65/j721e: Fix up un-necessary
  status set to "okay" for crypto
 
 The default state of a device tree node is "okay". There is no specific

--- a/recipes-kernel/linux/files/patches-5.10/0005-arm64-dts-ti-am65-j721e-Fix-up-un-necessary-status-s.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0005-arm64-dts-ti-am65-j721e-Fix-up-un-necessary-status-s.patch
@@ -1,4 +1,4 @@
-From adb8a885a99440e26388b57d4deb52713cbc2047 Mon Sep 17 00:00:00 2001
+From 7e6d0d38dbb9ecaec40c6bd114a190c3c70db701 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Fri, 13 Nov 2020 15:18:24 -0600
 Subject: [PATCH 005/103] arm64: dts: ti: am65/j721e: Fix up un-necessary

--- a/recipes-kernel/linux/files/patches-5.10/0006-arm64-dts-ti-k3-mmc-fix-dtbs_check-warnings.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0006-arm64-dts-ti-k3-mmc-fix-dtbs_check-warnings.patch
@@ -1,4 +1,4 @@
-From 87968911ca97166d2a4609742fa2487a4b5e2568 Mon Sep 17 00:00:00 2001
+From 1e9e0ce5f597a81cb06fe2c9fd6afa6e1b40f28e Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 15 Jan 2021 21:30:16 +0200
 Subject: [PATCH 006/103] arm64: dts: ti: k3: mmc: fix dtbs_check warnings

--- a/recipes-kernel/linux/files/patches-5.10/0006-arm64-dts-ti-k3-mmc-fix-dtbs_check-warnings.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0006-arm64-dts-ti-k3-mmc-fix-dtbs_check-warnings.patch
@@ -1,7 +1,7 @@
 From 1e9e0ce5f597a81cb06fe2c9fd6afa6e1b40f28e Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 15 Jan 2021 21:30:16 +0200
-Subject: [PATCH 006/103] arm64: dts: ti: k3: mmc: fix dtbs_check warnings
+Subject: [PATCH 006/104] arm64: dts: ti: k3: mmc: fix dtbs_check warnings
 
 Now the dtbs_check produces below warnings
  sdhci@4f80000: clock-names:0: 'clk_ahb' was expected

--- a/recipes-kernel/linux/files/patches-5.10/0007-arm64-dts-ti-k3-am65-main-Add-device_type-to-pcie-_r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0007-arm64-dts-ti-k3-am65-main-Add-device_type-to-pcie-_r.patch
@@ -1,7 +1,7 @@
 From df5654b83079b816f97e59f22442451783c7ee16 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Feb 2021 20:32:56 +0100
-Subject: [PATCH 007/103] arm64: dts: ti: k3-am65-main: Add device_type to
+Subject: [PATCH 007/104] arm64: dts: ti: k3-am65-main: Add device_type to
  pcie*_rc nodes
 
 This is demanded by the parent binding of ti,am654-pcie-rc, see

--- a/recipes-kernel/linux/files/patches-5.10/0007-arm64-dts-ti-k3-am65-main-Add-device_type-to-pcie-_r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0007-arm64-dts-ti-k3-am65-main-Add-device_type-to-pcie-_r.patch
@@ -1,4 +1,4 @@
-From 28b856d8212448ef662e23b3432b89315df03257 Mon Sep 17 00:00:00 2001
+From df5654b83079b816f97e59f22442451783c7ee16 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Feb 2021 20:32:56 +0100
 Subject: [PATCH 007/103] arm64: dts: ti: k3-am65-main: Add device_type to

--- a/recipes-kernel/linux/files/patches-5.10/0008-arm64-dts-ti-k3-am65-main-Add-ICSSG-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0008-arm64-dts-ti-k3-am65-main-Add-ICSSG-nodes.patch
@@ -1,7 +1,7 @@
 From 4e181216098a40fb76f7c63e0798e56d47282c22 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Thu, 4 Mar 2021 10:07:11 -0600
-Subject: [PATCH 008/103] arm64: dts: ti: k3-am65-main: Add ICSSG nodes
+Subject: [PATCH 008/104] arm64: dts: ti: k3-am65-main: Add ICSSG nodes
 
 Add the DT nodes for the ICSSG0, ICSSG1 and ICSSG2 processor subsystems
 that are present on the K3 AM65x SoCs. The three ICSSGs are identical

--- a/recipes-kernel/linux/files/patches-5.10/0008-arm64-dts-ti-k3-am65-main-Add-ICSSG-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0008-arm64-dts-ti-k3-am65-main-Add-ICSSG-nodes.patch
@@ -1,4 +1,4 @@
-From c1818495a86e51e201600807292dbb4d105c8464 Mon Sep 17 00:00:00 2001
+From 4e181216098a40fb76f7c63e0798e56d47282c22 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Thu, 4 Mar 2021 10:07:11 -0600
 Subject: [PATCH 008/103] arm64: dts: ti: k3-am65-main: Add ICSSG nodes

--- a/recipes-kernel/linux/files/patches-5.10/0009-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0009-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
@@ -1,7 +1,7 @@
 From 6826a5ba8b482fc4bb5becef8f96c1b3db910724 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 20 Feb 2021 13:49:51 +0100
-Subject: [PATCH 009/103] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
+Subject: [PATCH 009/104] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
 
 Add the DT entry for a watchdog based on RTI1.
 

--- a/recipes-kernel/linux/files/patches-5.10/0009-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0009-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
@@ -1,4 +1,4 @@
-From ddc9fca38ab9d74b9d390d610f7e15391a3b30e0 Mon Sep 17 00:00:00 2001
+From 6826a5ba8b482fc4bb5becef8f96c1b3db910724 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 20 Feb 2021 13:49:51 +0100
 Subject: [PATCH 009/103] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry

--- a/recipes-kernel/linux/files/patches-5.10/0010-arm64-dts-ti-Add-support-for-Siemens-IOT2050-boards.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0010-arm64-dts-ti-Add-support-for-Siemens-IOT2050-boards.patch
@@ -1,4 +1,4 @@
-From cc29df6d07eb8a0257563121d1d88e1d55bcaa7d Mon Sep 17 00:00:00 2001
+From 1d669c763d4615e124e9bb7dc69d2e2ceff06f1b Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Mar 2021 15:33:43 +0100
 Subject: [PATCH 010/103] arm64: dts: ti: Add support for Siemens IOT2050

--- a/recipes-kernel/linux/files/patches-5.10/0010-arm64-dts-ti-Add-support-for-Siemens-IOT2050-boards.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0010-arm64-dts-ti-Add-support-for-Siemens-IOT2050-boards.patch
@@ -1,7 +1,7 @@
 From 1d669c763d4615e124e9bb7dc69d2e2ceff06f1b Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Mar 2021 15:33:43 +0100
-Subject: [PATCH 010/103] arm64: dts: ti: Add support for Siemens IOT2050
+Subject: [PATCH 010/104] arm64: dts: ti: Add support for Siemens IOT2050
  boards
 
 Add support for two Siemens SIMATIC IOT2050 variants, Basic and

--- a/recipes-kernel/linux/files/patches-5.10/0011-arm64-dts-ti-k3-am65-j721e-am64-Map-the-dma-navigato.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0011-arm64-dts-ti-k3-am65-j721e-am64-Map-the-dma-navigato.patch
@@ -1,4 +1,4 @@
-From 7fcb7ab13a1deedaae6f31edf124e7691f3439bb Mon Sep 17 00:00:00 2001
+From 4f6a29565478e48baca234f7db41423f24b369e7 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Mon, 10 May 2021 09:54:29 -0500
 Subject: [PATCH 011/103] arm64: dts: ti: k3-am65|j721e|am64: Map the dma /

--- a/recipes-kernel/linux/files/patches-5.10/0011-arm64-dts-ti-k3-am65-j721e-am64-Map-the-dma-navigato.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0011-arm64-dts-ti-k3-am65-j721e-am64-Map-the-dma-navigato.patch
@@ -1,7 +1,7 @@
 From 4f6a29565478e48baca234f7db41423f24b369e7 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Mon, 10 May 2021 09:54:29 -0500
-Subject: [PATCH 011/103] arm64: dts: ti: k3-am65|j721e|am64: Map the dma /
+Subject: [PATCH 011/104] arm64: dts: ti: k3-am65|j721e|am64: Map the dma /
  navigator subsystem via explicit ranges
 
 Instead of using empty ranges property, lets map explicitly the address

--- a/recipes-kernel/linux/files/patches-5.10/0012-arm64-dts-ti-k3-Introduce-reg-definition-for-interru.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0012-arm64-dts-ti-k3-Introduce-reg-definition-for-interru.patch
@@ -1,7 +1,7 @@
 From 9459f7de770e30b4e1c6cb3497878980ae201dbb Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Tue, 11 May 2021 14:48:21 -0500
-Subject: [PATCH 012/103] arm64: dts: ti: k3*: Introduce reg definition for
+Subject: [PATCH 012/104] arm64: dts: ti: k3*: Introduce reg definition for
  interrupt routers
 
 Interrupt routers are memory mapped peripherals, that are organized

--- a/recipes-kernel/linux/files/patches-5.10/0012-arm64-dts-ti-k3-Introduce-reg-definition-for-interru.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0012-arm64-dts-ti-k3-Introduce-reg-definition-for-interru.patch
@@ -1,4 +1,4 @@
-From 979c2e4416e36f678d4f7a8f25d9914bba5d4536 Mon Sep 17 00:00:00 2001
+From 9459f7de770e30b4e1c6cb3497878980ae201dbb Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Tue, 11 May 2021 14:48:21 -0500
 Subject: [PATCH 012/103] arm64: dts: ti: k3*: Introduce reg definition for

--- a/recipes-kernel/linux/files/patches-5.10/0013-mmc-sdhci_am654-Use-pm_runtime_resume_and_get-to-rep.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0013-mmc-sdhci_am654-Use-pm_runtime_resume_and_get-to-rep.patch
@@ -1,7 +1,7 @@
 From 7dece4acefd346f3d91dac239f472fa677a03cc8 Mon Sep 17 00:00:00 2001
 From: Tian Tao <tiantao6@hisilicon.com>
 Date: Fri, 21 May 2021 08:59:35 +0800
-Subject: [PATCH 013/103] mmc: sdhci_am654: Use pm_runtime_resume_and_get() to
+Subject: [PATCH 013/104] mmc: sdhci_am654: Use pm_runtime_resume_and_get() to
  replace open coding
 
 use pm_runtime_resume_and_get() to replace pm_runtime_get_sync and

--- a/recipes-kernel/linux/files/patches-5.10/0013-mmc-sdhci_am654-Use-pm_runtime_resume_and_get-to-rep.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0013-mmc-sdhci_am654-Use-pm_runtime_resume_and_get-to-rep.patch
@@ -1,4 +1,4 @@
-From 836c9f69a0cc0ba733450216989592eeae6528b1 Mon Sep 17 00:00:00 2001
+From 7dece4acefd346f3d91dac239f472fa677a03cc8 Mon Sep 17 00:00:00 2001
 From: Tian Tao <tiantao6@hisilicon.com>
 Date: Fri, 21 May 2021 08:59:35 +0800
 Subject: [PATCH 013/103] mmc: sdhci_am654: Use pm_runtime_resume_and_get() to

--- a/recipes-kernel/linux/files/patches-5.10/0014-arm64-dts-ti-k3-am65-iot2050-common-Disable-mailbox-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0014-arm64-dts-ti-k3-am65-iot2050-common-Disable-mailbox-.patch
@@ -1,7 +1,7 @@
 From d9f8c6d7080aa8afa64c5a62e2f31bed8bb1cec9 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 14 May 2021 16:20:16 -0500
-Subject: [PATCH 014/103] arm64: dts: ti: k3-am65-iot2050-common: Disable
+Subject: [PATCH 014/104] arm64: dts: ti: k3-am65-iot2050-common: Disable
  mailbox nodes
 
 There are no sub-mailbox devices defined currently for both the

--- a/recipes-kernel/linux/files/patches-5.10/0014-arm64-dts-ti-k3-am65-iot2050-common-Disable-mailbox-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0014-arm64-dts-ti-k3-am65-iot2050-common-Disable-mailbox-.patch
@@ -1,4 +1,4 @@
-From bfb1156b6302aa71c2e47ef73386679f30a2c631 Mon Sep 17 00:00:00 2001
+From d9f8c6d7080aa8afa64c5a62e2f31bed8bb1cec9 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 14 May 2021 16:20:16 -0500
 Subject: [PATCH 014/103] arm64: dts: ti: k3-am65-iot2050-common: Disable

--- a/recipes-kernel/linux/files/patches-5.10/0015-arm64-dts-ti-k3-am65-Add-support-for-UHS-I-modes-in-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0015-arm64-dts-ti-k3-am65-Add-support-for-UHS-I-modes-in-.patch
@@ -1,7 +1,7 @@
 From 439502cf5032deed64467ae37e47ff9ecc9bee25 Mon Sep 17 00:00:00 2001
 From: Aswath Govindraju <a-govindraju@ti.com>
 Date: Sat, 29 May 2021 09:07:49 +0530
-Subject: [PATCH 015/103] arm64: dts: ti: k3-am65: Add support for UHS-I modes
+Subject: [PATCH 015/104] arm64: dts: ti: k3-am65: Add support for UHS-I modes
  in MMCSD1 subsystem
 
 UHS-I speed modes are supported in AM65 S.R. 2.0 SoC[1].

--- a/recipes-kernel/linux/files/patches-5.10/0015-arm64-dts-ti-k3-am65-Add-support-for-UHS-I-modes-in-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0015-arm64-dts-ti-k3-am65-Add-support-for-UHS-I-modes-in-.patch
@@ -1,4 +1,4 @@
-From 79acce813c32695bbe058f3461471287436c5264 Mon Sep 17 00:00:00 2001
+From 439502cf5032deed64467ae37e47ff9ecc9bee25 Mon Sep 17 00:00:00 2001
 From: Aswath Govindraju <a-govindraju@ti.com>
 Date: Sat, 29 May 2021 09:07:49 +0530
 Subject: [PATCH 015/103] arm64: dts: ti: k3-am65: Add support for UHS-I modes

--- a/recipes-kernel/linux/files/patches-5.10/0016-arm64-dts-ti-k3-am65-main-Add-ICSSG-MDIO-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0016-arm64-dts-ti-k3-am65-main-Add-ICSSG-MDIO-nodes.patch
@@ -1,4 +1,4 @@
-From e1455d06345936e5a436f12c137ca80a963f94de Mon Sep 17 00:00:00 2001
+From 868dc7de7c92cb29d6302760fa77c73bf16e6248 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 1 Jun 2021 10:00:31 -0500
 Subject: [PATCH 016/103] arm64: dts: ti: k3-am65-main: Add ICSSG MDIO nodes

--- a/recipes-kernel/linux/files/patches-5.10/0016-arm64-dts-ti-k3-am65-main-Add-ICSSG-MDIO-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0016-arm64-dts-ti-k3-am65-main-Add-ICSSG-MDIO-nodes.patch
@@ -1,7 +1,7 @@
 From 868dc7de7c92cb29d6302760fa77c73bf16e6248 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 1 Jun 2021 10:00:31 -0500
-Subject: [PATCH 016/103] arm64: dts: ti: k3-am65-main: Add ICSSG MDIO nodes
+Subject: [PATCH 016/104] arm64: dts: ti: k3-am65-main: Add ICSSG MDIO nodes
 
 The ICSSGs on K3 AM65x SoCs contain an MDIO controller that can
 be used to control external PHYs associated with the Industrial

--- a/recipes-kernel/linux/files/patches-5.10/0017-arm64-dts-ti-iot2050-Configure-r5f-cluster-on-basic-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0017-arm64-dts-ti-iot2050-Configure-r5f-cluster-on-basic-.patch
@@ -1,4 +1,4 @@
-From 841a04398bc75c8dd7a83bd15972b2fbcb33539c Mon Sep 17 00:00:00 2001
+From d73a5ea673496131b8478859308e9f12d4c438e5 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 2 Jun 2021 08:56:15 +0200
 Subject: [PATCH 017/103] arm64: dts: ti: iot2050: Configure r5f cluster on

--- a/recipes-kernel/linux/files/patches-5.10/0017-arm64-dts-ti-iot2050-Configure-r5f-cluster-on-basic-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0017-arm64-dts-ti-iot2050-Configure-r5f-cluster-on-basic-.patch
@@ -1,7 +1,7 @@
 From d73a5ea673496131b8478859308e9f12d4c438e5 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 2 Jun 2021 08:56:15 +0200
-Subject: [PATCH 017/103] arm64: dts: ti: iot2050: Configure r5f cluster on
+Subject: [PATCH 017/104] arm64: dts: ti: iot2050: Configure r5f cluster on
  basic variant in split mode
 
 Lockstep mode is not supported here. So turn it off to avoid warnings

--- a/recipes-kernel/linux/files/patches-5.10/0018-arm64-dts-ti-am65-align-ti-pindir-d0-out-d1-in-prope.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0018-arm64-dts-ti-am65-align-ti-pindir-d0-out-d1-in-prope.patch
@@ -1,4 +1,4 @@
-From 73fd4a21d9e767f1487abb244bfad3c8760839c9 Mon Sep 17 00:00:00 2001
+From 78d7a8954f39ac89d7a86fb379286878cc09cfa6 Mon Sep 17 00:00:00 2001
 From: Aswath Govindraju <a-govindraju@ti.com>
 Date: Tue, 8 Jun 2021 10:44:13 +0530
 Subject: [PATCH 018/103] arm64: dts: ti: am65: align ti,pindir-d0-out-d1-in

--- a/recipes-kernel/linux/files/patches-5.10/0018-arm64-dts-ti-am65-align-ti-pindir-d0-out-d1-in-prope.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0018-arm64-dts-ti-am65-align-ti-pindir-d0-out-d1-in-prope.patch
@@ -1,7 +1,7 @@
 From 78d7a8954f39ac89d7a86fb379286878cc09cfa6 Mon Sep 17 00:00:00 2001
 From: Aswath Govindraju <a-govindraju@ti.com>
 Date: Tue, 8 Jun 2021 10:44:13 +0530
-Subject: [PATCH 018/103] arm64: dts: ti: am65: align ti,pindir-d0-out-d1-in
+Subject: [PATCH 018/104] arm64: dts: ti: am65: align ti,pindir-d0-out-d1-in
  property with dt-shema
 
 ti,pindir-d0-out-d1-in property is expected to be of type boolean.

--- a/recipes-kernel/linux/files/patches-5.10/0019-firmware-ti_sci-rm-Add-support-for-tx_tdtype-paramet.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0019-firmware-ti_sci-rm-Add-support-for-tx_tdtype-paramet.patch
@@ -1,7 +1,7 @@
 From 201581a7c6ca8d91135a3b594ae3c903d4e205f6 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:02 -0700
-Subject: [PATCH 019/103] firmware: ti_sci: rm: Add support for tx_tdtype
+Subject: [PATCH 019/104] firmware: ti_sci: rm: Add support for tx_tdtype
  parameter for tx channel
 
 The system controller's resource manager have support for configuring the

--- a/recipes-kernel/linux/files/patches-5.10/0019-firmware-ti_sci-rm-Add-support-for-tx_tdtype-paramet.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0019-firmware-ti_sci-rm-Add-support-for-tx_tdtype-paramet.patch
@@ -1,4 +1,4 @@
-From 8b9ac996e25b620bc9e977e9547a4f0413812151 Mon Sep 17 00:00:00 2001
+From 201581a7c6ca8d91135a3b594ae3c903d4e205f6 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:02 -0700
 Subject: [PATCH 019/103] firmware: ti_sci: rm: Add support for tx_tdtype

--- a/recipes-kernel/linux/files/patches-5.10/0020-firmware-ti_sci-Use-struct-ti_sci_resource_desc-in-g.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0020-firmware-ti_sci-Use-struct-ti_sci_resource_desc-in-g.patch
@@ -1,4 +1,4 @@
-From 7b0b2ba05dd0df27d77f7903c6ffca87e46f335b Mon Sep 17 00:00:00 2001
+From a964810f23910b5c1c0a85ee7ea6f1ade83d05ba Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:03 -0700
 Subject: [PATCH 020/103] firmware: ti_sci: Use struct ti_sci_resource_desc in

--- a/recipes-kernel/linux/files/patches-5.10/0020-firmware-ti_sci-Use-struct-ti_sci_resource_desc-in-g.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0020-firmware-ti_sci-Use-struct-ti_sci_resource_desc-in-g.patch
@@ -1,7 +1,7 @@
 From a964810f23910b5c1c0a85ee7ea6f1ade83d05ba Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:03 -0700
-Subject: [PATCH 020/103] firmware: ti_sci: Use struct ti_sci_resource_desc in
+Subject: [PATCH 020/104] firmware: ti_sci: Use struct ti_sci_resource_desc in
  get_range ops
 
 Use the ti_sci_resource_desc directly and update it's start and num members

--- a/recipes-kernel/linux/files/patches-5.10/0021-firmware-ti_sci-rm-Add-support-for-second-resource-r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0021-firmware-ti_sci-rm-Add-support-for-second-resource-r.patch
@@ -1,7 +1,7 @@
 From 77148768c1ca36782540b068bdfb8e7b7632fcc7 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:03 -0700
-Subject: [PATCH 021/103] firmware: ti_sci: rm: Add support for second resource
+Subject: [PATCH 021/104] firmware: ti_sci: rm: Add support for second resource
  range
 
 Sysfw added support for a second range in the resource range API to be able

--- a/recipes-kernel/linux/files/patches-5.10/0021-firmware-ti_sci-rm-Add-support-for-second-resource-r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0021-firmware-ti_sci-rm-Add-support-for-second-resource-r.patch
@@ -1,4 +1,4 @@
-From db047b314d1ada639f2da1c0a5c5d8f9a9e75ffe Mon Sep 17 00:00:00 2001
+From 77148768c1ca36782540b068bdfb8e7b7632fcc7 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:03 -0700
 Subject: [PATCH 021/103] firmware: ti_sci: rm: Add support for second resource

--- a/recipes-kernel/linux/files/patches-5.10/0022-soc-ti-ti_sci_inta_msi-Add-support-for-second-range-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0022-soc-ti-ti_sci_inta_msi-Add-support-for-second-range-.patch
@@ -1,7 +1,7 @@
 From 3ad8a348de3d87f0a47ad87b6088a922bd4d02d3 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:04 -0700
-Subject: [PATCH 022/103] soc: ti: ti_sci_inta_msi: Add support for second
+Subject: [PATCH 022/104] soc: ti: ti_sci_inta_msi: Add support for second
  range in resource ranges
 
 Allocate MSI entries for both first and second range if they are valid

--- a/recipes-kernel/linux/files/patches-5.10/0022-soc-ti-ti_sci_inta_msi-Add-support-for-second-range-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0022-soc-ti-ti_sci_inta_msi-Add-support-for-second-range-.patch
@@ -1,4 +1,4 @@
-From 7be82ebd6424dff4cc6395350ec92a797634dfcc Mon Sep 17 00:00:00 2001
+From 3ad8a348de3d87f0a47ad87b6088a922bd4d02d3 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:04 -0700
 Subject: [PATCH 022/103] soc: ti: ti_sci_inta_msi: Add support for second

--- a/recipes-kernel/linux/files/patches-5.10/0023-firmware-ti_sci-rm-Add-support-for-extended_ch_type-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0023-firmware-ti_sci-rm-Add-support-for-extended_ch_type-.patch
@@ -1,4 +1,4 @@
-From 6f82544a26c26c5c50197ff136cd6bd75271bde8 Mon Sep 17 00:00:00 2001
+From 9f3de90dc04ed00b3185b4c9c3a476968329f350 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:05 -0700
 Subject: [PATCH 023/103] firmware: ti_sci: rm: Add support for

--- a/recipes-kernel/linux/files/patches-5.10/0023-firmware-ti_sci-rm-Add-support-for-extended_ch_type-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0023-firmware-ti_sci-rm-Add-support-for-extended_ch_type-.patch
@@ -1,7 +1,7 @@
 From 9f3de90dc04ed00b3185b4c9c3a476968329f350 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:05 -0700
-Subject: [PATCH 023/103] firmware: ti_sci: rm: Add support for
+Subject: [PATCH 023/104] firmware: ti_sci: rm: Add support for
  extended_ch_type for tx channel
 
 Sysfw added 'extended_ch_type' to the tx_ch_cfg_req message which should be

--- a/recipes-kernel/linux/files/patches-5.10/0024-firmware-ti_sci-rm-Remove-ring_get_config-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0024-firmware-ti_sci-rm-Remove-ring_get_config-support.patch
@@ -1,4 +1,4 @@
-From 0dcebe77d001e2f013f6278a6aa52737b9a1fadc Mon Sep 17 00:00:00 2001
+From 3a14e51fc33f0a5cdde74486ca6785b53c44e56b Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:05 -0700
 Subject: [PATCH 024/103] firmware: ti_sci: rm: Remove ring_get_config support

--- a/recipes-kernel/linux/files/patches-5.10/0024-firmware-ti_sci-rm-Remove-ring_get_config-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0024-firmware-ti_sci-rm-Remove-ring_get_config-support.patch
@@ -1,7 +1,7 @@
 From 3a14e51fc33f0a5cdde74486ca6785b53c44e56b Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:05 -0700
-Subject: [PATCH 024/103] firmware: ti_sci: rm: Remove ring_get_config support
+Subject: [PATCH 024/104] firmware: ti_sci: rm: Remove ring_get_config support
 
 The ring_get_cfg (0x1111 message) is not used and it is not supported by
 sysfw for a long time.

--- a/recipes-kernel/linux/files/patches-5.10/0025-firmware-ti_sci-rm-Add-new-ops-for-ring-configuratio.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0025-firmware-ti_sci-rm-Add-new-ops-for-ring-configuratio.patch
@@ -1,4 +1,4 @@
-From 468c4e09e47eded6cbf8492d4abe8dc2f354ee6b Mon Sep 17 00:00:00 2001
+From c59c747aea59df711bf35a368ccecb8ed6970792 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:06 -0700
 Subject: [PATCH 025/103] firmware: ti_sci: rm: Add new ops for ring

--- a/recipes-kernel/linux/files/patches-5.10/0025-firmware-ti_sci-rm-Add-new-ops-for-ring-configuratio.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0025-firmware-ti_sci-rm-Add-new-ops-for-ring-configuratio.patch
@@ -1,7 +1,7 @@
 From c59c747aea59df711bf35a368ccecb8ed6970792 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:06 -0700
-Subject: [PATCH 025/103] firmware: ti_sci: rm: Add new ops for ring
+Subject: [PATCH 025/104] firmware: ti_sci: rm: Add new ops for ring
  configuration
 
 The sysfw ring configuration message has been extended to include virtid

--- a/recipes-kernel/linux/files/patches-5.10/0026-soc-ti-k3-ringacc-Use-the-ti_sci-set_cfg-callback-fo.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0026-soc-ti-k3-ringacc-Use-the-ti_sci-set_cfg-callback-fo.patch
@@ -1,7 +1,7 @@
 From e67f7ab42c598740da245f461cb44e63ad743440 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:07 -0700
-Subject: [PATCH 026/103] soc: ti: k3-ringacc: Use the ti_sci set_cfg callback
+Subject: [PATCH 026/104] soc: ti: k3-ringacc: Use the ti_sci set_cfg callback
  for ring configuration
 
 Switch to the new set_cfg to configure the ring.

--- a/recipes-kernel/linux/files/patches-5.10/0026-soc-ti-k3-ringacc-Use-the-ti_sci-set_cfg-callback-fo.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0026-soc-ti-k3-ringacc-Use-the-ti_sci-set_cfg-callback-fo.patch
@@ -1,4 +1,4 @@
-From cd1713cb27ec8e39a83cf5c88298c38c99901276 Mon Sep 17 00:00:00 2001
+From e67f7ab42c598740da245f461cb44e63ad743440 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:07 -0700
 Subject: [PATCH 026/103] soc: ti: k3-ringacc: Use the ti_sci set_cfg callback

--- a/recipes-kernel/linux/files/patches-5.10/0027-firmware-ti_sci-rm-Remove-unused-config-from-ti_sci_.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0027-firmware-ti_sci-rm-Remove-unused-config-from-ti_sci_.patch
@@ -1,7 +1,7 @@
 From b52a49d481aedcfee6a30b772b39038fd9c83a12 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:07 -0700
-Subject: [PATCH 027/103] firmware: ti_sci: rm: Remove unused config() from
+Subject: [PATCH 027/104] firmware: ti_sci: rm: Remove unused config() from
  ti_sci_rm_ringacc_ops
 
 The ringacc driver has been converted to use the new set_cfg function to

--- a/recipes-kernel/linux/files/patches-5.10/0027-firmware-ti_sci-rm-Remove-unused-config-from-ti_sci_.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0027-firmware-ti_sci-rm-Remove-unused-config-from-ti_sci_.patch
@@ -1,4 +1,4 @@
-From a3e2986dacaa21ff7c171c4d1c3cd26635b64a36 Mon Sep 17 00:00:00 2001
+From b52a49d481aedcfee6a30b772b39038fd9c83a12 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:07 -0700
 Subject: [PATCH 027/103] firmware: ti_sci: rm: Remove unused config() from

--- a/recipes-kernel/linux/files/patches-5.10/0028-soc-ti-k3-ringacc-Use-correct-device-for-allocation-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0028-soc-ti-k3-ringacc-Use-correct-device-for-allocation-.patch
@@ -1,4 +1,4 @@
-From c92a34f1fe4f3d696001ef5ccc9910071e7c276e Mon Sep 17 00:00:00 2001
+From 0178e1728745fc4a911b02c347eef9692ee84013 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:22 -0700
 Subject: [PATCH 028/103] soc: ti: k3-ringacc: Use correct device for

--- a/recipes-kernel/linux/files/patches-5.10/0028-soc-ti-k3-ringacc-Use-correct-device-for-allocation-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0028-soc-ti-k3-ringacc-Use-correct-device-for-allocation-.patch
@@ -1,7 +1,7 @@
 From 0178e1728745fc4a911b02c347eef9692ee84013 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:22 -0700
-Subject: [PATCH 028/103] soc: ti: k3-ringacc: Use correct device for
+Subject: [PATCH 028/104] soc: ti: k3-ringacc: Use correct device for
  allocation in RING mode
 
 In RING mode the ringacc does not access the ring memory. In this access

--- a/recipes-kernel/linux/files/patches-5.10/0029-soc-ti-pruss-Remove-wrong-check-against-get_match_da.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0029-soc-ti-pruss-Remove-wrong-check-against-get_match_da.patch
@@ -1,7 +1,7 @@
 From 3c43cf32b8651a36ee609e9e8d38c3cf93ed94c1 Mon Sep 17 00:00:00 2001
 From: Grzegorz Jaszczyk <grzegorz.jaszczyk@linaro.org>
 Date: Sat, 21 Nov 2020 19:22:25 -0800
-Subject: [PATCH 029/103] soc: ti: pruss: Remove wrong check against
+Subject: [PATCH 029/104] soc: ti: pruss: Remove wrong check against
  *get_match_data return value
 
 Since the of_device_get_match_data() doesn't return error code, remove

--- a/recipes-kernel/linux/files/patches-5.10/0029-soc-ti-pruss-Remove-wrong-check-against-get_match_da.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0029-soc-ti-pruss-Remove-wrong-check-against-get_match_da.patch
@@ -1,4 +1,4 @@
-From 5885d12a1d62fb5e713f52480e22c38ceaa10d49 Mon Sep 17 00:00:00 2001
+From 3c43cf32b8651a36ee609e9e8d38c3cf93ed94c1 Mon Sep 17 00:00:00 2001
 From: Grzegorz Jaszczyk <grzegorz.jaszczyk@linaro.org>
 Date: Sat, 21 Nov 2020 19:22:25 -0800
 Subject: [PATCH 029/103] soc: ti: pruss: Remove wrong check against

--- a/recipes-kernel/linux/files/patches-5.10/0030-soc-ti-pruss-Correct-the-pruss_clk_init-error-trace-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0030-soc-ti-pruss-Correct-the-pruss_clk_init-error-trace-.patch
@@ -1,4 +1,4 @@
-From 4515bf2aad2e263f0b5265d65b73a488ec38bd56 Mon Sep 17 00:00:00 2001
+From 09f68ee7d4a5be640db99ed9c56baa9cff032e98 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 24 Jan 2021 20:51:37 -0800
 Subject: [PATCH 030/103] soc: ti: pruss: Correct the pruss_clk_init error

--- a/recipes-kernel/linux/files/patches-5.10/0030-soc-ti-pruss-Correct-the-pruss_clk_init-error-trace-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0030-soc-ti-pruss-Correct-the-pruss_clk_init-error-trace-.patch
@@ -1,7 +1,7 @@
 From 09f68ee7d4a5be640db99ed9c56baa9cff032e98 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 24 Jan 2021 20:51:37 -0800
-Subject: [PATCH 030/103] soc: ti: pruss: Correct the pruss_clk_init error
+Subject: [PATCH 030/104] soc: ti: pruss: Correct the pruss_clk_init error
  trace text
 
 The pruss_clk_init() function can register more than one clock.

--- a/recipes-kernel/linux/files/patches-5.10/0031-soc-ti-pruss-Refactor-the-CFG-sub-module-init.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0031-soc-ti-pruss-Refactor-the-CFG-sub-module-init.patch
@@ -1,4 +1,4 @@
-From 7cb7ed5769eb25c6da24ecede9d710a047f1045a Mon Sep 17 00:00:00 2001
+From 408da169fd05954f67422b69c182c59543570327 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 31 Jan 2021 20:53:43 -0800
 Subject: [PATCH 031/103] soc: ti: pruss: Refactor the CFG sub-module init

--- a/recipes-kernel/linux/files/patches-5.10/0031-soc-ti-pruss-Refactor-the-CFG-sub-module-init.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0031-soc-ti-pruss-Refactor-the-CFG-sub-module-init.patch
@@ -1,7 +1,7 @@
 From 408da169fd05954f67422b69c182c59543570327 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 31 Jan 2021 20:53:43 -0800
-Subject: [PATCH 031/103] soc: ti: pruss: Refactor the CFG sub-module init
+Subject: [PATCH 031/104] soc: ti: pruss: Refactor the CFG sub-module init
 
 The CFG sub-module is not present on some earlier SoCs like the
 DA850/OMAPL-138 in the TI Davinci family. Refactor out the CFG

--- a/recipes-kernel/linux/files/patches-5.10/0032-soc-ti-k3-ringacc-Use-of_device_get_match_data.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0032-soc-ti-k3-ringacc-Use-of_device_get_match_data.patch
@@ -1,7 +1,7 @@
 From e75c57ddd0d2dca8a719d1c7de1664692cceccb4 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 31 Jan 2021 20:58:49 -0800
-Subject: [PATCH 032/103] soc: ti: k3-ringacc: Use of_device_get_match_data()
+Subject: [PATCH 032/104] soc: ti: k3-ringacc: Use of_device_get_match_data()
 
 Simplify the retrieval of getting the match data in the probe
 function by directly using of_device_get_match_data() instead

--- a/recipes-kernel/linux/files/patches-5.10/0032-soc-ti-k3-ringacc-Use-of_device_get_match_data.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0032-soc-ti-k3-ringacc-Use-of_device_get_match_data.patch
@@ -1,4 +1,4 @@
-From 0a7f3ada3c0cbdf7dc6c7c119c4c69ab6776550a Mon Sep 17 00:00:00 2001
+From e75c57ddd0d2dca8a719d1c7de1664692cceccb4 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 31 Jan 2021 20:58:49 -0800
 Subject: [PATCH 032/103] soc: ti: k3-ringacc: Use of_device_get_match_data()

--- a/recipes-kernel/linux/files/patches-5.10/0033-remoteproc-ti_k3-fix-Wcast-function-type-warning.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0033-remoteproc-ti_k3-fix-Wcast-function-type-warning.patch
@@ -1,4 +1,4 @@
-From 43a124175d910c2d9a9a4b271319ae064591cf26 Mon Sep 17 00:00:00 2001
+From 780cbbda3b4d6844474068cc0b9b96b574944829 Mon Sep 17 00:00:00 2001
 From: Arnd Bergmann <arnd@arndb.de>
 Date: Mon, 26 Oct 2020 17:05:23 +0100
 Subject: [PATCH 033/103] remoteproc: ti_k3: fix -Wcast-function-type warning

--- a/recipes-kernel/linux/files/patches-5.10/0033-remoteproc-ti_k3-fix-Wcast-function-type-warning.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0033-remoteproc-ti_k3-fix-Wcast-function-type-warning.patch
@@ -1,7 +1,7 @@
 From 780cbbda3b4d6844474068cc0b9b96b574944829 Mon Sep 17 00:00:00 2001
 From: Arnd Bergmann <arnd@arndb.de>
 Date: Mon, 26 Oct 2020 17:05:23 +0100
-Subject: [PATCH 033/103] remoteproc: ti_k3: fix -Wcast-function-type warning
+Subject: [PATCH 033/104] remoteproc: ti_k3: fix -Wcast-function-type warning
 
 The function cast causes a warning with "make W=1"
 

--- a/recipes-kernel/linux/files/patches-5.10/0034-remoteproc-Add-a-rproc_set_firmware-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0034-remoteproc-Add-a-rproc_set_firmware-API.patch
@@ -1,7 +1,7 @@
 From 45c511cd51003520e278a4d9ef58f4eec6873cdf Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 20 Nov 2020 21:20:42 -0600
-Subject: [PATCH 034/103] remoteproc: Add a rproc_set_firmware() API
+Subject: [PATCH 034/104] remoteproc: Add a rproc_set_firmware() API
 
 A new API, rproc_set_firmware() is added to allow the remoteproc platform
 drivers and remoteproc client drivers to be able to configure a custom

--- a/recipes-kernel/linux/files/patches-5.10/0034-remoteproc-Add-a-rproc_set_firmware-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0034-remoteproc-Add-a-rproc_set_firmware-API.patch
@@ -1,4 +1,4 @@
-From f32b92f216b7202456d069ae3d269831fab09a9d Mon Sep 17 00:00:00 2001
+From 45c511cd51003520e278a4d9ef58f4eec6873cdf Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 20 Nov 2020 21:20:42 -0600
 Subject: [PATCH 034/103] remoteproc: Add a rproc_set_firmware() API

--- a/recipes-kernel/linux/files/patches-5.10/0035-remoteproc-pru-Add-a-PRU-remoteproc-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0035-remoteproc-pru-Add-a-PRU-remoteproc-driver.patch
@@ -1,7 +1,7 @@
 From f8f8c77fc640e76591c659ed34ce024c70f940c8 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:09:58 +0100
-Subject: [PATCH 035/103] remoteproc: pru: Add a PRU remoteproc driver
+Subject: [PATCH 035/104] remoteproc: pru: Add a PRU remoteproc driver
 
 The Programmable Real-Time Unit Subsystem (PRUSS) consists of
 dual 32-bit RISC cores (Programmable Real-Time Units, or PRUs)

--- a/recipes-kernel/linux/files/patches-5.10/0035-remoteproc-pru-Add-a-PRU-remoteproc-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0035-remoteproc-pru-Add-a-PRU-remoteproc-driver.patch
@@ -1,4 +1,4 @@
-From 07db0c3a32cf5fd91735a50a0c93477fbd8a7c56 Mon Sep 17 00:00:00 2001
+From f8f8c77fc640e76591c659ed34ce024c70f940c8 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:09:58 +0100
 Subject: [PATCH 035/103] remoteproc: pru: Add a PRU remoteproc driver

--- a/recipes-kernel/linux/files/patches-5.10/0036-remoteproc-pru-Add-support-for-PRU-specific-interrup.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0036-remoteproc-pru-Add-support-for-PRU-specific-interrup.patch
@@ -1,7 +1,7 @@
 From 689e7258ae463d74c1d0d11818407e0f3993cd8f Mon Sep 17 00:00:00 2001
 From: Grzegorz Jaszczyk <grzegorz.jaszczyk@linaro.org>
 Date: Tue, 8 Dec 2020 15:09:59 +0100
-Subject: [PATCH 036/103] remoteproc: pru: Add support for PRU specific
+Subject: [PATCH 036/104] remoteproc: pru: Add support for PRU specific
  interrupt configuration
 
 The firmware blob can contain optional ELF sections: .resource_table

--- a/recipes-kernel/linux/files/patches-5.10/0036-remoteproc-pru-Add-support-for-PRU-specific-interrup.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0036-remoteproc-pru-Add-support-for-PRU-specific-interrup.patch
@@ -1,4 +1,4 @@
-From 5679467ecb3808f4f604cb368f52698443e8bd0a Mon Sep 17 00:00:00 2001
+From 689e7258ae463d74c1d0d11818407e0f3993cd8f Mon Sep 17 00:00:00 2001
 From: Grzegorz Jaszczyk <grzegorz.jaszczyk@linaro.org>
 Date: Tue, 8 Dec 2020 15:09:59 +0100
 Subject: [PATCH 036/103] remoteproc: pru: Add support for PRU specific

--- a/recipes-kernel/linux/files/patches-5.10/0037-remoteproc-pru-Add-pru-specific-debugfs-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0037-remoteproc-pru-Add-pru-specific-debugfs-support.patch
@@ -1,4 +1,4 @@
-From 682d53b6dc6cda4f40104bcf46ed6afaa9d4ff11 Mon Sep 17 00:00:00 2001
+From 3d9f8312393731a7cc7fee70364e98a29ef4399f Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:10:00 +0100
 Subject: [PATCH 037/103] remoteproc: pru: Add pru-specific debugfs support

--- a/recipes-kernel/linux/files/patches-5.10/0037-remoteproc-pru-Add-pru-specific-debugfs-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0037-remoteproc-pru-Add-pru-specific-debugfs-support.patch
@@ -1,7 +1,7 @@
 From 3d9f8312393731a7cc7fee70364e98a29ef4399f Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:10:00 +0100
-Subject: [PATCH 037/103] remoteproc: pru: Add pru-specific debugfs support
+Subject: [PATCH 037/104] remoteproc: pru: Add pru-specific debugfs support
 
 The remoteproc core creates certain standard debugfs entries,
 that does not give a whole lot of useful information for the

--- a/recipes-kernel/linux/files/patches-5.10/0038-remoteproc-pru-Add-support-for-various-PRU-cores-on-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0038-remoteproc-pru-Add-support-for-various-PRU-cores-on-.patch
@@ -1,7 +1,7 @@
 From 3dd1224abd96d69a312a3fd5b87523570296fdb0 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:10:01 +0100
-Subject: [PATCH 038/103] remoteproc: pru: Add support for various PRU cores on
+Subject: [PATCH 038/104] remoteproc: pru: Add support for various PRU cores on
  K3 AM65x SoCs
 
 The K3 AM65x family of SoCs have the next generation of the PRU-ICSS

--- a/recipes-kernel/linux/files/patches-5.10/0038-remoteproc-pru-Add-support-for-various-PRU-cores-on-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0038-remoteproc-pru-Add-support-for-various-PRU-cores-on-.patch
@@ -1,4 +1,4 @@
-From dd98dfef09d220ed3a56c9c6afe8d22ae63c8f68 Mon Sep 17 00:00:00 2001
+From 3dd1224abd96d69a312a3fd5b87523570296fdb0 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:10:01 +0100
 Subject: [PATCH 038/103] remoteproc: pru: Add support for various PRU cores on

--- a/recipes-kernel/linux/files/patches-5.10/0039-remoteproc-pru-Fix-loading-of-GNU-Binutils-ELF.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0039-remoteproc-pru-Fix-loading-of-GNU-Binutils-ELF.patch
@@ -1,4 +1,4 @@
-From 5ebb678fae540c469649d6325b1a0ab03cf005cb Mon Sep 17 00:00:00 2001
+From 74f1f0137b0dc47119f03920083b24b6d07c9cc9 Mon Sep 17 00:00:00 2001
 From: Dimitar Dimitrov <dimitar@dinux.eu>
 Date: Wed, 30 Dec 2020 12:50:05 +0200
 Subject: [PATCH 039/103] remoteproc: pru: Fix loading of GNU Binutils ELF

--- a/recipes-kernel/linux/files/patches-5.10/0039-remoteproc-pru-Fix-loading-of-GNU-Binutils-ELF.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0039-remoteproc-pru-Fix-loading-of-GNU-Binutils-ELF.patch
@@ -1,7 +1,7 @@
 From 74f1f0137b0dc47119f03920083b24b6d07c9cc9 Mon Sep 17 00:00:00 2001
 From: Dimitar Dimitrov <dimitar@dinux.eu>
 Date: Wed, 30 Dec 2020 12:50:05 +0200
-Subject: [PATCH 039/103] remoteproc: pru: Fix loading of GNU Binutils ELF
+Subject: [PATCH 039/104] remoteproc: pru: Fix loading of GNU Binutils ELF
 
 PRU port of GNU Binutils lacks support for separate address spaces.
 PRU IRAM addresses are marked with artificial offset to differentiate

--- a/recipes-kernel/linux/files/patches-5.10/0040-remoteproc-pru-Fix-firmware-loading-crashes-on-K3-So.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0040-remoteproc-pru-Fix-firmware-loading-crashes-on-K3-So.patch
@@ -1,4 +1,4 @@
-From e4205f3bbc2ae7d5cbf34520cef694c10e21479a Mon Sep 17 00:00:00 2001
+From 2fdf087d6ea8bdf0d79f1f028c88aff534a7682f Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Mon, 15 Mar 2021 15:58:59 -0500
 Subject: [PATCH 040/103] remoteproc: pru: Fix firmware loading crashes on K3

--- a/recipes-kernel/linux/files/patches-5.10/0040-remoteproc-pru-Fix-firmware-loading-crashes-on-K3-So.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0040-remoteproc-pru-Fix-firmware-loading-crashes-on-K3-So.patch
@@ -1,7 +1,7 @@
 From 2fdf087d6ea8bdf0d79f1f028c88aff534a7682f Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Mon, 15 Mar 2021 15:58:59 -0500
-Subject: [PATCH 040/103] remoteproc: pru: Fix firmware loading crashes on K3
+Subject: [PATCH 040/104] remoteproc: pru: Fix firmware loading crashes on K3
  SoCs
 
 The K3 PRUs are 32-bit processors and in general have some limitations

--- a/recipes-kernel/linux/files/patches-5.10/0041-remoteproc-pru-Fixup-interrupt-parent-logic-for-fw-e.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0041-remoteproc-pru-Fixup-interrupt-parent-logic-for-fw-e.patch
@@ -1,7 +1,7 @@
 From 73cf263b9f828611c8a9bb8cc4146e5b5e1f53fd Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:39 -0500
-Subject: [PATCH 041/103] remoteproc: pru: Fixup interrupt-parent logic for fw
+Subject: [PATCH 041/104] remoteproc: pru: Fixup interrupt-parent logic for fw
  events
 
 The PRU firmware interrupt mapping logic in pru_handle_intrmap() uses

--- a/recipes-kernel/linux/files/patches-5.10/0041-remoteproc-pru-Fixup-interrupt-parent-logic-for-fw-e.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0041-remoteproc-pru-Fixup-interrupt-parent-logic-for-fw-e.patch
@@ -1,4 +1,4 @@
-From 9b9fc0a495d2b5d67b0ef4a043a08e8a3e264227 Mon Sep 17 00:00:00 2001
+From 73cf263b9f828611c8a9bb8cc4146e5b5e1f53fd Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:39 -0500
 Subject: [PATCH 041/103] remoteproc: pru: Fixup interrupt-parent logic for fw

--- a/recipes-kernel/linux/files/patches-5.10/0042-remoteproc-pru-Fix-wrong-success-return-value-for-fw.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0042-remoteproc-pru-Fix-wrong-success-return-value-for-fw.patch
@@ -1,7 +1,7 @@
 From f8decd3cc37f9b4058336e905537ef13d26a778e Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:40 -0500
-Subject: [PATCH 042/103] remoteproc: pru: Fix wrong success return value for
+Subject: [PATCH 042/104] remoteproc: pru: Fix wrong success return value for
  fw events
 
 The irq_create_fwspec_mapping() returns a proper virq value on success

--- a/recipes-kernel/linux/files/patches-5.10/0042-remoteproc-pru-Fix-wrong-success-return-value-for-fw.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0042-remoteproc-pru-Fix-wrong-success-return-value-for-fw.patch
@@ -1,4 +1,4 @@
-From 12ade80e407396eb07dd37156615979e2a151457 Mon Sep 17 00:00:00 2001
+From f8decd3cc37f9b4058336e905537ef13d26a778e Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:40 -0500
 Subject: [PATCH 042/103] remoteproc: pru: Fix wrong success return value for

--- a/recipes-kernel/linux/files/patches-5.10/0043-remoteproc-pru-Fix-and-cleanup-firmware-interrupt-ma.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0043-remoteproc-pru-Fix-and-cleanup-firmware-interrupt-ma.patch
@@ -1,4 +1,4 @@
-From 7df01c788ecfaa549307c93740f64d9779d24ceb Mon Sep 17 00:00:00 2001
+From 24dffa08a60dd035ca7ebc84c2ff1f24ea1c02ba Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:41 -0500
 Subject: [PATCH 043/103] remoteproc: pru: Fix and cleanup firmware interrupt

--- a/recipes-kernel/linux/files/patches-5.10/0043-remoteproc-pru-Fix-and-cleanup-firmware-interrupt-ma.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0043-remoteproc-pru-Fix-and-cleanup-firmware-interrupt-ma.patch
@@ -1,7 +1,7 @@
 From 24dffa08a60dd035ca7ebc84c2ff1f24ea1c02ba Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:41 -0500
-Subject: [PATCH 043/103] remoteproc: pru: Fix and cleanup firmware interrupt
+Subject: [PATCH 043/104] remoteproc: pru: Fix and cleanup firmware interrupt
  mapping logic
 
 The PRU firmware interrupt mappings are configured and unconfigured in

--- a/recipes-kernel/linux/files/patches-5.10/0044-watchdog-Start-watchdog-in-watchdog_set_last_hw_keep.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0044-watchdog-Start-watchdog-in-watchdog_set_last_hw_keep.patch
@@ -1,7 +1,7 @@
 From a70f71435aeb270461b903fbac329c5dbe5b8f53 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 30 Jul 2021 21:19:38 +0200
-Subject: [PATCH 044/103] watchdog: Start watchdog in
+Subject: [PATCH 044/104] watchdog: Start watchdog in
  watchdog_set_last_hw_keepalive only if appropriate
 
 We must not pet a running watchdog when handle_boot_enabled is off

--- a/recipes-kernel/linux/files/patches-5.10/0044-watchdog-Start-watchdog-in-watchdog_set_last_hw_keep.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0044-watchdog-Start-watchdog-in-watchdog_set_last_hw_keep.patch
@@ -1,4 +1,4 @@
-From 090b183db1181bec21569f7f75aad650deba64c5 Mon Sep 17 00:00:00 2001
+From a70f71435aeb270461b903fbac329c5dbe5b8f53 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 30 Jul 2021 21:19:38 +0200
 Subject: [PATCH 044/103] watchdog: Start watchdog in

--- a/recipes-kernel/linux/files/patches-5.10/0045-arm64-dts-ti-iot2050-Flip-mmc-device-ordering-on-Adv.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0045-arm64-dts-ti-iot2050-Flip-mmc-device-ordering-on-Adv.patch
@@ -1,7 +1,7 @@
 From abc18492a5539993d5285a556e4a9126b96a2570 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 1 Sep 2021 21:52:11 +0200
-Subject: [PATCH 045/103] arm64: dts: ti: iot2050: Flip mmc device ordering on
+Subject: [PATCH 045/104] arm64: dts: ti: iot2050: Flip mmc device ordering on
  Advanced devices
 
 This ensures that the SD card will remain mmc0 across Basic and Advanced

--- a/recipes-kernel/linux/files/patches-5.10/0045-arm64-dts-ti-iot2050-Flip-mmc-device-ordering-on-Adv.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0045-arm64-dts-ti-iot2050-Flip-mmc-device-ordering-on-Adv.patch
@@ -1,4 +1,4 @@
-From a8897cac7126799515985b36fe4cd4826e06a2d9 Mon Sep 17 00:00:00 2001
+From abc18492a5539993d5285a556e4a9126b96a2570 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 1 Sep 2021 21:52:11 +0200
 Subject: [PATCH 045/103] arm64: dts: ti: iot2050: Flip mmc device ordering on

--- a/recipes-kernel/linux/files/patches-5.10/0046-arm64-dts-ti-iot2050-Disable-SR2.0-only-PRUs.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0046-arm64-dts-ti-iot2050-Disable-SR2.0-only-PRUs.patch
@@ -1,7 +1,7 @@
 From 2fb0050859879e563c0a76dfd461decb9cfc95a7 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 1 Sep 2021 19:58:30 +0200
-Subject: [PATCH 046/103] arm64: dts: ti: iot2050: Disable SR2.0-only PRUs
+Subject: [PATCH 046/104] arm64: dts: ti: iot2050: Disable SR2.0-only PRUs
 
 The IOT2050 devices described so far are using SR1.0 silicon, thus do
 not have the additional PRUs of the ICSSG of the SR2.0. Disable them.

--- a/recipes-kernel/linux/files/patches-5.10/0046-arm64-dts-ti-iot2050-Disable-SR2.0-only-PRUs.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0046-arm64-dts-ti-iot2050-Disable-SR2.0-only-PRUs.patch
@@ -1,4 +1,4 @@
-From d385a57f3369ef15861a478e30faa206d4a4883c Mon Sep 17 00:00:00 2001
+From 2fb0050859879e563c0a76dfd461decb9cfc95a7 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 1 Sep 2021 19:58:30 +0200
 Subject: [PATCH 046/103] arm64: dts: ti: iot2050: Disable SR2.0-only PRUs

--- a/recipes-kernel/linux/files/patches-5.10/0047-arm64-dts-ti-iot2050-Add-enabled-mailboxes-and-carve.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0047-arm64-dts-ti-iot2050-Add-enabled-mailboxes-and-carve.patch
@@ -1,7 +1,7 @@
 From cdf6fc8692ded5de1f07b5bf57b913f8d09fcb71 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 9 Sep 2021 08:01:16 +0200
-Subject: [PATCH 047/103] arm64: dts: ti: iot2050: Add/enabled mailboxes and
+Subject: [PATCH 047/104] arm64: dts: ti: iot2050: Add/enabled mailboxes and
  carve-outs for R5F cores
 
 Analogously to the am654-base-board, configure the mailboxes for the the

--- a/recipes-kernel/linux/files/patches-5.10/0047-arm64-dts-ti-iot2050-Add-enabled-mailboxes-and-carve.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0047-arm64-dts-ti-iot2050-Add-enabled-mailboxes-and-carve.patch
@@ -1,4 +1,4 @@
-From 4dfff98854bb72fc45b104b6d16cba58f919d649 Mon Sep 17 00:00:00 2001
+From cdf6fc8692ded5de1f07b5bf57b913f8d09fcb71 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 9 Sep 2021 08:01:16 +0200
 Subject: [PATCH 047/103] arm64: dts: ti: iot2050: Add/enabled mailboxes and

--- a/recipes-kernel/linux/files/patches-5.10/0048-arm64-dts-ti-iot2050-Prepare-for-adding-2nd-generati.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0048-arm64-dts-ti-iot2050-Prepare-for-adding-2nd-generati.patch
@@ -1,4 +1,4 @@
-From 0027698996f25ae7e3eeb71a25971e3208895e0e Mon Sep 17 00:00:00 2001
+From fe440dc4af4e1455d7d8aeb593061561a53f1de0 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 7 Sep 2021 17:49:55 +0200
 Subject: [PATCH 048/103] arm64: dts: ti: iot2050: Prepare for adding

--- a/recipes-kernel/linux/files/patches-5.10/0048-arm64-dts-ti-iot2050-Prepare-for-adding-2nd-generati.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0048-arm64-dts-ti-iot2050-Prepare-for-adding-2nd-generati.patch
@@ -1,7 +1,7 @@
 From fe440dc4af4e1455d7d8aeb593061561a53f1de0 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 7 Sep 2021 17:49:55 +0200
-Subject: [PATCH 048/103] arm64: dts: ti: iot2050: Prepare for adding
+Subject: [PATCH 048/104] arm64: dts: ti: iot2050: Prepare for adding
  2nd-generation boards
 
 The current IOT2050 devices are Product Generation 1 (PG1), using SR1.0

--- a/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
@@ -1,4 +1,4 @@
-From d2b397098f7c151c6332e5d90e6f4dc27a9c257e Mon Sep 17 00:00:00 2001
+From da40c1cadf6dd6ae4b7baeefb5ee4bebe33b2485 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 21 Jun 2021 11:04:56 +0200
 Subject: [PATCH 049/103] arm64: dts: ti: iot2050: Add support for product

--- a/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
@@ -1,7 +1,7 @@
 From da40c1cadf6dd6ae4b7baeefb5ee4bebe33b2485 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 21 Jun 2021 11:04:56 +0200
-Subject: [PATCH 049/103] arm64: dts: ti: iot2050: Add support for product
+Subject: [PATCH 049/104] arm64: dts: ti: iot2050: Add support for product
  generation 2 boards
 
 This adds the devices trees for IOT2050 Product Generation 2 (PG2)

--- a/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
@@ -1,7 +1,7 @@
 From 33d69881d3fb0e277395f1dfefa4ef0344d242ed Mon Sep 17 00:00:00 2001
 From: Tomi Valkeinen <tomi.valkeinen@ti.com>
 Date: Mon, 31 May 2021 16:31:35 +0530
-Subject: [PATCH 050/103] arm64: dts: ti: k3-am65-main: fix DSS irq trigger
+Subject: [PATCH 050/104] arm64: dts: ti: k3-am65-main: fix DSS irq trigger
  type
 
 DSS irq trigger type is set to IRQ_TYPE_EDGE_RISING. For some reason this

--- a/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
@@ -1,4 +1,4 @@
-From eee06ab1eb0a504f87eed44f2a4804491a037ec7 Mon Sep 17 00:00:00 2001
+From 33d69881d3fb0e277395f1dfefa4ef0344d242ed Mon Sep 17 00:00:00 2001
 From: Tomi Valkeinen <tomi.valkeinen@ti.com>
 Date: Mon, 31 May 2021 16:31:35 +0530
 Subject: [PATCH 050/103] arm64: dts: ti: k3-am65-main: fix DSS irq trigger

--- a/recipes-kernel/linux/files/patches-5.10/0051-irqdomain-Export-of_phandle_args_to_fwspec.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0051-irqdomain-Export-of_phandle_args_to_fwspec.patch
@@ -1,7 +1,7 @@
 From 28dd3636604b696b47d21d4b1be95b2cc12f4c9d Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:46 +0530
-Subject: [PATCH 051/103] irqdomain: Export of_phandle_args_to_fwspec()
+Subject: [PATCH 051/104] irqdomain: Export of_phandle_args_to_fwspec()
 
 Export of_phandle_args_to_fwspec() to be used by drivers.
 of_phandle_args_to_fwspec() can be used by drivers to get irq specifier

--- a/recipes-kernel/linux/files/patches-5.10/0051-irqdomain-Export-of_phandle_args_to_fwspec.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0051-irqdomain-Export-of_phandle_args_to_fwspec.patch
@@ -1,4 +1,4 @@
-From 9776d1a8ee1d02525cf7ac73913e15d5a06d3d95 Mon Sep 17 00:00:00 2001
+From 28dd3636604b696b47d21d4b1be95b2cc12f4c9d Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:46 +0530
 Subject: [PATCH 051/103] irqdomain: Export of_phandle_args_to_fwspec()

--- a/recipes-kernel/linux/files/patches-5.10/0052-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0052-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
@@ -1,7 +1,7 @@
 From 04c871cbf7cbd59535ebd00fcf25a932ba4f03de Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:47 +0530
-Subject: [PATCH 052/103] PCI: keystone: Convert to using hierarchy domain for
+Subject: [PATCH 052/104] PCI: keystone: Convert to using hierarchy domain for
  legacy interrupts
 
 K2G provides separate IRQ lines for each of the four legacy interrupts.

--- a/recipes-kernel/linux/files/patches-5.10/0052-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0052-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
@@ -1,4 +1,4 @@
-From eda30b60aa8d2f10285f5e8f7583079b9844feb2 Mon Sep 17 00:00:00 2001
+From 04c871cbf7cbd59535ebd00fcf25a932ba4f03de Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:47 +0530
 Subject: [PATCH 052/103] PCI: keystone: Convert to using hierarchy domain for

--- a/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
@@ -1,7 +1,7 @@
 From 58c2bab2ea4abe8545ef1224dc794b4b3dc7a898 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:48 +0530
-Subject: [PATCH 053/103] PCI: keystone: Add PCI legacy interrupt support for
+Subject: [PATCH 053/104] PCI: keystone: Add PCI legacy interrupt support for
  AM654
 
 Add PCI legacy interrupt support for AM654. AM654 has a single HW

--- a/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
@@ -1,4 +1,4 @@
-From a9079da9bf7cb5b1153e4856278b8f02bd243e60 Mon Sep 17 00:00:00 2001
+From 58c2bab2ea4abe8545ef1224dc794b4b3dc7a898 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:48 +0530
 Subject: [PATCH 053/103] PCI: keystone: Add PCI legacy interrupt support for

--- a/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
@@ -1,4 +1,4 @@
-From 0cb84a5c5cb275f0b7c70d857eb084823d108b45 Mon Sep 17 00:00:00 2001
+From fd456433e2baf5e3a08ffe3e5ed4f502852d631e Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:49 +0530
 Subject: [PATCH 054/103] PCI: keystone: Add workaround for Errata #i2037

--- a/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
@@ -1,7 +1,7 @@
 From fd456433e2baf5e3a08ffe3e5ed4f502852d631e Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:49 +0530
-Subject: [PATCH 054/103] PCI: keystone: Add workaround for Errata #i2037
+Subject: [PATCH 054/104] PCI: keystone: Add workaround for Errata #i2037
  (AM65x SR 1.0)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/recipes-kernel/linux/files/patches-5.10/0055-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0055-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
@@ -1,7 +1,7 @@
 From 552c4e9ad10298a89788308c4608af11ec0147a0 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:38:07 +0530
-Subject: [PATCH 055/103] arm64: dts: ti: k3-am65-main: Add properties to
+Subject: [PATCH 055/104] arm64: dts: ti: k3-am65-main: Add properties to
  support legacy interrupts
 
 Add DT properties in PCIe DT node to support legacy interrupts.

--- a/recipes-kernel/linux/files/patches-5.10/0055-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0055-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
@@ -1,4 +1,4 @@
-From 8cea63b40d5a9dfd423426e34426d4501a156ae9 Mon Sep 17 00:00:00 2001
+From 552c4e9ad10298a89788308c4608af11ec0147a0 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:38:07 +0530
 Subject: [PATCH 055/103] arm64: dts: ti: k3-am65-main: Add properties to

--- a/recipes-kernel/linux/files/patches-5.10/0056-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0056-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
@@ -1,7 +1,7 @@
 From 459243d9de2157832ef6dc1299b5e74eed71f93b Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 20 Nov 2020 21:01:54 -0600
-Subject: [PATCH 056/103] remoteproc: Fix unbalanced boot with sysfs for no
+Subject: [PATCH 056/104] remoteproc: Fix unbalanced boot with sysfs for no
  auto-boot rprocs
 
 The remoteproc core performs automatic boot and shutdown of a remote

--- a/recipes-kernel/linux/files/patches-5.10/0056-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0056-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
@@ -1,4 +1,4 @@
-From 50a6f51917a20103d3e5273ff7e656fc34c82e3d Mon Sep 17 00:00:00 2001
+From 459243d9de2157832ef6dc1299b5e74eed71f93b Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 20 Nov 2020 21:01:54 -0600
 Subject: [PATCH 056/103] remoteproc: Fix unbalanced boot with sysfs for no

--- a/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Introduce-deny_sysfs_ops-flag.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Introduce-deny_sysfs_ops-flag.patch
@@ -1,4 +1,4 @@
-From ece2717dfe60efc411f45bbce6fd6cf407149bb3 Mon Sep 17 00:00:00 2001
+From 143dfa543c399ac80b6527145362808091796033 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 13:05:28 -0500
 Subject: [PATCH 057/103] remoteproc: Introduce deny_sysfs_ops flag

--- a/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Introduce-deny_sysfs_ops-flag.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Introduce-deny_sysfs_ops-flag.patch
@@ -1,7 +1,7 @@
 From 143dfa543c399ac80b6527145362808091796033 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 13:05:28 -0500
-Subject: [PATCH 057/103] remoteproc: Introduce deny_sysfs_ops flag
+Subject: [PATCH 057/104] remoteproc: Introduce deny_sysfs_ops flag
 
 The remoteproc framework provides sysfs interfaces for changing the
 firmware name and for starting/stopping a remote processor through

--- a/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
@@ -1,4 +1,4 @@
-From 5856d386d9ca6753757162e54a5cbcf3700b8da5 Mon Sep 17 00:00:00 2001
+From 004e270e87b86c6c0a6baa796a85b9eed4995670 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:32:29 -0500
 Subject: [PATCH 058/103] remoteproc: pru: Add APIs to get and put the PRU

--- a/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
@@ -1,7 +1,7 @@
 From 004e270e87b86c6c0a6baa796a85b9eed4995670 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:32:29 -0500
-Subject: [PATCH 058/103] remoteproc: pru: Add APIs to get and put the PRU
+Subject: [PATCH 058/104] remoteproc: pru: Add APIs to get and put the PRU
  cores
 
 Add two new APIs, pru_rproc_get() and pru_rproc_put(), to the PRU

--- a/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
@@ -1,4 +1,4 @@
-From 39cbb414a68c66fba265ab941f15cbd24c5e069c Mon Sep 17 00:00:00 2001
+From a69fc2f933555e1c1193d607723fee59d544656e Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 16 Dec 2020 17:52:37 +0100
 Subject: [PATCH 059/103] remoteproc: pru: Deny rproc sysfs ops for PRU client

--- a/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
@@ -1,7 +1,7 @@
 From a69fc2f933555e1c1193d607723fee59d544656e Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 16 Dec 2020 17:52:37 +0100
-Subject: [PATCH 059/103] remoteproc: pru: Deny rproc sysfs ops for PRU client
+Subject: [PATCH 059/104] remoteproc: pru: Deny rproc sysfs ops for PRU client
  driven boots
 
 The PRU remoteproc driver is not configured for 'auto-boot' by default,

--- a/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
@@ -1,4 +1,4 @@
-From 4c6786d8d25190ef1a25ad971387299e95935307 Mon Sep 17 00:00:00 2001
+From 012ca2186b2d53ef054262c302b57feece8dc3e5 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Fri, 26 Mar 2021 15:43:53 -0500
 Subject: [PATCH 060/103] remoteproc: pru: Add pru_rproc_set_ctable() function

--- a/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
@@ -1,7 +1,7 @@
 From 012ca2186b2d53ef054262c302b57feece8dc3e5 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Fri, 26 Mar 2021 15:43:53 -0500
-Subject: [PATCH 060/103] remoteproc: pru: Add pru_rproc_set_ctable() function
+Subject: [PATCH 060/104] remoteproc: pru: Add pru_rproc_set_ctable() function
 
 Some firmwares expect the OS drivers to configure the CTABLE
 entries publishing dynamically allocated memory regions. For

--- a/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Configure-firmware-based-on-client-se.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Configure-firmware-based-on-client-se.patch
@@ -1,4 +1,4 @@
-From 7ae8f3cb1b1f553571840adb7c8d86db9703f877 Mon Sep 17 00:00:00 2001
+From 47fbe25296c2aedd8984013ceddc224d9642b516 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:50:14 -0500
 Subject: [PATCH 061/103] remoteproc: pru: Configure firmware based on client

--- a/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Configure-firmware-based-on-client-se.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Configure-firmware-based-on-client-se.patch
@@ -1,7 +1,7 @@
 From 47fbe25296c2aedd8984013ceddc224d9642b516 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:50:14 -0500
-Subject: [PATCH 061/103] remoteproc: pru: Configure firmware based on client
+Subject: [PATCH 061/104] remoteproc: pru: Configure firmware based on client
  setup
 
 Client device node property firmware-name is now used to configure

--- a/recipes-kernel/linux/files/patches-5.10/0062-soc-ti-pruss-Add-pruss_get-put-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0062-soc-ti-pruss-Add-pruss_get-put-API.patch
@@ -1,7 +1,7 @@
 From 4453abfd5a3b492c3b05e4bb02ca123d78bf2ba7 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:58:00 -0500
-Subject: [PATCH 062/103] soc: ti: pruss: Add pruss_get()/put() API
+Subject: [PATCH 062/104] soc: ti: pruss: Add pruss_get()/put() API
 
 Add two new get and put API, pruss_get() and pruss_put() to the
 PRUSS platform driver to allow client drivers to request a handle

--- a/recipes-kernel/linux/files/patches-5.10/0062-soc-ti-pruss-Add-pruss_get-put-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0062-soc-ti-pruss-Add-pruss_get-put-API.patch
@@ -1,4 +1,4 @@
-From f166ffd46c4198bd834b3ddb7cf4bad55914ffc9 Mon Sep 17 00:00:00 2001
+From 4453abfd5a3b492c3b05e4bb02ca123d78bf2ba7 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:58:00 -0500
 Subject: [PATCH 062/103] soc: ti: pruss: Add pruss_get()/put() API

--- a/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
@@ -1,7 +1,7 @@
 From fb3fea63574bba2c562eee7c28d71357a9545dc0 Mon Sep 17 00:00:00 2001
 From: "Andrew F. Davis" <afd@ti.com>
 Date: Fri, 26 Mar 2021 16:11:42 -0500
-Subject: [PATCH 063/103] soc: ti: pruss: Add
+Subject: [PATCH 063/104] soc: ti: pruss: Add
  pruss_{request,release}_mem_region() API
 
 Add two new API - pruss_request_mem_region() & pruss_release_mem_region(),

--- a/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
@@ -1,4 +1,4 @@
-From e36353636d8f82532327835b895ce8d2334b6419 Mon Sep 17 00:00:00 2001
+From fb3fea63574bba2c562eee7c28d71357a9545dc0 Mon Sep 17 00:00:00 2001
 From: "Andrew F. Davis" <afd@ti.com>
 Date: Fri, 26 Mar 2021 16:11:42 -0500
 Subject: [PATCH 063/103] soc: ti: pruss: Add

--- a/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
@@ -1,4 +1,4 @@
-From c91e6a12f44eaa529c5cd9df4b1ef2b7f07316c1 Mon Sep 17 00:00:00 2001
+From bfce31c5fef1ef76a40e0bbed539ee11f6f888e6 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:27:34 -0500
 Subject: [PATCH 064/103] soc: ti: pruss: Add pruss_cfg_read()/update() API

--- a/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
@@ -1,7 +1,7 @@
 From bfce31c5fef1ef76a40e0bbed539ee11f6f888e6 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:27:34 -0500
-Subject: [PATCH 064/103] soc: ti: pruss: Add pruss_cfg_read()/update() API
+Subject: [PATCH 064/104] soc: ti: pruss: Add pruss_cfg_read()/update() API
 
 Add two new generic API pruss_cfg_read() and pruss_cfg_update() to
 the PRUSS platform driver to allow other drivers to read and program

--- a/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
@@ -1,4 +1,4 @@
-From 3eda4fe5c672b48cbef3c5f2a73ad9806e7ba3ff Mon Sep 17 00:00:00 2001
+From 1ca4e7aeeda0a765753352171e019e835dcb7279 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 11 Dec 2020 19:48:09 +0100
 Subject: [PATCH 065/103] soc: ti: pruss: Add helper functions to set GPI mode,

--- a/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
@@ -1,7 +1,7 @@
 From 1ca4e7aeeda0a765753352171e019e835dcb7279 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 11 Dec 2020 19:48:09 +0100
-Subject: [PATCH 065/103] soc: ti: pruss: Add helper functions to set GPI mode,
+Subject: [PATCH 065/104] soc: ti: pruss: Add helper functions to set GPI mode,
  MII_RT_event and XFR
 
 The PRUSS CFG module is represented as a syscon node and is currently

--- a/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
@@ -1,7 +1,7 @@
 From c9cd11d8f6bd96802f279d796fced16613b6a86d Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:38:11 -0500
-Subject: [PATCH 066/103] soc: ti: pruss: Add helper function to enable OCP
+Subject: [PATCH 066/104] soc: ti: pruss: Add helper function to enable OCP
  master ports
 
 The PRU-ICSS subsystem on OMAP-architecture based SoCS (AM33xx, AM437x

--- a/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
@@ -1,4 +1,4 @@
-From e6dfc31561dc0200ea89c7c6aeaa3a0d43c9c082 Mon Sep 17 00:00:00 2001
+From c9cd11d8f6bd96802f279d796fced16613b6a86d Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:38:11 -0500
 Subject: [PATCH 066/103] soc: ti: pruss: Add helper function to enable OCP

--- a/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
@@ -1,7 +1,7 @@
 From 46cce61506abe3dcc29bde4ea7b8b0a3dff61f8f Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 09:24:51 -0500
-Subject: [PATCH 067/103] soc: ti: pruss: Add helper functions to get/set
+Subject: [PATCH 067/104] soc: ti: pruss: Add helper functions to get/set
  PRUSS_CFG_GPMUX
 
 Add two new helper functions pruss_cfg_get_gpmux() & pruss_cfg_set_gpmux()

--- a/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
@@ -1,4 +1,4 @@
-From 970f5626f7a418f49cfb2c188802bef999c445c4 Mon Sep 17 00:00:00 2001
+From 46cce61506abe3dcc29bde4ea7b8b0a3dff61f8f Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 09:24:51 -0500
 Subject: [PATCH 067/103] soc: ti: pruss: Add helper functions to get/set

--- a/recipes-kernel/linux/files/patches-5.10/0068-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0068-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
@@ -1,4 +1,4 @@
-From e7e1b3ac3b12634109cfe5928201cf4e33a85fcd Mon Sep 17 00:00:00 2001
+From 5cdccb2c5de3ef475f5c9f08f2f30f966c1efb0a Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 10:11:42 -0500
 Subject: [PATCH 068/103] remoteproc/pru: add support for configuring GPMUX

--- a/recipes-kernel/linux/files/patches-5.10/0068-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0068-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
@@ -1,7 +1,7 @@
 From 5cdccb2c5de3ef475f5c9f08f2f30f966c1efb0a Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 10:11:42 -0500
-Subject: [PATCH 068/103] remoteproc/pru: add support for configuring GPMUX
+Subject: [PATCH 068/104] remoteproc/pru: add support for configuring GPMUX
  based on client setup
 
 Client device node property ti,pruss-gp-mux-sel can now be used to

--- a/recipes-kernel/linux/files/patches-5.10/0069-net-ethernet-ti-prueth-Add-IEP-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0069-net-ethernet-ti-prueth-Add-IEP-driver.patch
@@ -1,7 +1,7 @@
 From 14969c5e3b51cff6b46bb0cea3ae42d1f028de46 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 20 Apr 2021 13:17:30 +0530
-Subject: [PATCH 069/103] net: ethernet: ti: prueth: Add IEP driver
+Subject: [PATCH 069/104] net: ethernet: ti: prueth: Add IEP driver
 
 Add a driver for Industrial Ethernet Peripheral (IEP) block of PRUSS to
 support timestamping of ethernet packets and thus support PTP and PPS

--- a/recipes-kernel/linux/files/patches-5.10/0069-net-ethernet-ti-prueth-Add-IEP-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0069-net-ethernet-ti-prueth-Add-IEP-driver.patch
@@ -1,4 +1,4 @@
-From d3bf017ff471bfffdb4f8e29812e0b81db093d2c Mon Sep 17 00:00:00 2001
+From 14969c5e3b51cff6b46bb0cea3ae42d1f028de46 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 20 Apr 2021 13:17:30 +0530
 Subject: [PATCH 069/103] net: ethernet: ti: prueth: Add IEP driver

--- a/recipes-kernel/linux/files/patches-5.10/0070-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0070-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
@@ -1,4 +1,4 @@
-From e86bad0255584bbdcc1221f530aa1699d914afa2 Mon Sep 17 00:00:00 2001
+From f93ae4b426527f9ae553c7a5f50a359c5ef8f65b Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Tue, 20 Apr 2021 13:17:31 +0530
 Subject: [PATCH 070/103] HACK: net: ethernet: ti: icss-iep: Fix sync0

--- a/recipes-kernel/linux/files/patches-5.10/0070-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0070-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
@@ -1,7 +1,7 @@
 From f93ae4b426527f9ae553c7a5f50a359c5ef8f65b Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Tue, 20 Apr 2021 13:17:31 +0530
-Subject: [PATCH 070/103] HACK: net: ethernet: ti: icss-iep: Fix sync0
+Subject: [PATCH 070/104] HACK: net: ethernet: ti: icss-iep: Fix sync0
  generation on a compare event
 
 commit 41e5c46849b5 ("net: ethernet: ti: icss-iep: Add support for generating

--- a/recipes-kernel/linux/files/patches-5.10/0071-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0071-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
@@ -1,4 +1,4 @@
-From 0675da2df623448679bbbb55be5f565348d1efdf Mon Sep 17 00:00:00 2001
+From 212a300213a7f1e594f664ec9c1f39bca941e556 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:28 +0300
 Subject: [PATCH 071/103] net: ethernet: ti: icss_iep: drop

--- a/recipes-kernel/linux/files/patches-5.10/0071-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0071-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
@@ -1,7 +1,7 @@
 From 212a300213a7f1e594f664ec9c1f39bca941e556 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:28 +0300
-Subject: [PATCH 071/103] net: ethernet: ti: icss_iep: drop
+Subject: [PATCH 071/104] net: ethernet: ti: icss_iep: drop
  ICSS_IEP_CAPx_FALL_REGy
 
 ICSS_IEP_CAPx_FALL_REGy are not used, but cause indexation issues in

--- a/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
@@ -1,7 +1,7 @@
 From bb059dace1750ec025768c26e56f3747357913fd Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:29 +0300
-Subject: [PATCH 072/103] net: ethernet: ti: icss_iep: fix access to x_REG1 in
+Subject: [PATCH 072/104] net: ethernet: ti: icss_iep: fix access to x_REG1 in
  non 64bit mode
 
 Do not access x_REG1 registers in non 64bit mode.

--- a/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
@@ -1,4 +1,4 @@
-From 5783de9a1009c5c5403cf15036881d9290673718 Mon Sep 17 00:00:00 2001
+From bb059dace1750ec025768c26e56f3747357913fd Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:29 +0300
 Subject: [PATCH 072/103] net: ethernet: ti: icss_iep: fix access to x_REG1 in

--- a/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
@@ -1,7 +1,7 @@
 From 4324c1a9e08a4f9ba96c1fc24248a25c1ded842a Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:30 +0300
-Subject: [PATCH 073/103] net: ethernet: ti: icss_iep: disable extts and pps if
+Subject: [PATCH 073/104] net: ethernet: ti: icss_iep: disable extts and pps if
  no slow compensation or non 64bit mode
 
 Disable extts and pps if no slow compensation support or non 64bit mode.

--- a/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
@@ -1,4 +1,4 @@
-From fdfd560117a218f2ed2ef2d6b0df4f4c10cb4024 Mon Sep 17 00:00:00 2001
+From 4324c1a9e08a4f9ba96c1fc24248a25c1ded842a Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:30 +0300
 Subject: [PATCH 073/103] net: ethernet: ti: icss_iep: disable extts and pps if

--- a/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
@@ -1,7 +1,7 @@
 From 2833cd133e8f3e6a1b1a021e94d73e110384c80c Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:31 +0300
-Subject: [PATCH 074/103] net: ethernet: ti: icss_iep: fix pps irq race vs pps
+Subject: [PATCH 074/104] net: ethernet: ti: icss_iep: fix pps irq race vs pps
  disable
 
 When PPS is disabled the PPS IRQ can be running and PPS timer started which

--- a/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
@@ -1,4 +1,4 @@
-From 11b7c159e7b702eb8d24d23c5098ca51f30d9491 Mon Sep 17 00:00:00 2001
+From 2833cd133e8f3e6a1b1a021e94d73e110384c80c Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:31 +0300
 Subject: [PATCH 074/103] net: ethernet: ti: icss_iep: fix pps irq race vs pps

--- a/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
@@ -1,7 +1,7 @@
 From 0ec103b2b148749483d765f9186dd21fe65ee8ba Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:32 +0300
-Subject: [PATCH 075/103] net: ethernet: ti: icss_iep: improve icss_iep_gettime
+Subject: [PATCH 075/104] net: ethernet: ti: icss_iep: improve icss_iep_gettime
 
 There are few issues with icss_iep_gettime():
 - it has to be very fast, but it's not protected from interruption

--- a/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
@@ -1,4 +1,4 @@
-From 845b9fd315f0e75d6a98e0670074bd84b972b07b Mon Sep 17 00:00:00 2001
+From 0ec103b2b148749483d765f9186dd21fe65ee8ba Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:32 +0300
 Subject: [PATCH 075/103] net: ethernet: ti: icss_iep: improve icss_iep_gettime

--- a/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
@@ -1,4 +1,4 @@
-From aec2be04e70f8e2b0757064aae251964b35835ba Mon Sep 17 00:00:00 2001
+From 1a21bd419d4aa6fceef9438287e3e6f55ce0e13b Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:33 +0300
 Subject: [PATCH 076/103] net: ethernet: ti: icss_iep: simplify peroutput

--- a/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
@@ -1,7 +1,7 @@
 From 1a21bd419d4aa6fceef9438287e3e6f55ce0e13b Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:33 +0300
-Subject: [PATCH 076/103] net: ethernet: ti: icss_iep: simplify peroutput
+Subject: [PATCH 076/104] net: ethernet: ti: icss_iep: simplify peroutput
  processing
 
 simplify peroutput processing

--- a/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
@@ -1,4 +1,4 @@
-From 32209923cfc0f2e5e2d3b435d8f1891d00891ef0 Mon Sep 17 00:00:00 2001
+From 863ec9f27fa24721a1fd5c2ecbea7f8b3cec59dc Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:34 +0300
 Subject: [PATCH 077/103] net: ethernet: ti: icss_iep: use readl/writel in

--- a/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
@@ -1,7 +1,7 @@
 From 863ec9f27fa24721a1fd5c2ecbea7f8b3cec59dc Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:34 +0300
-Subject: [PATCH 077/103] net: ethernet: ti: icss_iep: use readl/writel in
+Subject: [PATCH 077/104] net: ethernet: ti: icss_iep: use readl/writel in
  cap_cmp_handler
 
 Use readl/writel in cap_cmp_handler and timer handler instead of regmap

--- a/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
@@ -1,7 +1,7 @@
 From 7ad205d59096b9de7883cb02fe841db248506862 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:35 +0300
-Subject: [PATCH 078/103] net: ethernet: ti: icss_iep: switch to .gettimex64()
+Subject: [PATCH 078/104] net: ethernet: ti: icss_iep: switch to .gettimex64()
 
 The .gettime64() is deprecated by commit 916444df305e ("ptp: deprecate
 gettime64() in favor of gettimex64()").

--- a/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
@@ -1,4 +1,4 @@
-From 46104dc8f21ccdeed7de36269ae14d3b1f9b367d Mon Sep 17 00:00:00 2001
+From 7ad205d59096b9de7883cb02fe841db248506862 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:35 +0300
 Subject: [PATCH 078/103] net: ethernet: ti: icss_iep: switch to .gettimex64()

--- a/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
@@ -1,7 +1,7 @@
 From 5ba507a117684a93de7e294dc5b7608bc2f5a724 Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Thu, 29 Apr 2021 18:13:36 +0300
-Subject: [PATCH 079/103] net: ethernet: ti: icss_iep: Update compare registers
+Subject: [PATCH 079/104] net: ethernet: ti: icss_iep: Update compare registers
  after changing ptp clock time
 
 Consider the scenario where PPS is enabled, then iep set_time or adjust_time is

--- a/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
@@ -1,4 +1,4 @@
-From 728916eccc909837890055684897e8cadcf65032 Mon Sep 17 00:00:00 2001
+From 5ba507a117684a93de7e294dc5b7608bc2f5a724 Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Thu, 29 Apr 2021 18:13:36 +0300
 Subject: [PATCH 079/103] net: ethernet: ti: icss_iep: Update compare registers

--- a/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
@@ -1,7 +1,7 @@
 From 9ab8cd572347222bf675f22b04585d7da68551c2 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:37 +0300
-Subject: [PATCH 080/103] net: ethernet: ti: icss_iep: request cmp_cap irq from
+Subject: [PATCH 080/104] net: ethernet: ti: icss_iep: request cmp_cap irq from
  probe
 
 The current INTC design allows to define IEP cmp_cap IRQ explicitly for IEP

--- a/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
@@ -1,4 +1,4 @@
-From 4530a35aec5409ea096ba6614244a3ab1e2dafd5 Mon Sep 17 00:00:00 2001
+From 9ab8cd572347222bf675f22b04585d7da68551c2 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:37 +0300
 Subject: [PATCH 080/103] net: ethernet: ti: icss_iep: request cmp_cap irq from

--- a/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
@@ -1,7 +1,7 @@
 From cf670598c14f1f40c623a7c8c6b318237ad7f9d6 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:38 +0300
-Subject: [PATCH 081/103] net: ethernet: ti: icss_iep: set phc time to system
+Subject: [PATCH 081/104] net: ethernet: ti: icss_iep: set phc time to system
  time on init
 
 Following customer feedback IEP PHC time has to be set to system time on

--- a/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
@@ -1,4 +1,4 @@
-From 9539dd1c2188de5b3ee8bbd1c04162e3c68503ee Mon Sep 17 00:00:00 2001
+From cf670598c14f1f40c623a7c8c6b318237ad7f9d6 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:38 +0300
 Subject: [PATCH 081/103] net: ethernet: ti: icss_iep: set phc time to system

--- a/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
@@ -1,4 +1,4 @@
-From 354e8246001e2a0aca20a635c585ce18ae933c02 Mon Sep 17 00:00:00 2001
+From ce0c55790d6e7429cdbbe52e68c5efff3027c0c8 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:39 +0300
 Subject: [PATCH 082/103] net: ethernet: ti: icss_iep: use

--- a/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
@@ -1,7 +1,7 @@
 From ce0c55790d6e7429cdbbe52e68c5efff3027c0c8 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:39 +0300
-Subject: [PATCH 082/103] net: ethernet: ti: icss_iep: use
+Subject: [PATCH 082/104] net: ethernet: ti: icss_iep: use
  devm_platform_ioremap_resource
 
 Use devm_platform_ioremap_resource() in probe to simplify code.

--- a/recipes-kernel/linux/files/patches-5.10/0083-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0083-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
@@ -1,7 +1,7 @@
 From 4b3621c113c6f473e0533e7a9188bbc562234f60 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 16 Mar 2021 18:00:25 -0500
-Subject: [PATCH 083/103] arm64: dts: ti: k3-am65-main: Add ICSSG IEP nodes
+Subject: [PATCH 083/104] arm64: dts: ti: k3-am65-main: Add ICSSG IEP nodes
 
 The ICSSG IP on AM65x SoCs have two Industrial Ethernet Peripherals (IEPs)
 to manage/generate Industrial Ethernet functions such as time stamping.

--- a/recipes-kernel/linux/files/patches-5.10/0083-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0083-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
@@ -1,4 +1,4 @@
-From 676436bf46b58b1c9c543dbd1d6e5f490d1bc727 Mon Sep 17 00:00:00 2001
+From 4b3621c113c6f473e0533e7a9188bbc562234f60 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 16 Mar 2021 18:00:25 -0500
 Subject: [PATCH 083/103] arm64: dts: ti: k3-am65-main: Add ICSSG IEP nodes

--- a/recipes-kernel/linux/files/patches-5.10/0084-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0084-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
@@ -1,4 +1,4 @@
-From 85b5a34f83a0d43de130ca602a9ac5ec8ba829de Mon Sep 17 00:00:00 2001
+From ce9fbe2f108154c8dbd5b743636919170685c7be Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:22 +0300
 Subject: [PATCH 084/103] dt-bindings: net: Add binding for ti,icssg-prueth

--- a/recipes-kernel/linux/files/patches-5.10/0084-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0084-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
@@ -1,7 +1,7 @@
 From ce9fbe2f108154c8dbd5b743636919170685c7be Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:22 +0300
-Subject: [PATCH 084/103] dt-bindings: net: Add binding for ti,icssg-prueth
+Subject: [PATCH 084/104] dt-bindings: net: Add binding for ti,icssg-prueth
  device
 
 This is the DT binding document for the ICSSG Dual-EMAC Ethernet

--- a/recipes-kernel/linux/files/patches-5.10/0085-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0085-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
@@ -1,7 +1,7 @@
 From 9e671235fc8509f24a82e8c80a040993f55b6a38 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:23 +0300
-Subject: [PATCH 085/103] net: ti: icssg-prueth: Add ICSSG ethernet driver
+Subject: [PATCH 085/104] net: ti: icssg-prueth: Add ICSSG ethernet driver
 
 This is the Ethernet driver for TI SoCs with the
 ICSSG PRU Sub-system running dual-EMAC firmware.

--- a/recipes-kernel/linux/files/patches-5.10/0085-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0085-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
@@ -1,4 +1,4 @@
-From 5c2dcff7b82fef0bc7a045a38519a23a7c06248c Mon Sep 17 00:00:00 2001
+From 9e671235fc8509f24a82e8c80a040993f55b6a38 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:23 +0300
 Subject: [PATCH 085/103] net: ti: icssg-prueth: Add ICSSG ethernet driver

--- a/recipes-kernel/linux/files/patches-5.10/0086-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0086-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
@@ -1,7 +1,7 @@
 From 09502d0b37bd2c91cebfdd9b4451fc8a28ed3f36 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:24 +0300
-Subject: [PATCH 086/103] net: ethernet: ti: icssg_prueth: add 10M full duplex
+Subject: [PATCH 086/104] net: ethernet: ti: icssg_prueth: add 10M full duplex
  support
 
 For 10M support RGMII need to be configured in inband mode and FW has to be

--- a/recipes-kernel/linux/files/patches-5.10/0086-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0086-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
@@ -1,4 +1,4 @@
-From e1b038feed6df1bade033dc5f2b242be50faa7ff Mon Sep 17 00:00:00 2001
+From 09502d0b37bd2c91cebfdd9b4451fc8a28ed3f36 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:24 +0300
 Subject: [PATCH 086/103] net: ethernet: ti: icssg_prueth: add 10M full duplex

--- a/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
@@ -1,4 +1,4 @@
-From 18072ef52e70961622c918a8fd333424a7e70053 Mon Sep 17 00:00:00 2001
+From 697cda9e51db3253bf5933d8eaa6f2a7d5c2bb63 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:25 +0300
 Subject: [PATCH 087/103] net: ethernet: ti: icssg_prueth: Use DMA device for

--- a/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
@@ -1,7 +1,7 @@
 From 697cda9e51db3253bf5933d8eaa6f2a7d5c2bb63 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:25 +0300
-Subject: [PATCH 087/103] net: ethernet: ti: icssg_prueth: Use DMA device for
+Subject: [PATCH 087/104] net: ethernet: ti: icssg_prueth: Use DMA device for
  DMA API
 
 For DMA API the DMA device should be used as cpsw does not accesses to

--- a/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
@@ -1,7 +1,7 @@
 From 59734af11ba3a042e3656e89b3567d94f9fdeffb Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:26 +0300
-Subject: [PATCH 088/103] net: ethernet: ti: icss_iep: add icss_iep_get_idx()
+Subject: [PATCH 088/104] net: ethernet: ti: icss_iep: add icss_iep_get_idx()
  api
 
 Add icss_iep_get_idx() API to allow retrieve IEP from phandle list in DT.

--- a/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
@@ -1,4 +1,4 @@
-From a6a9e65a10099bb820a6259e2e03862c4687a59d Mon Sep 17 00:00:00 2001
+From 59734af11ba3a042e3656e89b3567d94f9fdeffb Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:26 +0300
 Subject: [PATCH 088/103] net: ethernet: ti: icss_iep: add icss_iep_get_idx()

--- a/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
@@ -1,7 +1,7 @@
 From d0268840960f41ef0f6c2c6a77d62425fbfc54ac Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:27 +0300
-Subject: [PATCH 089/103] net: ethernet: ti: icss_iep: use readl() in
+Subject: [PATCH 089/104] net: ethernet: ti: icss_iep: use readl() in
  icss_iep_get_count_low/hi()
 
 Use readl() in icss_iep_get_count_low/hi() to speed up hot path.

--- a/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
@@ -1,4 +1,4 @@
-From a9e735d298663e6ce2d9b249fc1173f8c2c868e2 Mon Sep 17 00:00:00 2001
+From d0268840960f41ef0f6c2c6a77d62425fbfc54ac Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:27 +0300
 Subject: [PATCH 089/103] net: ethernet: ti: icss_iep: use readl() in

--- a/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
@@ -1,4 +1,4 @@
-From f71242f87070ae1d960296eae436e5d83ba44df2 Mon Sep 17 00:00:00 2001
+From d973cbd0d89ee83189be9a57be1d08e804604f08 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:28 +0300
 Subject: [PATCH 090/103] net: ethernet: ti: icss_iep: fix init for sr2.0

--- a/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
@@ -1,7 +1,7 @@
 From d973cbd0d89ee83189be9a57be1d08e804604f08 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:28 +0300
-Subject: [PATCH 090/103] net: ethernet: ti: icss_iep: fix init for sr2.0
+Subject: [PATCH 090/104] net: ethernet: ti: icss_iep: fix init for sr2.0
 
 There are two issues with IEP initialization for ICSSG SR2.0 where only one
 IEP0 is used in shadow mode:

--- a/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
@@ -1,4 +1,4 @@
-From 580d2378342423997e961ab4215b4f960bdf0411 Mon Sep 17 00:00:00 2001
+From 2edcbd51f46b19555cedd3a68ab07f41b1fe3c7b Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:29 +0300
 Subject: [PATCH 091/103] net: ethernet: ti: icss_iep: sr2.0 fix NULL pointer

--- a/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
@@ -1,7 +1,7 @@
 From 2edcbd51f46b19555cedd3a68ab07f41b1fe3c7b Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:29 +0300
-Subject: [PATCH 091/103] net: ethernet: ti: icss_iep: sr2.0 fix NULL pointer
+Subject: [PATCH 091/104] net: ethernet: ti: icss_iep: sr2.0 fix NULL pointer
  exception on pps stop
 
 The NULL pointer exception is observed on pps stop - fix it as timer is not

--- a/recipes-kernel/linux/files/patches-5.10/0092-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0092-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
@@ -1,7 +1,7 @@
 From a914bcc1ce768c203be3c95979e7892ae334262a Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:30 +0300
-Subject: [PATCH 092/103] net: ti: ethernet: icssg-prueth: add packet
+Subject: [PATCH 092/104] net: ti: ethernet: icssg-prueth: add packet
  timestamping and ptp support
 
 Add packet timestamping TS and PTP PHC clock support.

--- a/recipes-kernel/linux/files/patches-5.10/0092-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0092-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
@@ -1,4 +1,4 @@
-From 6deadcda533fd67b5ec1969553969762f7921f40 Mon Sep 17 00:00:00 2001
+From a914bcc1ce768c203be3c95979e7892ae334262a Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:30 +0300
 Subject: [PATCH 092/103] net: ti: ethernet: icssg-prueth: add packet

--- a/recipes-kernel/linux/files/patches-5.10/0093-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0093-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
@@ -1,7 +1,7 @@
 From 34d0c89336ce2361f99d6b9a6fa4b1376e018a95 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:33 +0300
-Subject: [PATCH 093/103] net: ethernet: ti: icssg_prueth: add am64x icssg
+Subject: [PATCH 093/104] net: ethernet: ti: icssg_prueth: add am64x icssg
  support
 
 Add AM64x ICSSG support which is similar to am65x SR2.0, but required:

--- a/recipes-kernel/linux/files/patches-5.10/0093-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0093-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
@@ -1,4 +1,4 @@
-From c8fc74c98f809e7b610748275af04cb6b04d7666 Mon Sep 17 00:00:00 2001
+From 34d0c89336ce2361f99d6b9a6fa4b1376e018a95 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:33 +0300
 Subject: [PATCH 093/103] net: ethernet: ti: icssg_prueth: add am64x icssg

--- a/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
@@ -1,4 +1,4 @@
-From ebb5b97d2b31f9c59064dba41d7f8b6d6691d9b9 Mon Sep 17 00:00:00 2001
+From 5fb3a0908b082e3a293b9e3aeb13ad1b627dc694 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 19 May 2021 19:31:36 +0300
 Subject: [PATCH 094/103] net: ethernet: ti: icssg_prueth: am65x SR2.0 add 10M

--- a/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
@@ -1,7 +1,7 @@
 From 5fb3a0908b082e3a293b9e3aeb13ad1b627dc694 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 19 May 2021 19:31:36 +0300
-Subject: [PATCH 094/103] net: ethernet: ti: icssg_prueth: am65x SR2.0 add 10M
+Subject: [PATCH 094/104] net: ethernet: ti: icssg_prueth: am65x SR2.0 add 10M
  full duplex support
 
 For for AM65x SR2.0 it's required to enable IEP1 in raw 64bit mode which is

--- a/recipes-kernel/linux/files/patches-5.10/0095-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0095-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
@@ -1,7 +1,7 @@
 From 19d6c003c45deb30105b30c85c7428d9a700bfd8 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Mon, 21 Jun 2021 15:47:49 +0530
-Subject: [PATCH 095/103] net: ti: icssg_prueth: Free desc pool before DMA
+Subject: [PATCH 095/104] net: ti: icssg_prueth: Free desc pool before DMA
  channel release
 
 Release DMA desc pool associated with channel before releasing the

--- a/recipes-kernel/linux/files/patches-5.10/0095-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0095-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
@@ -1,4 +1,4 @@
-From d03eead74a043d8e944b96f6343655dd9a7af41a Mon Sep 17 00:00:00 2001
+From 19d6c003c45deb30105b30c85c7428d9a700bfd8 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Mon, 21 Jun 2021 15:47:49 +0530
 Subject: [PATCH 095/103] net: ti: icssg_prueth: Free desc pool before DMA

--- a/recipes-kernel/linux/files/patches-5.10/0096-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0096-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
@@ -1,7 +1,7 @@
 From 4e4b7bc421c1bbfd06e81b1d2f3e63d75fb83f76 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:47 +0300
-Subject: [PATCH 096/103] net: ethernet: icssg-prueth: fix rgmii tx delay
+Subject: [PATCH 096/104] net: ethernet: icssg-prueth: fix rgmii tx delay
  configuration
 
 The driver enables RGMII TX delay without checking specified

--- a/recipes-kernel/linux/files/patches-5.10/0096-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0096-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
@@ -1,4 +1,4 @@
-From 2e99066aa0af9be9208986517ba21d0034178abc Mon Sep 17 00:00:00 2001
+From 4e4b7bc421c1bbfd06e81b1d2f3e63d75fb83f76 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:47 +0300
 Subject: [PATCH 096/103] net: ethernet: icssg-prueth: fix rgmii tx delay

--- a/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
@@ -1,4 +1,4 @@
-From ca1bc006d727e129f50fd94a4b0048e4bfc8d4bb Mon Sep 17 00:00:00 2001
+From 58d6496469f8a0680aef73a0f76ca0ddf09a5d33 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:48 +0300
 Subject: [PATCH 097/103] net: ethernet: icssg-prueth: enable "fixed-link"

--- a/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
@@ -1,7 +1,7 @@
 From 58d6496469f8a0680aef73a0f76ca0ddf09a5d33 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:48 +0300
-Subject: [PATCH 097/103] net: ethernet: icssg-prueth: enable "fixed-link"
+Subject: [PATCH 097/104] net: ethernet: icssg-prueth: enable "fixed-link"
  connection
 
 The ICSSG has incomplete and incorrect "fixed-link" connection type

--- a/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
@@ -1,7 +1,7 @@
 From bf026ff75aa00466ce7b2afdcad75e7bc26b5c2b Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:12 +0300
-Subject: [PATCH 098/103] net: ethernet: icssg-prueth: fix bug 'scheduling
+Subject: [PATCH 098/104] net: ethernet: icssg-prueth: fix bug 'scheduling
  while atomic' from emac_ndo_set_rx_mode()
 
 The .ndo_set_rx_mode() is called with BH disabled and should be atomic, but

--- a/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
@@ -1,4 +1,4 @@
-From 39ea4ba867d108ff1043ae0178ed801217490d79 Mon Sep 17 00:00:00 2001
+From bf026ff75aa00466ce7b2afdcad75e7bc26b5c2b Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:12 +0300
 Subject: [PATCH 098/103] net: ethernet: icssg-prueth: fix bug 'scheduling

--- a/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
@@ -1,4 +1,4 @@
-From 20012a55e95f9b3a39a6a30bf17d79cd7e2b7881 Mon Sep 17 00:00:00 2001
+From d0ff925cc96d1726bae397aca0ea92e34d805b35 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:13 +0300
 Subject: [PATCH 099/103] net: ethernet: icssg-prueth: fix enabling/disabling

--- a/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
@@ -1,7 +1,7 @@
 From d0ff925cc96d1726bae397aca0ea92e34d805b35 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:13 +0300
-Subject: [PATCH 099/103] net: ethernet: icssg-prueth: fix enabling/disabling
+Subject: [PATCH 099/104] net: ethernet: icssg-prueth: fix enabling/disabling
  port in emac_adjust_link()
 
 The port state is set to FORWARD in emac_ndo_open() and never changed, but

--- a/recipes-kernel/linux/files/patches-5.10/0100-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0100-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
@@ -1,7 +1,7 @@
 From ee97fc99e48ee4621f820424cffd7cdbadd2cecc Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 27 Jun 2020 10:53:13 +0200
-Subject: [PATCH 100/103] arm64: dts: ti: iot2050: Add icssg-prueth nodes for
+Subject: [PATCH 100/104] arm64: dts: ti: iot2050: Add icssg-prueth nodes for
  PG1 and PG2 devices
 
 Add the required nodes to enable ICSSG SR1.0 and SR2.0 based prueth

--- a/recipes-kernel/linux/files/patches-5.10/0100-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0100-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
@@ -1,4 +1,4 @@
-From 712d4ea504755b6593b30f14478baecf274c5003 Mon Sep 17 00:00:00 2001
+From ee97fc99e48ee4621f820424cffd7cdbadd2cecc Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 27 Jun 2020 10:53:13 +0200
 Subject: [PATCH 100/103] arm64: dts: ti: iot2050: Add icssg-prueth nodes for

--- a/recipes-kernel/linux/files/patches-5.10/0101-HACK-setting-the-RJ45-port-led-behavior.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0101-HACK-setting-the-RJ45-port-led-behavior.patch
@@ -1,4 +1,4 @@
-From 5a90dfc402dcdcb70b5d1954ace8eb2629409213 Mon Sep 17 00:00:00 2001
+From 214a5b0ee349dc5eb5d96e58067e98558a7bb8ab Mon Sep 17 00:00:00 2001
 From: zengchao <chao.zeng@siemens.com>
 Date: Wed, 6 Nov 2019 11:21:49 +0800
 Subject: [PATCH 101/103] HACK: setting the RJ45 port led behavior

--- a/recipes-kernel/linux/files/patches-5.10/0101-HACK-setting-the-RJ45-port-led-behavior.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0101-HACK-setting-the-RJ45-port-led-behavior.patch
@@ -1,7 +1,7 @@
 From 214a5b0ee349dc5eb5d96e58067e98558a7bb8ab Mon Sep 17 00:00:00 2001
 From: zengchao <chao.zeng@siemens.com>
 Date: Wed, 6 Nov 2019 11:21:49 +0800
-Subject: [PATCH 101/103] HACK: setting the RJ45 port led behavior
+Subject: [PATCH 101/104] HACK: setting the RJ45 port led behavior
 
 Temporary needed until we have a proper, likely LED-class based
 solution upstream.

--- a/recipes-kernel/linux/files/patches-5.10/0102-WIP-feat-extend-led-panic-indicator-on-and-off.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0102-WIP-feat-extend-led-panic-indicator-on-and-off.patch
@@ -1,4 +1,4 @@
-From 2d44a8c7b8b2d7f5c62f66bd4248b2bb3313efb8 Mon Sep 17 00:00:00 2001
+From 3341677dc20deb9041ee1f8f9b916e1dd1993af6 Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Tue, 22 Dec 2020 15:05:56 +0800
 Subject: [PATCH 102/103] WIP: feat:extend led panic-indicator on and off

--- a/recipes-kernel/linux/files/patches-5.10/0102-WIP-feat-extend-led-panic-indicator-on-and-off.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0102-WIP-feat-extend-led-panic-indicator-on-and-off.patch
@@ -1,7 +1,7 @@
 From 3341677dc20deb9041ee1f8f9b916e1dd1993af6 Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Tue, 22 Dec 2020 15:05:56 +0800
-Subject: [PATCH 102/103] WIP: feat:extend led panic-indicator on and off
+Subject: [PATCH 102/104] WIP: feat:extend led panic-indicator on and off
 
 WIP because upstream strategy is still under discussion.
 

--- a/recipes-kernel/linux/files/patches-5.10/0103-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0103-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
@@ -1,4 +1,4 @@
-From 5ae053ba6dcd01262bfc6352c591e5fb70d1ff2a Mon Sep 17 00:00:00 2001
+From 27ae988de3408a9816401d8de4d8fee5abe425f6 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Mar 2021 15:28:21 +0100
 Subject: [PATCH 103/103] WIP: arm64: dts: ti: iot2050: Add node for generic

--- a/recipes-kernel/linux/files/patches-5.10/0103-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0103-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
@@ -1,7 +1,7 @@
 From 27ae988de3408a9816401d8de4d8fee5abe425f6 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Mar 2021 15:28:21 +0100
-Subject: [PATCH 103/103] WIP: arm64: dts: ti: iot2050: Add node for generic
+Subject: [PATCH 103/104] WIP: arm64: dts: ti: iot2050: Add node for generic
  spidev
 
 This allows to use mcu_spi0 via userspace spidev.

--- a/recipes-kernel/linux/files/patches-5.10/0104-watchdog-rti-wdt-Provide-set_timeout-handler-to-make.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0104-watchdog-rti-wdt-Provide-set_timeout-handler-to-make.patch
@@ -1,0 +1,61 @@
+From 059b734e40f2507b7802d3a95adced72c8feaa29 Mon Sep 17 00:00:00 2001
+From: Jan Kiszka <jan.kiszka@siemens.com>
+Date: Mon, 13 Sep 2021 12:27:17 +0200
+Subject: [PATCH 104/104] watchdog: rti-wdt: Provide set_timeout handler to
+ make existing userspace happy
+
+Prominent userspace - systemd - cannot handle watchdogs without
+WDIOF_SETTIMEOUT, even if it was configured to the same time as the
+driver selected or was used by firmware to start the watchdog. To avoid
+failing in this case, implement a handler that only fails if a deviating
+set_timeout is requested.
+
+Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
+---
+ drivers/watchdog/rti_wdt.c | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/watchdog/rti_wdt.c b/drivers/watchdog/rti_wdt.c
+index 359302f71f7e..365255b15a0d 100644
+--- a/drivers/watchdog/rti_wdt.c
++++ b/drivers/watchdog/rti_wdt.c
+@@ -173,13 +173,27 @@ static unsigned int rti_wdt_get_timeleft_ms(struct watchdog_device *wdd)
+ 	return timer_counter;
+ }
+ 
++static int rti_wdt_set_timeout(struct watchdog_device *wdd,
++			       unsigned int timeout)
++{
++	/*
++	 * Updating the timeout after start is actually not supported, but
++	 * let's ignore requests for the already configured value. Helps
++	 * existing userspace such as systemd.
++	 */
++	if (timeout != heartbeat)
++		return -EOPNOTSUPP;
++
++	return 0;
++}
++
+ static unsigned int rti_wdt_get_timeleft(struct watchdog_device *wdd)
+ {
+ 	return rti_wdt_get_timeleft_ms(wdd) / 1000;
+ }
+ 
+ static const struct watchdog_info rti_wdt_info = {
+-	.options = WDIOF_KEEPALIVEPING,
++	.options = WDIOF_KEEPALIVEPING | WDIOF_SETTIMEOUT,
+ 	.identity = "K3 RTI Watchdog",
+ };
+ 
+@@ -187,6 +201,7 @@ static const struct watchdog_ops rti_wdt_ops = {
+ 	.owner		= THIS_MODULE,
+ 	.start		= rti_wdt_start,
+ 	.ping		= rti_wdt_ping,
++	.set_timeout	= rti_wdt_set_timeout,
+ 	.get_timeleft	= rti_wdt_get_timeleft,
+ };
+ 
+-- 
+2.31.1
+

--- a/recipes-kernel/linux/linux-iot2050_5.10.64.bb
+++ b/recipes-kernel/linux/linux-iot2050_5.10.64.bb
@@ -9,6 +9,6 @@ require linux-iot2050-5.10.inc
 
 KERNEL_SOURCE = "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-${PV}.tar.xz"
 
-SRC_URI[sha256sum] = "19a15e838885a0081de5f9874e608fc3f3b1d9e69f2cc5cfa883b8b5499bcb2e"
+SRC_URI[sha256sum] = "3eb84bd24a2de2b4749314e34597c02401c5d6831b055ed5224adb405c35e30a"
 
 S = "${WORKDIR}/linux-${PV}"


### PR DESCRIPTION
An alternative to #182, avoiding the systemd rebuild by a driver patch - or hack (to be found out). Will send that patch for discussion upstream as well.

This also rebases over 5.10.64 while at it.