### PR TITLE
u-boot: dts : remove usb3.0 related dts configurations

### DIFF
--- a/recipes-bsp/u-boot/files/0001-arm-mach-k3-am6_init-Prioritize-MSMC-traffic-over-DD.patch
+++ b/recipes-bsp/u-boot/files/0001-arm-mach-k3-am6_init-Prioritize-MSMC-traffic-over-DD.patch
@@ -1,7 +1,7 @@
-From 1438d1bfbdd163f29db3c1d1c0e0c1a075896b1c Mon Sep 17 00:00:00 2001
+From 5014cee42c56acf22a8a008c52e23836658775a6 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Wed, 8 Sep 2021 22:28:59 +0200
-Subject: [PATCH 1/8] arm: mach-k3: am6_init: Prioritize MSMC traffic over DDR
+Subject: [PATCH 1/9] arm: mach-k3: am6_init: Prioritize MSMC traffic over DDR
  in NAVSS Northbridge
 
 NB0 is bridge to SRAM and NB1 is bridge to DDR.
@@ -87,5 +87,5 @@ index 1908a13f0f..f533e22e06 100644
 +
  #endif /* __ASM_ARCH_AM6_HARDWARE_H */
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-bsp/u-boot/files/0002-arm-dts-Add-IOT2050-device-tree-files.patch
+++ b/recipes-bsp/u-boot/files/0002-arm-dts-Add-IOT2050-device-tree-files.patch
@@ -1,7 +1,7 @@
-From 6685cfd1b25dd18458dfb085d3ee7b7908df4c53 Mon Sep 17 00:00:00 2001
+From 28e23b9eae2df249ee7cd6ca5a42e94ba3066a9a Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 30 Nov 2020 10:13:04 +0100
-Subject: [PATCH 2/8] arm: dts: Add IOT2050 device tree files
+Subject: [PATCH 2/9] arm: dts: Add IOT2050 device tree files
 
 Prepares for the addition of the IOT2050 board which is based on the TI
 AM65x. The board comes in four variants, Basic and Advanced, each as
@@ -1415,5 +1415,5 @@ index 0000000000..077f165bdc
 +	model = "SIMATIC IOT2050 Advanced";
 +};
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-bsp/u-boot/files/0003-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
+++ b/recipes-bsp/u-boot/files/0003-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
@@ -1,7 +1,7 @@
-From 073c027d0e87d87b36ed3fd4719bfa18a1bd5bfb Mon Sep 17 00:00:00 2001
+From eb53e38ed17dc7473a31ba39741069043796af05 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 11 May 2020 20:10:16 +0200
-Subject: [PATCH 3/8] board: siemens: Add support for SIMATIC IOT2050 devices
+Subject: [PATCH 3/9] board: siemens: Add support for SIMATIC IOT2050 devices
 
 This adds support for the IOT2050 Basic and Advanced devices. The Basic
 used the dual-core AM6528 GP processor, the Advanced one the AM6548 HS
@@ -735,5 +735,5 @@ index 0000000000..ddb4cfcc8e
 +
 +#endif /* __CONFIG_IOT2050_H */
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-bsp/u-boot/files/0004-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
+++ b/recipes-bsp/u-boot/files/0004-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
@@ -1,7 +1,7 @@
-From 049155b02be5ff9fcb65d617c42273fdf6cb0f35 Mon Sep 17 00:00:00 2001
+From bafadb0c2cf426e24b0b3fd92f4cb26e725536e6 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 27 Jun 2020 07:58:01 +0200
-Subject: [PATCH 4/8] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
+Subject: [PATCH 4/9] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
 
 Add the DT entry for a watchdog based on RTI1. It requires additional
 firmware on the MCU R5F cores to handle the expiry, e.g.
@@ -35,5 +35,5 @@ index 7454c8cec0..903796bf7d 100644
 +	};
  };
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-bsp/u-boot/files/0005-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
+++ b/recipes-bsp/u-boot/files/0005-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
@@ -1,7 +1,7 @@
-From 1d4a3aa8419e3de467b0cccf5efcc563a0c7a2f0 Mon Sep 17 00:00:00 2001
+From dfbd667386edf27c86c53f39c103d6951ed76c7b Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 21 Jun 2020 09:04:30 +0200
-Subject: [PATCH 5/8] watchdog: rti_wdt: Add support for loading firmware
+Subject: [PATCH 5/9] watchdog: rti_wdt: Add support for loading firmware
 
 To avoid the need of extra boot scripting on AM65x for loading a
 watchdog firmware, add the required rproc init and loading logic for the
