### PR TITLE
u-boot-iot2050: Update patches

### DIFF
--- a/recipes-bsp/u-boot/files/0001-arm-mach-k3-am6_init-Prioritize-MSMC-traffic-over-DD.patch
+++ b/recipes-bsp/u-boot/files/0001-arm-mach-k3-am6_init-Prioritize-MSMC-traffic-over-DD.patch
@@ -1,4 +1,4 @@
-From 9df7c3c562514af966b3d27a873e10468031af82 Mon Sep 17 00:00:00 2001
+From 1438d1bfbdd163f29db3c1d1c0e0c1a075896b1c Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Wed, 8 Sep 2021 22:28:59 +0200
 Subject: [PATCH 1/8] arm: mach-k3: am6_init: Prioritize MSMC traffic over DDR

--- a/recipes-bsp/u-boot/files/0002-arm-dts-Add-IOT2050-device-tree-files.patch
+++ b/recipes-bsp/u-boot/files/0002-arm-dts-Add-IOT2050-device-tree-files.patch
@@ -1,4 +1,4 @@
-From 605cf79343bb34c53b3315f1b7610aefcb100af3 Mon Sep 17 00:00:00 2001
+From 6685cfd1b25dd18458dfb085d3ee7b7908df4c53 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 30 Nov 2020 10:13:04 +0100
 Subject: [PATCH 2/8] arm: dts: Add IOT2050 device tree files
@@ -10,7 +10,7 @@ files needed. Furthermore, the SPL has its own device tree.
 
 Based on original board support by Le Jin, Gao Nian and Chao Zeng.
 
-[backport, filtering out not yet supported nodes]
+[backported, filtering out not yet supported nodes]
 
 Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
 ---
@@ -19,15 +19,15 @@ Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
  arch/arm/dts/k3-am65-iot2050-common-pg1.dtsi  |  22 +
  arch/arm/dts/k3-am65-iot2050-common-pg2.dtsi  |  51 ++
  .../dts/k3-am65-iot2050-common-u-boot.dtsi    |  99 +++
- arch/arm/dts/k3-am65-iot2050-common.dtsi      | 699 ++++++++++++++++++
+ arch/arm/dts/k3-am65-iot2050-common.dtsi      | 721 ++++++++++++++++++
  arch/arm/dts/k3-am65-iot2050-spl.dts          |  17 +
  .../dts/k3-am6528-iot2050-basic-common.dtsi   |  63 ++
- arch/arm/dts/k3-am6528-iot2050-basic-pg2.dts  |  21 +
- arch/arm/dts/k3-am6528-iot2050-basic.dts      |  21 +
+ arch/arm/dts/k3-am6528-iot2050-basic-pg2.dts  |  24 +
+ arch/arm/dts/k3-am6528-iot2050-basic.dts      |  24 +
  .../k3-am6548-iot2050-advanced-common.dtsi    |  59 ++
- .../dts/k3-am6548-iot2050-advanced-pg2.dts    |  26 +
- arch/arm/dts/k3-am6548-iot2050-advanced.dts   |  21 +
- 13 files changed, 1255 insertions(+), 1 deletion(-)
+ .../dts/k3-am6548-iot2050-advanced-pg2.dts    |  29 +
+ arch/arm/dts/k3-am6548-iot2050-advanced.dts   |  24 +
+ 13 files changed, 1289 insertions(+), 1 deletion(-)
  create mode 100644 arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
  create mode 100644 arch/arm/dts/k3-am65-iot2050-common-pg1.dtsi
  create mode 100644 arch/arm/dts/k3-am65-iot2050-common-pg2.dtsi
@@ -245,7 +245,7 @@ index 0000000000..5d18401f9f
 +};
 diff --git a/arch/arm/dts/k3-am65-iot2050-common-pg2.dtsi b/arch/arm/dts/k3-am65-iot2050-common-pg2.dtsi
 new file mode 100644
-index 0000000000..2323628b04
+index 0000000000..c25bce7339
 --- /dev/null
 +++ b/arch/arm/dts/k3-am65-iot2050-common-pg2.dtsi
 @@ -0,0 +1,51 @@
