### PR TITLE
iot2050-image: Warn users about firmware incompatibility

### DIFF
--- a/recipes-core/images/iot2050-image-base.bb
+++ b/recipes-core/images/iot2050-image-base.bb
@@ -56,3 +56,8 @@ python image_postprocess_restore_sources_list () {
     else:
         bb.note('No need to restore sources for mainline packages')
 }
+
+python do_image_append() {
+    bb.warn('This image is NOT COMPATIBLE with current official firmware releases!\n'
+            'It is recommended to build release V01.01.01 instead.')
+}


### PR DESCRIPTION
By now, many users are familiar with building own imaging to get latest
features and fixes. As we are now requiring a firmware update for
supporting the 5.10 kernel, reports arrive that things are unexpectedly
broken.

Warn about this situation prominently during the image build. This
warning can later be adjusted to "requires firmware release ..." or
completely dropped again.