@@ -170,5 +170,5 @@ index 8335b20ae8..253286d349 100644
  	timer_margin >>= WDT_PRELOAD_SHIFT;
  	if (timer_margin > WDT_PRELOAD_MAX)
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-bsp/u-boot/files/0006-watchdog-Allow-to-use-CONFIG_WDT-without-starting-wa.patch
+++ b/recipes-bsp/u-boot/files/0006-watchdog-Allow-to-use-CONFIG_WDT-without-starting-wa.patch
@@ -1,7 +1,7 @@
-From 6f43edea2ec02b39b92453bc012e82c4c327782e Mon Sep 17 00:00:00 2001
+From 0c2bb1f89117c59f68e91d99b56d89ffd2a376b1 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
 Date: Tue, 9 Mar 2021 14:26:56 +0100
-Subject: [PATCH 6/8] watchdog: Allow to use CONFIG_WDT without starting
+Subject: [PATCH 6/9] watchdog: Allow to use CONFIG_WDT without starting
  watchdog
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -68,5 +68,5 @@ index 28f7918c46..01e5fa47e8 100644
  	gd->flags |= GD_FLG_WDT_READY;
  	printf("WDT:   Started with%s servicing (%ds timeout)\n",
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-bsp/u-boot/files/0007-iot2050-Enable-watchdog-support-but-do-not-auto-star.patch
+++ b/recipes-bsp/u-boot/files/0007-iot2050-Enable-watchdog-support-but-do-not-auto-star.patch
@@ -1,7 +1,7 @@
-From 127ad94ae5665d87cb6def61cb59335287b630fa Mon Sep 17 00:00:00 2001
+From 88dc18b97e06f2ec88c5f4f9d6ef03baa257211a Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 19 Jun 2020 08:56:35 +0200
-Subject: [PATCH 7/8] iot2050: Enable watchdog support, but do not auto-start
+Subject: [PATCH 7/9] iot2050: Enable watchdog support, but do not auto-start
  it
 
 This allows to use the watchdog in custom scripts but does not enforce
@@ -111,5 +111,5 @@ index f7bc80ea83..dc2d9c9811 100644
 +the R5F core(s) to trigger the system reset. One possible source is
 +https://github.com/siemens/k3-rti-wdt.
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-bsp/u-boot/files/0008-sf-Querying-write-protect-status-before-operating-th.patch
+++ b/recipes-bsp/u-boot/files/0008-sf-Querying-write-protect-status-before-operating-th.patch
@@ -1,7 +1,7 @@
-From 53678fa87a34d25272d5fe19a21397cf0d39afe6 Mon Sep 17 00:00:00 2001
+From 7222c036ffe4ccc6d07f69b1ee676666b39d7552 Mon Sep 17 00:00:00 2001
 From: Chao Zeng <chao.zeng@siemens.com>
 Date: Tue, 22 Jun 2021 13:21:26 +0800
-Subject: [PATCH 8/8] sf: Querying write-protect status before operating the
+Subject: [PATCH 8/9] sf: Querying write-protect status before operating the
  flash
 
 When operating the write-protection flash,spi_flash_std_write() and
@@ -45,5 +45,5 @@ index 6c87434867..29b465b296 100644
  }
  
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-bsp/u-boot/files/0009-u-boot-dts-remove-usb3.0-related-dts-configurations.patch
+++ b/recipes-bsp/u-boot/files/0009-u-boot-dts-remove-usb3.0-related-dts-configurations.patch
@@ -1,0 +1,78 @@
+From b736741e8b5db849b9c698a8bbdd2f3a3549c714 Mon Sep 17 00:00:00 2001
+From: chao zeng <chao.zeng@siemens.com>
+Date: Fri, 24 Sep 2021 11:50:29 +0800
+Subject: [PATCH 9/9] u-boot: dts : remove usb3.0 related dts configurations
+
+This is a known issue that usb3.0 can not work under u-boot.
+The usb3.0 port can only work at usb2.0 mode. So remove the usb3.0
+related dts configurations,and disable the usb3.0 serdes signal.
+
+These modification should be removed when the usb3.0 is ready under u-boot
+
+Signed-off-by: chao zeng <chao.zeng@siemens.com>
+---
+ arch/arm/dts/k3-am65-iot2050-u-boot-pg2.dtsi  | 26 +++++++++++++++++++
+ arch/arm/dts/k3-am6528-iot2050-basic-pg2.dts  |  1 +
+ .../dts/k3-am6548-iot2050-advanced-pg2.dts    |  1 +
+ 3 files changed, 28 insertions(+)
+ create mode 100644 arch/arm/dts/k3-am65-iot2050-u-boot-pg2.dtsi
+
+diff --git a/arch/arm/dts/k3-am65-iot2050-u-boot-pg2.dtsi b/arch/arm/dts/k3-am65-iot2050-u-boot-pg2.dtsi
+new file mode 100644
+index 0000000000..76d95b38c4
+--- /dev/null
++++ b/arch/arm/dts/k3-am65-iot2050-u-boot-pg2.dtsi
+@@ -0,0 +1,26 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (c) Siemens AG, 2018-2021
++ *
++ * Authors:
++ *   Chao Zeng <chao.zeng@siemens.com>
++ *
++ * U-Boot bits of the IOT2050 Advanced PG2 variants
++ */
++
++&serdes0 {
++	status = "disabled";
++};
++
++&dwc3_0 {
++	assigned-clock-parents = <&k3_clks 151 4>,	/* set REF_CLK to 20MHz i.e. PER0_PLL/48 */
++					 <&k3_clks 151 9>;	/* set PIPE3_TXB_CLK to CLK_12M_RC/256 (for HS only) */
++	/delete-property/ phys;
++	/delete-property/ phy-names;
++};
++
++&usb0_phy {
++	maximum-speed = "high-speed";
++	/delete-property/ snps,dis-u1-entry-quirk;
++	/delete-property/ snps,dis-u2-entry-quirk;
++};
+diff --git a/arch/arm/dts/k3-am6528-iot2050-basic-pg2.dts b/arch/arm/dts/k3-am6528-iot2050-basic-pg2.dts
+index c62549a4b4..95b21ce959 100644
+--- a/arch/arm/dts/k3-am6528-iot2050-basic-pg2.dts
++++ b/arch/arm/dts/k3-am6528-iot2050-basic-pg2.dts
+@@ -17,6 +17,7 @@
+ 
+ #include "k3-am6528-iot2050-basic-common.dtsi"
+ #include "k3-am65-iot2050-common-pg2.dtsi"
++#include "k3-am65-iot2050-u-boot-pg2.dtsi"
+ 
+ / {
+ 	compatible = "siemens,iot2050-basic-pg2", "ti,am654";
+diff --git a/arch/arm/dts/k3-am6548-iot2050-advanced-pg2.dts b/arch/arm/dts/k3-am6548-iot2050-advanced-pg2.dts
+index f00dc86d01..1420ba1041 100644
+--- a/arch/arm/dts/k3-am6548-iot2050-advanced-pg2.dts
++++ b/arch/arm/dts/k3-am6548-iot2050-advanced-pg2.dts
+@@ -17,6 +17,7 @@
+ 
+ #include "k3-am6548-iot2050-advanced-common.dtsi"
+ #include "k3-am65-iot2050-common-pg2.dtsi"
++#include "k3-am65-iot2050-u-boot-pg2.dtsi"
+ 
+ / {
+ 	compatible = "siemens,iot2050-advanced-pg2", "ti,am654";
+-- 
+2.32.0
+

--- a/recipes-bsp/u-boot/u-boot-iot2050_2021.04.bb
+++ b/recipes-bsp/u-boot/u-boot-iot2050_2021.04.bb
@@ -20,6 +20,7 @@ SRC_URI += " \
     file://0006-watchdog-Allow-to-use-CONFIG_WDT-without-starting-wa.patch \
     file://0007-iot2050-Enable-watchdog-support-but-do-not-auto-star.patch \
     file://0008-sf-Querying-write-protect-status-before-operating-th.patch \
+    file://0009-u-boot-dts-remove-usb3.0-related-dts-configurations.patch \
     "
 
 SRC_URI[sha256sum] = "0d438b1bb5cceb57a18ea2de4a0d51f7be5b05b98717df05938636e0aadfe11a"


### PR DESCRIPTION
This is a known issue that usb3.0 can not work under u-boot.
The usb3.0 port can only work at usb2.0 mode. So remove the usb3.0
related dts configurations,and disable the usb3.0 serdes signal.

Signed-off-by: Chao Zeng <chao.zeng@siemens.com>