@@ -261,7 +261,7 @@ index 0000000000..2323628b04
 + */
 +
 +&main_pmx0 {
-+	cp2102n_reset_pin_default: cp2102n_reset_pin_default {
++	cp2102n_reset_pin_default: cp2102n-reset-pin-default {
 +		pinctrl-single,pins = <
 +			/* (AF12) GPIO1_24, used as cp2102 reset */
 +			AM65X_IOPAD(0x01e0, PIN_OUTPUT, 7)
@@ -407,10 +407,10 @@ index 0000000000..88c36fcf43
 +};
 diff --git a/arch/arm/dts/k3-am65-iot2050-common.dtsi b/arch/arm/dts/k3-am65-iot2050-common.dtsi
 new file mode 100644
-index 0000000000..bfef3e044c
+index 0000000000..c28c440b8e
 --- /dev/null
 +++ b/arch/arm/dts/k3-am65-iot2050-common.dtsi
-@@ -0,0 +1,699 @@
+@@ -0,0 +1,721 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (c) Siemens AG, 2018-2021
@@ -1064,11 +1064,21 @@ index 0000000000..bfef3e044c
 +};
 +
 +&mailbox0_cluster0 {
-+	status = "disabled";
++	interrupts = <436>;
++
++	mbox_mcu_r5fss0_core0: mbox-mcu-r5fss0-core0 {
++		ti,mbox-tx = <1 0 0>;
++		ti,mbox-rx = <0 0 0>;
++	};
 +};
 +
 +&mailbox0_cluster1 {
-+	status = "disabled";
++	interrupts = <432>;
++
++	mbox_mcu_r5fss0_core1: mbox-mcu-r5fss0-core1 {
++		ti,mbox-tx = <1 0 0>;
++		ti,mbox-rx = <0 0 0>;
++	};
 +};
 +
 +&mailbox0_cluster2 {
@@ -1109,6 +1119,18 @@ index 0000000000..bfef3e044c
 +
 +&mailbox0_cluster11 {
 +	status = "disabled";
++};
++
++&mcu_r5fss0_core0 {
++	memory-region = <&mcu_r5fss0_core0_dma_memory_region>,
++			<&mcu_r5fss0_core0_memory_region>;
++	mboxes = <&mailbox0_cluster0 &mbox_mcu_r5fss0_core0>;
++};
++
++&mcu_r5fss0_core1 {
++	memory-region = <&mcu_r5fss0_core1_dma_memory_region>,
++			<&mcu_r5fss0_core1_memory_region>;
++	mboxes = <&mailbox0_cluster1 &mbox_mcu_r5fss0_core1>;
 +};
 diff --git a/arch/arm/dts/k3-am65-iot2050-spl.dts b/arch/arm/dts/k3-am65-iot2050-spl.dts
 new file mode 100644
@@ -1204,10 +1226,10 @@ index 0000000000..0d215b4d66
 +};
 diff --git a/arch/arm/dts/k3-am6528-iot2050-basic-pg2.dts b/arch/arm/dts/k3-am6528-iot2050-basic-pg2.dts
 new file mode 100644
-index 0000000000..5ce609dd49
+index 0000000000..c62549a4b4
 --- /dev/null
 +++ b/arch/arm/dts/k3-am6528-iot2050-basic-pg2.dts
-@@ -0,0 +1,21 @@
+@@ -0,0 +1,24 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (c) Siemens AG, 2018-2021
@@ -1218,6 +1240,9 @@ index 0000000000..5ce609dd49
 + *
 + * AM6528-based (dual-core) IOT2050 Basic variant, Product Generation 2
 + * 1 GB RAM, no eMMC, main_uart0 on connector X30
++ *
++ * Product homepage:
++ * https://new.siemens.com/global/en/products/automation/pc-based/iot-gateways/simatic-iot2050.html
 + */
 +
 +/dts-v1/;
@@ -1231,10 +1256,10 @@ index 0000000000..5ce609dd49
 +};
 diff --git a/arch/arm/dts/k3-am6528-iot2050-basic.dts b/arch/arm/dts/k3-am6528-iot2050-basic.dts
 new file mode 100644
