### PR TITLE
linux-iot2050: Update patch queue to fix USB DT entry

### DIFF
--- a/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
@@ -1,4 +1,4 @@
-From da40c1cadf6dd6ae4b7baeefb5ee4bebe33b2485 Mon Sep 17 00:00:00 2001
+From 18aff536825cb030c6684e05a41ccab22d4832bc Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 21 Jun 2021 11:04:56 +0200
 Subject: [PATCH 049/104] arm64: dts: ti: iot2050: Add support for product
@@ -37,7 +37,7 @@ index 22108491f16e..e8a07d411627 100644
  
 diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050-common-pg2.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050-common-pg2.dtsi
 new file mode 100644
-index 000000000000..2323628b0444
+index 000000000000..e73458ca6900
 --- /dev/null
 +++ b/arch/arm64/boot/dts/ti/k3-am65-iot2050-common-pg2.dtsi
 @@ -0,0 +1,51 @@
@@ -53,7 +53,7 @@ index 000000000000..2323628b0444
 + */
 +
 +&main_pmx0 {
-+	cp2102n_reset_pin_default: cp2102n_reset_pin_default {
++	cp2102n_reset_pin_default: cp2102n-reset-pin-default {
 +		pinctrl-single,pins = <
 +			/* (AF12) GPIO1_24, used as cp2102 reset */
 +			AM65X_IOPAD(0x01e0, PIN_OUTPUT, 7)
@@ -87,7 +87,7 @@ index 000000000000..2323628b0444
 +	phy-names = "usb3-phy";
 +};
 +
-+&usb0_phy {
++&usb0 {
 +	maximum-speed = "super-speed";
 +	snps,dis-u1-entry-quirk;
 +	snps,dis-u2-entry-quirk;

--- a/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
@@ -1,4 +1,4 @@
-From 33d69881d3fb0e277395f1dfefa4ef0344d242ed Mon Sep 17 00:00:00 2001
+From d015fec92e923f9c2f5d06b89a5150932110b5b3 Mon Sep 17 00:00:00 2001
 From: Tomi Valkeinen <tomi.valkeinen@ti.com>
 Date: Mon, 31 May 2021 16:31:35 +0530
 Subject: [PATCH 050/104] arm64: dts: ti: k3-am65-main: fix DSS irq trigger

--- a/recipes-kernel/linux/files/patches-5.10/0051-irqdomain-Export-of_phandle_args_to_fwspec.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0051-irqdomain-Export-of_phandle_args_to_fwspec.patch
@@ -1,4 +1,4 @@
-From 28dd3636604b696b47d21d4b1be95b2cc12f4c9d Mon Sep 17 00:00:00 2001
+From e2e14f439f530b49f6aba20dd4b23d45e6af336b Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:46 +0530
 Subject: [PATCH 051/104] irqdomain: Export of_phandle_args_to_fwspec()

--- a/recipes-kernel/linux/files/patches-5.10/0052-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0052-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
@@ -1,4 +1,4 @@
-From 04c871cbf7cbd59535ebd00fcf25a932ba4f03de Mon Sep 17 00:00:00 2001
+From 3ae60cd248a02fa9f2a1aed6e544fdebc585abfe Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:47 +0530
 Subject: [PATCH 052/104] PCI: keystone: Convert to using hierarchy domain for

--- a/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
@@ -1,4 +1,4 @@
-From 58c2bab2ea4abe8545ef1224dc794b4b3dc7a898 Mon Sep 17 00:00:00 2001
+From 6fbb01738fb415801007e25e6962e8c965f90580 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:48 +0530
 Subject: [PATCH 053/104] PCI: keystone: Add PCI legacy interrupt support for

--- a/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
@@ -1,4 +1,4 @@
-From fd456433e2baf5e3a08ffe3e5ed4f502852d631e Mon Sep 17 00:00:00 2001
+From a42300009644e3549472ca14648b07ecfed243cf Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:49 +0530
 Subject: [PATCH 054/104] PCI: keystone: Add workaround for Errata #i2037

--- a/recipes-kernel/linux/files/patches-5.10/0055-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0055-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
@@ -1,4 +1,4 @@
-From 552c4e9ad10298a89788308c4608af11ec0147a0 Mon Sep 17 00:00:00 2001
+From af16fed3807c9be3777284270ceed919d65ebf25 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:38:07 +0530
 Subject: [PATCH 055/104] arm64: dts: ti: k3-am65-main: Add properties to

--- a/recipes-kernel/linux/files/patches-5.10/0056-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0056-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
@@ -1,4 +1,4 @@
-From 459243d9de2157832ef6dc1299b5e74eed71f93b Mon Sep 17 00:00:00 2001
+From 0ee4d816ac51e946a4c2cf7d4ec8acb639f0b1a7 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 20 Nov 2020 21:01:54 -0600
 Subject: [PATCH 056/104] remoteproc: Fix unbalanced boot with sysfs for no

--- a/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Introduce-deny_sysfs_ops-flag.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Introduce-deny_sysfs_ops-flag.patch
@@ -1,4 +1,4 @@
-From 143dfa543c399ac80b6527145362808091796033 Mon Sep 17 00:00:00 2001
+From 9566b2e022f1cd74300ea8c7bdca737ec7b70485 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 13:05:28 -0500
 Subject: [PATCH 057/104] remoteproc: Introduce deny_sysfs_ops flag

--- a/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
@@ -1,4 +1,4 @@
-From 004e270e87b86c6c0a6baa796a85b9eed4995670 Mon Sep 17 00:00:00 2001
+From 8fa387356193dd3f8dcd96889962d044e711ceb2 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:32:29 -0500
 Subject: [PATCH 058/104] remoteproc: pru: Add APIs to get and put the PRU

--- a/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
@@ -1,4 +1,4 @@
-From a69fc2f933555e1c1193d607723fee59d544656e Mon Sep 17 00:00:00 2001
+From 4c88ce9f46c959ff426ca4137f8798d8b8b22f9f Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 16 Dec 2020 17:52:37 +0100
 Subject: [PATCH 059/104] remoteproc: pru: Deny rproc sysfs ops for PRU client

--- a/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
@@ -1,4 +1,4 @@
-From 012ca2186b2d53ef054262c302b57feece8dc3e5 Mon Sep 17 00:00:00 2001
+From 62255f5c519ecf01ac4cd4f76c1647884d2fadb4 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Fri, 26 Mar 2021 15:43:53 -0500
 Subject: [PATCH 060/104] remoteproc: pru: Add pru_rproc_set_ctable() function

--- a/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Configure-firmware-based-on-client-se.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Configure-firmware-based-on-client-se.patch
@@ -1,4 +1,4 @@
-From 47fbe25296c2aedd8984013ceddc224d9642b516 Mon Sep 17 00:00:00 2001
+From 3b6f5e3b257ee95ef065fd774ba01b4e21b1f474 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:50:14 -0500
 Subject: [PATCH 061/104] remoteproc: pru: Configure firmware based on client

--- a/recipes-kernel/linux/files/patches-5.10/0062-soc-ti-pruss-Add-pruss_get-put-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0062-soc-ti-pruss-Add-pruss_get-put-API.patch
@@ -1,4 +1,4 @@
-From 4453abfd5a3b492c3b05e4bb02ca123d78bf2ba7 Mon Sep 17 00:00:00 2001
+From 9fcfa8b94ca04ba0d7469776aa73064ffd9df7d2 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:58:00 -0500
 Subject: [PATCH 062/104] soc: ti: pruss: Add pruss_get()/put() API

--- a/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
@@ -1,4 +1,4 @@
-From fb3fea63574bba2c562eee7c28d71357a9545dc0 Mon Sep 17 00:00:00 2001
+From 801663d092c00ba746890bf1788392f4c4c3af7d Mon Sep 17 00:00:00 2001
 From: "Andrew F. Davis" <afd@ti.com>
 Date: Fri, 26 Mar 2021 16:11:42 -0500
 Subject: [PATCH 063/104] soc: ti: pruss: Add

--- a/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
@@ -1,4 +1,4 @@
-From bfce31c5fef1ef76a40e0bbed539ee11f6f888e6 Mon Sep 17 00:00:00 2001
+From ebe83c407096ff77435d0fabb727c5c422c76580 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:27:34 -0500
 Subject: [PATCH 064/104] soc: ti: pruss: Add pruss_cfg_read()/update() API

--- a/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
@@ -1,4 +1,4 @@
-From 1ca4e7aeeda0a765753352171e019e835dcb7279 Mon Sep 17 00:00:00 2001
+From f20835fa37b8ac3126bef948c5f9cba156dd7418 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 11 Dec 2020 19:48:09 +0100
 Subject: [PATCH 065/104] soc: ti: pruss: Add helper functions to set GPI mode,

--- a/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
@@ -1,4 +1,4 @@
-From c9cd11d8f6bd96802f279d796fced16613b6a86d Mon Sep 17 00:00:00 2001
+From d103d01f3ed58361c07b339d17573cfc87cb9031 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:38:11 -0500
 Subject: [PATCH 066/104] soc: ti: pruss: Add helper function to enable OCP

--- a/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
@@ -1,4 +1,4 @@
-From 46cce61506abe3dcc29bde4ea7b8b0a3dff61f8f Mon Sep 17 00:00:00 2001
+From 067a1552aec430e014f11b39e74cd0f615d86739 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 09:24:51 -0500
 Subject: [PATCH 067/104] soc: ti: pruss: Add helper functions to get/set

--- a/recipes-kernel/linux/files/patches-5.10/0068-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0068-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
@@ -1,4 +1,4 @@
-From 5cdccb2c5de3ef475f5c9f08f2f30f966c1efb0a Mon Sep 17 00:00:00 2001
+From 745c3882f3c86cae59b7c1ba69855bd02d00c82c Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 10:11:42 -0500
 Subject: [PATCH 068/104] remoteproc/pru: add support for configuring GPMUX

--- a/recipes-kernel/linux/files/patches-5.10/0069-net-ethernet-ti-prueth-Add-IEP-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0069-net-ethernet-ti-prueth-Add-IEP-driver.patch
@@ -1,4 +1,4 @@
-From 14969c5e3b51cff6b46bb0cea3ae42d1f028de46 Mon Sep 17 00:00:00 2001
+From 8f902858363f80034a21a89932139a42ad0bf0a2 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 20 Apr 2021 13:17:30 +0530
 Subject: [PATCH 069/104] net: ethernet: ti: prueth: Add IEP driver

--- a/recipes-kernel/linux/files/patches-5.10/0070-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0070-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
@@ -1,4 +1,4 @@
-From f93ae4b426527f9ae553c7a5f50a359c5ef8f65b Mon Sep 17 00:00:00 2001
+From 78ad4241b67421e67c38c1c187c26dbb73b514d1 Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Tue, 20 Apr 2021 13:17:31 +0530
 Subject: [PATCH 070/104] HACK: net: ethernet: ti: icss-iep: Fix sync0

--- a/recipes-kernel/linux/files/patches-5.10/0071-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0071-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
@@ -1,4 +1,4 @@
-From 212a300213a7f1e594f664ec9c1f39bca941e556 Mon Sep 17 00:00:00 2001
+From 60b572e25d8e35e8ef3742e423b0a0742d01455a Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:28 +0300
 Subject: [PATCH 071/104] net: ethernet: ti: icss_iep: drop

--- a/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
@@ -1,4 +1,4 @@
-From bb059dace1750ec025768c26e56f3747357913fd Mon Sep 17 00:00:00 2001
+From c74706ee3e3c437dbb884cfcdfc42106196f05ee Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:29 +0300
 Subject: [PATCH 072/104] net: ethernet: ti: icss_iep: fix access to x_REG1 in

--- a/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
@@ -1,4 +1,4 @@
-From 4324c1a9e08a4f9ba96c1fc24248a25c1ded842a Mon Sep 17 00:00:00 2001
+From 84642db14e786cd75b5e09cdc63b198b4106306a Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:30 +0300
 Subject: [PATCH 073/104] net: ethernet: ti: icss_iep: disable extts and pps if

--- a/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
@@ -1,4 +1,4 @@
-From 2833cd133e8f3e6a1b1a021e94d73e110384c80c Mon Sep 17 00:00:00 2001
+From 7ae3ddd4b61c073a33161d2c16793eab8416f17f Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:31 +0300
 Subject: [PATCH 074/104] net: ethernet: ti: icss_iep: fix pps irq race vs pps

--- a/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
@@ -1,4 +1,4 @@
-From 0ec103b2b148749483d765f9186dd21fe65ee8ba Mon Sep 17 00:00:00 2001
+From 0961dd65d33fd3cfd9c6af60e2ec609e46394abb Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:32 +0300
 Subject: [PATCH 075/104] net: ethernet: ti: icss_iep: improve icss_iep_gettime

--- a/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
@@ -1,4 +1,4 @@
-From 1a21bd419d4aa6fceef9438287e3e6f55ce0e13b Mon Sep 17 00:00:00 2001
+From 9bf5e97a7e8181388cf518a7a6af2d49c4b68805 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:33 +0300
 Subject: [PATCH 076/104] net: ethernet: ti: icss_iep: simplify peroutput

--- a/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
@@ -1,4 +1,4 @@
-From 863ec9f27fa24721a1fd5c2ecbea7f8b3cec59dc Mon Sep 17 00:00:00 2001
+From a71ee9b5c0fc7f7d8c461f4a38a1b7235dc0ccd9 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:34 +0300
 Subject: [PATCH 077/104] net: ethernet: ti: icss_iep: use readl/writel in

--- a/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
@@ -1,4 +1,4 @@
-From 7ad205d59096b9de7883cb02fe841db248506862 Mon Sep 17 00:00:00 2001
+From eb458f3b70173d21ff0151bc7e1e5c0d041aa06c Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:35 +0300
 Subject: [PATCH 078/104] net: ethernet: ti: icss_iep: switch to .gettimex64()

--- a/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
@@ -1,4 +1,4 @@
-From 5ba507a117684a93de7e294dc5b7608bc2f5a724 Mon Sep 17 00:00:00 2001
+From 8600a63674b05b345f2c5dac2e9e632f4d3bd9dd Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Thu, 29 Apr 2021 18:13:36 +0300
 Subject: [PATCH 079/104] net: ethernet: ti: icss_iep: Update compare registers

--- a/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
@@ -1,4 +1,4 @@
-From 9ab8cd572347222bf675f22b04585d7da68551c2 Mon Sep 17 00:00:00 2001
+From 32ea082d2e162b7a5ce913484bde9d4ed3031c87 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:37 +0300
 Subject: [PATCH 080/104] net: ethernet: ti: icss_iep: request cmp_cap irq from

--- a/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
@@ -1,4 +1,4 @@
-From cf670598c14f1f40c623a7c8c6b318237ad7f9d6 Mon Sep 17 00:00:00 2001
+From 0c4ae8ea3bb385129eaaf0c84ff05ca67f9f8f0c Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:38 +0300
 Subject: [PATCH 081/104] net: ethernet: ti: icss_iep: set phc time to system

--- a/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
@@ -1,4 +1,4 @@
-From ce0c55790d6e7429cdbbe52e68c5efff3027c0c8 Mon Sep 17 00:00:00 2001
+From ba0fb92955b85a0bf90d2ad73f9c0481adbc2e1f Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:39 +0300
 Subject: [PATCH 082/104] net: ethernet: ti: icss_iep: use

--- a/recipes-kernel/linux/files/patches-5.10/0083-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0083-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
@@ -1,4 +1,4 @@
-From 4b3621c113c6f473e0533e7a9188bbc562234f60 Mon Sep 17 00:00:00 2001
+From 043a134d8d46f1bd497db5e114d0bbe326e46378 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 16 Mar 2021 18:00:25 -0500
 Subject: [PATCH 083/104] arm64: dts: ti: k3-am65-main: Add ICSSG IEP nodes

--- a/recipes-kernel/linux/files/patches-5.10/0084-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0084-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
@@ -1,4 +1,4 @@
-From ce9fbe2f108154c8dbd5b743636919170685c7be Mon Sep 17 00:00:00 2001
+From 352dc62c5c36c6d2ad23c7429ecca275af836a3e Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:22 +0300
 Subject: [PATCH 084/104] dt-bindings: net: Add binding for ti,icssg-prueth

--- a/recipes-kernel/linux/files/patches-5.10/0085-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0085-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
@@ -1,4 +1,4 @@
-From 9e671235fc8509f24a82e8c80a040993f55b6a38 Mon Sep 17 00:00:00 2001
+From c3be05c640f3ac35f0349ab0f861d3c552f0bd57 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:23 +0300
 Subject: [PATCH 085/104] net: ti: icssg-prueth: Add ICSSG ethernet driver

--- a/recipes-kernel/linux/files/patches-5.10/0086-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0086-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
@@ -1,4 +1,4 @@
-From 09502d0b37bd2c91cebfdd9b4451fc8a28ed3f36 Mon Sep 17 00:00:00 2001
+From eaf14682c7e545e897968d32b9552e4162774a50 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:24 +0300
 Subject: [PATCH 086/104] net: ethernet: ti: icssg_prueth: add 10M full duplex

--- a/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
@@ -1,4 +1,4 @@
-From 697cda9e51db3253bf5933d8eaa6f2a7d5c2bb63 Mon Sep 17 00:00:00 2001
+From 98dd46caaa1f2df7a6389dc584d60c94b14f3fc6 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:25 +0300
 Subject: [PATCH 087/104] net: ethernet: ti: icssg_prueth: Use DMA device for

--- a/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
@@ -1,4 +1,4 @@
-From 59734af11ba3a042e3656e89b3567d94f9fdeffb Mon Sep 17 00:00:00 2001
+From 12d4d1a80249c134f663c5c2dbaf22b09cb000e0 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:26 +0300
 Subject: [PATCH 088/104] net: ethernet: ti: icss_iep: add icss_iep_get_idx()

--- a/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
@@ -1,4 +1,4 @@
-From d0268840960f41ef0f6c2c6a77d62425fbfc54ac Mon Sep 17 00:00:00 2001
+From ce1a000c10b8e7e5d8131881e0710f25b99f8918 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:27 +0300
 Subject: [PATCH 089/104] net: ethernet: ti: icss_iep: use readl() in

--- a/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
@@ -1,4 +1,4 @@
-From d973cbd0d89ee83189be9a57be1d08e804604f08 Mon Sep 17 00:00:00 2001
+From 2fdcd242488e6110efe413e7e8bf26a527b3ffe8 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:28 +0300
 Subject: [PATCH 090/104] net: ethernet: ti: icss_iep: fix init for sr2.0

--- a/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
@@ -1,4 +1,4 @@
-From 2edcbd51f46b19555cedd3a68ab07f41b1fe3c7b Mon Sep 17 00:00:00 2001
+From dc61819613feab4d9619c224c738d707bd7d3687 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:29 +0300
 Subject: [PATCH 091/104] net: ethernet: ti: icss_iep: sr2.0 fix NULL pointer

--- a/recipes-kernel/linux/files/patches-5.10/0092-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0092-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
@@ -1,4 +1,4 @@
-From a914bcc1ce768c203be3c95979e7892ae334262a Mon Sep 17 00:00:00 2001
+From 9801bc6f46a6ab949c84398578a0c100da290319 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:30 +0300
 Subject: [PATCH 092/104] net: ti: ethernet: icssg-prueth: add packet

--- a/recipes-kernel/linux/files/patches-5.10/0093-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0093-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
@@ -1,4 +1,4 @@
-From 34d0c89336ce2361f99d6b9a6fa4b1376e018a95 Mon Sep 17 00:00:00 2001
+From 596d1d83778020fd5a8df06c80c36729cc65e552 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:33 +0300
 Subject: [PATCH 093/104] net: ethernet: ti: icssg_prueth: add am64x icssg

--- a/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
@@ -1,4 +1,4 @@
-From 5fb3a0908b082e3a293b9e3aeb13ad1b627dc694 Mon Sep 17 00:00:00 2001
+From d565a0a0b9d915281f95c3755fcfc36d78172e7c Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 19 May 2021 19:31:36 +0300
 Subject: [PATCH 094/104] net: ethernet: ti: icssg_prueth: am65x SR2.0 add 10M

--- a/recipes-kernel/linux/files/patches-5.10/0095-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0095-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
@@ -1,4 +1,4 @@
-From 19d6c003c45deb30105b30c85c7428d9a700bfd8 Mon Sep 17 00:00:00 2001
+From ccb6f8b8bcf23b254fae4d1f0b51265bf5d0ead0 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Mon, 21 Jun 2021 15:47:49 +0530
 Subject: [PATCH 095/104] net: ti: icssg_prueth: Free desc pool before DMA

--- a/recipes-kernel/linux/files/patches-5.10/0096-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0096-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
@@ -1,4 +1,4 @@
-From 4e4b7bc421c1bbfd06e81b1d2f3e63d75fb83f76 Mon Sep 17 00:00:00 2001
+From e1f7c7672096f10f474f504b0ef29685831169d1 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:47 +0300
 Subject: [PATCH 096/104] net: ethernet: icssg-prueth: fix rgmii tx delay

--- a/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
@@ -1,4 +1,4 @@
-From 58d6496469f8a0680aef73a0f76ca0ddf09a5d33 Mon Sep 17 00:00:00 2001
+From fce321b6376c541a5562e7a0518d037f0f090717 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:48 +0300
 Subject: [PATCH 097/104] net: ethernet: icssg-prueth: enable "fixed-link"

--- a/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
@@ -1,4 +1,4 @@
-From bf026ff75aa00466ce7b2afdcad75e7bc26b5c2b Mon Sep 17 00:00:00 2001
+From 9fe8f18af949b19c59a226f7f1d2b2597672081d Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:12 +0300
 Subject: [PATCH 098/104] net: ethernet: icssg-prueth: fix bug 'scheduling

--- a/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
@@ -1,4 +1,4 @@
-From d0ff925cc96d1726bae397aca0ea92e34d805b35 Mon Sep 17 00:00:00 2001
+From 1b1140f6088a19746908a6f59cde4e49c6e3ede2 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:13 +0300
 Subject: [PATCH 099/104] net: ethernet: icssg-prueth: fix enabling/disabling

--- a/recipes-kernel/linux/files/patches-5.10/0100-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0100-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
@@ -1,4 +1,4 @@
-From ee97fc99e48ee4621f820424cffd7cdbadd2cecc Mon Sep 17 00:00:00 2001
+From 4a1be7fe9afc4b4d869ef637c2c41dc99266356f Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 27 Jun 2020 10:53:13 +0200
 Subject: [PATCH 100/104] arm64: dts: ti: iot2050: Add icssg-prueth nodes for

--- a/recipes-kernel/linux/files/patches-5.10/0101-HACK-setting-the-RJ45-port-led-behavior.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0101-HACK-setting-the-RJ45-port-led-behavior.patch
@@ -1,4 +1,4 @@
-From 214a5b0ee349dc5eb5d96e58067e98558a7bb8ab Mon Sep 17 00:00:00 2001
+From 95c9dd53a0065a3535457e0819c3c0dbbc843f42 Mon Sep 17 00:00:00 2001
 From: zengchao <chao.zeng@siemens.com>
 Date: Wed, 6 Nov 2019 11:21:49 +0800
 Subject: [PATCH 101/104] HACK: setting the RJ45 port led behavior

--- a/recipes-kernel/linux/files/patches-5.10/0102-WIP-feat-extend-led-panic-indicator-on-and-off.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0102-WIP-feat-extend-led-panic-indicator-on-and-off.patch
@@ -1,4 +1,4 @@
-From 3341677dc20deb9041ee1f8f9b916e1dd1993af6 Mon Sep 17 00:00:00 2001
+From 63a024c97bb2c85fb0decb1bdbfa369b5ab0a0a3 Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Tue, 22 Dec 2020 15:05:56 +0800
 Subject: [PATCH 102/104] WIP: feat:extend led panic-indicator on and off

--- a/recipes-kernel/linux/files/patches-5.10/0103-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0103-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
@@ -1,4 +1,4 @@
-From 27ae988de3408a9816401d8de4d8fee5abe425f6 Mon Sep 17 00:00:00 2001
+From d8c55854d446024c9cd1227884c8be0f35b3c36b Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Mar 2021 15:28:21 +0100
 Subject: [PATCH 103/104] WIP: arm64: dts: ti: iot2050: Add node for generic

--- a/recipes-kernel/linux/files/patches-5.10/0104-watchdog-rti-wdt-Provide-set_timeout-handler-to-make.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0104-watchdog-rti-wdt-Provide-set_timeout-handler-to-make.patch
@@ -1,4 +1,4 @@
-From 059b734e40f2507b7802d3a95adced72c8feaa29 Mon Sep 17 00:00:00 2001
+From 5527baa53e1abd5f649441bd142642383794435f Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 13 Sep 2021 12:27:17 +0200
 Subject: [PATCH 104/104] watchdog: rti-wdt: Provide set_timeout handler to


### PR DESCRIPTION
usb0_phy must have been usb0, the host controller. This truly enables
USB 3.0 mode now.

The update also brings a naming fix for cp2102n_reset_pin_default from
upstream.

Obsoletes #194.