-index 0000000000..368a25d449
+index 0000000000..87928ff282
 --- /dev/null
 +++ b/arch/arm/dts/k3-am6528-iot2050-basic.dts
-@@ -0,0 +1,21 @@
+@@ -0,0 +1,24 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (c) Siemens AG, 2018-2021
@@ -1245,6 +1270,9 @@ index 0000000000..368a25d449
 + *
 + * AM6528-based (dual-core) IOT2050 Basic variant, Product Generation 1
 + * 1 GB RAM, no eMMC, main_uart0 on connector X30
++ *
++ * Product homepage:
++ * https://new.siemens.com/global/en/products/automation/pc-based/iot-gateways/simatic-iot2050.html
 + */
 +
 +/dts-v1/;
@@ -1323,10 +1351,10 @@ index 0000000000..816a4cb4a6
 +};
 diff --git a/arch/arm/dts/k3-am6548-iot2050-advanced-pg2.dts b/arch/arm/dts/k3-am6548-iot2050-advanced-pg2.dts
 new file mode 100644
-index 0000000000..066390616b
+index 0000000000..f00dc86d01
 --- /dev/null
 +++ b/arch/arm/dts/k3-am6548-iot2050-advanced-pg2.dts
-@@ -0,0 +1,26 @@
+@@ -0,0 +1,29 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (c) Siemens AG, 2018-2021
@@ -1337,6 +1365,9 @@ index 0000000000..066390616b
 + *
 + * AM6548-based (quad-core) IOT2050 Advanced variant, Product Generation 2
 + * 2 GB RAM, 16 GB eMMC, USB-serial converter on connector X30
++ *
++ * Product homepage:
++ * https://new.siemens.com/global/en/products/automation/pc-based/iot-gateways/simatic-iot2050.html
 + */
 +
 +/dts-v1/;
@@ -1355,10 +1386,10 @@ index 0000000000..066390616b
 +};
 diff --git a/arch/arm/dts/k3-am6548-iot2050-advanced.dts b/arch/arm/dts/k3-am6548-iot2050-advanced.dts
 new file mode 100644
-index 0000000000..7ee5e4942c
+index 0000000000..077f165bdc
 --- /dev/null
 +++ b/arch/arm/dts/k3-am6548-iot2050-advanced.dts
-@@ -0,0 +1,21 @@
+@@ -0,0 +1,24 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (c) Siemens AG, 2018-2021
@@ -1369,6 +1400,9 @@ index 0000000000..7ee5e4942c
 + *
 + * AM6548-based (quad-core) IOT2050 Advanced variant, Product Generation 1
 + * 2 GB RAM, 16 GB eMMC, USB-serial converter on connector X30
++ *
++ * Product homepage:
++ * https://new.siemens.com/global/en/products/automation/pc-based/iot-gateways/simatic-iot2050.html
 + */
 +
 +/dts-v1/;

--- a/recipes-bsp/u-boot/files/0003-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
+++ b/recipes-bsp/u-boot/files/0003-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
@@ -1,4 +1,4 @@
-From fa3ba2612198610ed008354227adca643766846e Mon Sep 17 00:00:00 2001
+From 073c027d0e87d87b36ed3fd4719bfa18a1bd5bfb Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 11 May 2020 20:10:16 +0200
 Subject: [PATCH 3/8] board: siemens: Add support for SIMATIC IOT2050 devices
@@ -24,14 +24,14 @@ Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
  board/siemens/iot2050/Kconfig     |  32 ++++
  board/siemens/iot2050/MAINTAINERS |   9 +
  board/siemens/iot2050/Makefile    |  10 ++
- board/siemens/iot2050/board.c     | 284 ++++++++++++++++++++++++++++++
+ board/siemens/iot2050/board.c     | 272 ++++++++++++++++++++++++++++++
  board/siemens/iot2050/config.mk   |   8 +
- configs/iot2050_defconfig         | 137 ++++++++++++++
+ configs/iot2050_defconfig         | 136 +++++++++++++++
  doc/board/index.rst               |   1 +
  doc/board/siemens/index.rst       |   9 +
- doc/board/siemens/iot2050.rst     |  78 ++++++++
+ doc/board/siemens/iot2050.rst     |  78 +++++++++
  include/configs/iot2050.h         |  62 +++++++
- 11 files changed, 631 insertions(+)
+ 11 files changed, 618 insertions(+)
  create mode 100644 board/siemens/iot2050/Kconfig
  create mode 100644 board/siemens/iot2050/MAINTAINERS
  create mode 100644 board/siemens/iot2050/Makefile
@@ -123,10 +123,10 @@ index 0000000000..619594ab8e
 +obj-y += board.o
 diff --git a/board/siemens/iot2050/board.c b/board/siemens/iot2050/board.c
 new file mode 100644
-index 0000000000..07e7370d08
+index 0000000000..b2110978ae
 --- /dev/null
 +++ b/board/siemens/iot2050/board.c
-@@ -0,0 +1,284 @@
+@@ -0,0 +1,272 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Board specific initialization for IOT2050
@@ -226,6 +226,16 @@ index 0000000000..07e7370d08
 +	env_set("board_a5e", info->a5e);
 +	env_set("fw_version", PLAIN_VERSION);
 +	env_set("seboot_version", info->seboot_version);
++
++	if (IS_ENABLED(CONFIG_NET)) {
++		/* set MAC addresses to ensure forwarding to the OS */
++		for (mac_cnt = 0; mac_cnt < info->mac_addr_cnt; mac_cnt++) {
++			if (is_valid_ethaddr(info->mac_addr[mac_cnt]))
++				eth_env_set_enetaddr_by_index("eth",
++							      mac_cnt + 1,
++							      info->mac_addr[mac_cnt]);
++		}
++	}
 +
 +	if (board_is_advanced()) {
 +		if (board_is_sr1())
@@ -369,28 +379,6 @@ index 0000000000..07e7370d08
 +{
 +}
 +
-+/* RJ45 LED configuration */
-+#define DP83867_DEVADDR			0x1f
-+
-+#define DP83867_LEDCR_1			0x0018
-+
-+#define DP83867_LED_1000_BT_LINK	0x5
-+#define DP83867_LED_100_BTX_LINK	0x6
-+#define DP83867_LED_LINK_BLINK_ACTIVE	0xb
-+#define DP83867_LED_SET(n, v)		((v) << ((n) * 4))
-+
-+#define DP83867_LED_SETTINGS \
-+	(DP83867_LED_SET(0, DP83867_LED_LINK_BLINK_ACTIVE) | \
-+	 DP83867_LED_SET(1, DP83867_LED_1000_BT_LINK) | \
-+	 DP83867_LED_SET(2, DP83867_LED_100_BTX_LINK) | \
-+	 DP83867_LED_SET(3, DP83867_LED_100_BTX_LINK))
-+
-+int board_phy_config(struct phy_device *phydev)
-+{
-+	return phy_write_mmd(phydev, DP83867_DEVADDR, DP83867_LEDCR_1,
-+			     DP83867_LED_SETTINGS);
-+}
-+
 +#if CONFIG_IS_ENABLED(LED) && CONFIG_IS_ENABLED(BOOTSTAGE)
 +/*
 + * Indicate any error or (accidental?) entering of CLI via the red status LED.
@@ -427,10 +415,10 @@ index 0000000000..267ec76c4e
 +flash.bin: all
 diff --git a/configs/iot2050_defconfig b/configs/iot2050_defconfig
 new file mode 100644
-index 0000000000..4bc6fa63e2
+index 0000000000..82a8a48ee0
 --- /dev/null
 +++ b/configs/iot2050_defconfig
-@@ -0,0 +1,137 @@
+@@ -0,0 +1,136 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_K3=y
 +CONFIG_SPL_GPIO_SUPPORT=y
@@ -484,7 +472,6 @@ index 0000000000..4bc6fa63e2
 +CONFIG_CMD_REMOTEPROC=y
 +CONFIG_CMD_USB=y
 +# CONFIG_CMD_SETEXPR is not set
-+# CONFIG_CMD_NET is not set
 +CONFIG_CMD_TIME=y
 +# CONFIG_ISO_PARTITION is not set
 +CONFIG_OF_CONTROL=y

--- a/recipes-bsp/u-boot/files/0004-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
+++ b/recipes-bsp/u-boot/files/0004-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
@@ -1,4 +1,4 @@
-From 27a7fdfb81c4348d5457a5d55bd7369154c75274 Mon Sep 17 00:00:00 2001
+From 049155b02be5ff9fcb65d617c42273fdf6cb0f35 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 27 Jun 2020 07:58:01 +0200
 Subject: [PATCH 4/8] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry

--- a/recipes-bsp/u-boot/files/0005-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
+++ b/recipes-bsp/u-boot/files/0005-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
@@ -1,4 +1,4 @@
-From 41c8877104f451c3b5e2019c5b57faba0f89d20c Mon Sep 17 00:00:00 2001
+From 1d4a3aa8419e3de467b0cccf5efcc563a0c7a2f0 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 21 Jun 2020 09:04:30 +0200
 Subject: [PATCH 5/8] watchdog: rti_wdt: Add support for loading firmware

--- a/recipes-bsp/u-boot/files/0006-watchdog-Allow-to-use-CONFIG_WDT-without-starting-wa.patch
+++ b/recipes-bsp/u-boot/files/0006-watchdog-Allow-to-use-CONFIG_WDT-without-starting-wa.patch
@@ -1,4 +1,4 @@
-From 4c6d980059525ed26cca2b08681ea069015231e6 Mon Sep 17 00:00:00 2001
+From 6f43edea2ec02b39b92453bc012e82c4c327782e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
 Date: Tue, 9 Mar 2021 14:26:56 +0100
 Subject: [PATCH 6/8] watchdog: Allow to use CONFIG_WDT without starting

--- a/recipes-bsp/u-boot/files/0007-iot2050-Enable-watchdog-support-but-do-not-auto-star.patch
+++ b/recipes-bsp/u-boot/files/0007-iot2050-Enable-watchdog-support-but-do-not-auto-star.patch
@@ -1,4 +1,4 @@
-From 2bab35be7fe49e99341f6addbc290702aa4becbc Mon Sep 17 00:00:00 2001
+From 127ad94ae5665d87cb6def61cb59335287b630fa Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 19 Jun 2020 08:56:35 +0200
 Subject: [PATCH 7/8] iot2050: Enable watchdog support, but do not auto-start
@@ -9,32 +9,36 @@ that the OS has to support it as well.
 
 Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
 ---
- arch/arm/dts/k3-am65-iot2050-boot-image.dtsi | 22 ++++++++++++++++++++
- configs/iot2050_defconfig                    |  6 ++++++
- 2 files changed, 28 insertions(+)
+ arch/arm/dts/k3-am65-iot2050-boot-image.dtsi | 25 ++++++++++++++++++++
+ configs/iot2050_defconfig                    |  6 +++++
+ tools/binman/missing-blob-help               |  5 ++++
+ 3 files changed, 36 insertions(+)
 
 diff --git a/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi b/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
-index 1e02cece6c..a6ccac04de 100644
+index 1e02cece6c..69479d7b18 100644
 --- a/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
 +++ b/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
-@@ -80,6 +80,16 @@
+@@ -80,6 +80,19 @@
  						filename = "arch/arm/dts/k3-am6548-iot2050-advanced-pg2.dtb";
  					};
  				};
 +
 +#ifdef CONFIG_WDT_K3_RTI_FW_FILE
 +				k3-rti-wdt-firmware {
-+					type = "blob";
++					type = "firmware";
 +					load = <0x82000000>;
-+					blob {
++					arch = "arm";
++					compression = "none";
++					blob-ext {
 +						filename = CONFIG_WDT_K3_RTI_FW_FILE;
++						missing-msg = "k3-rti-wdt-firmware";
 +					};
 +				};
 +#endif
  			};
  
  			configurations {
-@@ -89,24 +99,36 @@
+@@ -89,24 +102,36 @@
  					description = "iot2050-basic";
  					firmware = "u-boot";
  					fdt = "fdt-iot2050-basic";
@@ -72,7 +76,7 @@ index 1e02cece6c..a6ccac04de 100644
  			};
  		};
 diff --git a/configs/iot2050_defconfig b/configs/iot2050_defconfig
-index 4bc6fa63e2..9dfbdd4a7f 100644
+index 82a8a48ee0..ffbce3264d 100644
 --- a/configs/iot2050_defconfig
 +++ b/configs/iot2050_defconfig
 @@ -50,6 +50,7 @@ CONFIG_CMD_MMC=y
@@ -81,9 +85,9 @@ index 4bc6fa63e2..9dfbdd4a7f 100644
  CONFIG_CMD_USB=y
 +CONFIG_CMD_WDT=y
  # CONFIG_CMD_SETEXPR is not set
- # CONFIG_CMD_NET is not set
  CONFIG_CMD_TIME=y
-@@ -134,4 +135,9 @@ CONFIG_USB_XHCI_DWC3=y
+ # CONFIG_ISO_PARTITION is not set
+@@ -133,4 +134,9 @@ CONFIG_USB_XHCI_DWC3=y
  CONFIG_USB_DWC3=y
  CONFIG_USB_DWC3_GENERIC=y
  CONFIG_USB_KEYBOARD=y
@@ -93,6 +97,19 @@ index 4bc6fa63e2..9dfbdd4a7f 100644
 +CONFIG_WDT_K3_RTI=y
 +CONFIG_WDT_K3_RTI_LOAD_FW=y
  CONFIG_OF_LIBFDT_OVERLAY=y
+diff --git a/tools/binman/missing-blob-help b/tools/binman/missing-blob-help
+index f7bc80ea83..dc2d9c9811 100644
+--- a/tools/binman/missing-blob-help
++++ b/tools/binman/missing-blob-help
+@@ -17,3 +17,8 @@ board/sunxi/README.sunxi64
+ scp-sunxi:
+ SCP firmware is required for system suspend, but is otherwise optional.
+ Please read the section on SCP firmware in board/sunxi/README.sunxi64
++
++k3-rti-wdt-firmware:
++If CONFIG_WDT_K3_RTI_LOAD_FW is enabled, a firmware image is needed for
++the R5F core(s) to trigger the system reset. One possible source is
++https://github.com/siemens/k3-rti-wdt.
 -- 
 2.31.1
 

--- a/recipes-bsp/u-boot/files/0008-sf-Querying-write-protect-status-before-operating-th.patch
+++ b/recipes-bsp/u-boot/files/0008-sf-Querying-write-protect-status-before-operating-th.patch
@@ -1,4 +1,4 @@
-From 69c91ee960fcb5c543c37c1ecf210209f0a1e7cc Mon Sep 17 00:00:00 2001
+From 53678fa87a34d25272d5fe19a21397cf0d39afe6 Mon Sep 17 00:00:00 2001
 From: Chao Zeng <chao.zeng@siemens.com>
 Date: Tue, 22 Jun 2021 13:21:26 +0800
 Subject: [PATCH 8/8] sf: Querying write-protect status before operating the

--- a/recipes-kernel/linux/linux-iot2050-rt_5.10.59-rt52.bb
+++ b/recipes-kernel/linux/linux-iot2050-rt_5.10.59-rt52.bb
@@ -13,7 +13,7 @@ KERNEL_SOURCE = "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-${KERNEL_BAS
 SRC_URI[sha256sum] = "333cadc15f23e2060bb9701dbd9c23cfb196c528cded797329a0c369c2b6ea80"
 
 SRC_URI += " \
-    https://mirrors.edge.kernel.org/pub/linux/kernel/projects/rt/5.10/patch-${PV}.patch.xz;sha256sum=bdf17a434c40f21f69cd60028e36347ebdbad76359e98ae8c6c9de2b6df8c644 \
+    https://mirrors.edge.kernel.org/pub/linux/kernel/projects/rt/5.10/older/patch-${PV}.patch.xz;sha256sum=bdf17a434c40f21f69cd60028e36347ebdbad76359e98ae8c6c9de2b6df8c644 \
     file://iot2050-rt.cfg"
 
 S = "${WORKDIR}/linux-${KERNEL_BASE_VER}"


### PR DESCRIPTION
This primarily fixes forwarding of the MAC addresses from the info
structure to the Linux device tree. It furthermore aligns the DT with
the upstream pending version and removes code that is dead until prueth
support is (re-)added.
