### PR TITLE
Fix the omap RS485 issue

### DIFF
--- a/recipes-app/switchserialmode/files/src/switchserialmode.c
+++ b/recipes-app/switchserialmode/files/src/switchserialmode.c
@@ -349,15 +349,17 @@ static E_STATUS ttyuart_switchto_rs485(const char *uartdev, int logicLevel)
 
     SET_UART_RTS_ACTIVE_LOGIC(rs485conf.flags, logicLevel);
 
-    rs485conf.flags |= SER_RS485_ENABLED | SER_RS485_RX_DURING_TX;
+    rs485conf.flags |= SER_RS485_ENABLED;
 
     return ttyuart_set_rs485conf(uartdev, &rs485conf);
 }
 
-static E_STATUS ttyuart_switchto_rs422(const char *uartdev)
+static E_STATUS ttyuart_switchto_rs422(const char *uartdev, int logicLevel)
 {
     struct serial_rs485 rs485conf;
     memset(&rs485conf, 0, sizeof(rs485conf));
+
+    SET_UART_RTS_ACTIVE_LOGIC(rs485conf.flags, logicLevel);
 
     rs485conf.flags |= SER_RS485_ENABLED | SER_RS485_RX_DURING_TX;
 
@@ -412,7 +414,7 @@ static void ttyuart_command_handle(int argc, char **argv)
     }
     else if(0 == strcasecmp(mode, "rs422"))
     {
-        ttyuart_switchto_rs422(devType);
+        ttyuart_switchto_rs422(devType, logicLevel);
     }
     else
     {

--- a/recipes-kernel/linux/files/patches-5.10/0001-dmaengine-ti-k3-udma-glue-Add-function-to-get-device.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0001-dmaengine-ti-k3-udma-glue-Add-function-to-get-device.patch
@@ -1,7 +1,7 @@
-From 83202d53880f68384482db221d5b30327057459c Mon Sep 17 00:00:00 2001
+From 82c840791fdb200ce51f4213f8ba015bc3bdaf2a Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Tue, 8 Dec 2020 11:04:24 +0200
-Subject: [PATCH 001/116] dmaengine: ti: k3-udma-glue: Add function to get
+Subject: [PATCH 001/117] dmaengine: ti: k3-udma-glue: Add function to get
  device pointer for DMA API
 
 Glue layer users should use the device of the DMA for DMA mapping and
@@ -99,5 +99,5 @@ index 5eb34ad973a7..d7c12f31377c 100644
  
  #endif /* K3_UDMA_GLUE_H_ */
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0002-arm64-dts-ti-k3-am65-ringacc-drop-ti-dma-ring-reset-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0002-arm64-dts-ti-k3-am65-ringacc-drop-ti-dma-ring-reset-.patch
@@ -1,7 +1,7 @@
-From 16fbb95307c6a968eeb93eb519cbf9eb88eff876 Mon Sep 17 00:00:00 2001
+From 59dbbcf94f701e0cb1d2f345be08d89b07b6bbf2 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Sat, 29 Aug 2020 21:41:39 +0300
-Subject: [PATCH 002/116] arm64: dts: ti: k3-am65: ringacc: drop ti,
+Subject: [PATCH 002/117] arm64: dts: ti: k3-am65: ringacc: drop ti,
  dma-ring-reset-quirk
 
 Remove obsolete "ti,dma-ring-reset-quirk" Ringacc DT property.
@@ -39,5 +39,5 @@ index 29aaf8dca6f6..044042b166d9 100644
  			ti,sci-dev-id = <195>;
  			msi-parent = <&inta_main_udmass>;
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0003-arm64-dts-ti-k3-am65-mcu-Add-MCU-domain-R5F-cluster-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0003-arm64-dts-ti-k3-am65-mcu-Add-MCU-domain-R5F-cluster-.patch
@@ -1,7 +1,7 @@
-From 160084a924e514651f22f3829f2450782c06dbc3 Mon Sep 17 00:00:00 2001
+From ac59d8a473ab5ed7681be6dd456f81bf2ec46b4e Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 28 Oct 2020 22:37:55 -0500
-Subject: [PATCH 003/116] arm64: dts: ti: k3-am65-mcu: Add MCU domain R5F
+Subject: [PATCH 003/117] arm64: dts: ti: k3-am65-mcu: Add MCU domain R5F
  cluster node
 
 The AM65x SoCs have a single dual-core Arm Cortex-R5F processor (R5FSS)
@@ -95,5 +95,5 @@ index 044042b166d9..7454c8cec0cc 100644
 +	};
  };
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0004-arm64-dts-ti-k3-am65-Cleanup-disabled-nodes-at-SoC-d.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0004-arm64-dts-ti-k3-am65-Cleanup-disabled-nodes-at-SoC-d.patch
@@ -1,7 +1,7 @@
-From a894a3372c3c8ee5af53ff05a08f64699227542d Mon Sep 17 00:00:00 2001
+From 340ff26cfed94b5188d9c910acbf61266aa5ea55 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Fri, 13 Nov 2020 15:18:22 -0600
-Subject: [PATCH 004/116] arm64: dts: ti: k3-am65*: Cleanup disabled nodes at
+Subject: [PATCH 004/117] arm64: dts: ti: k3-am65*: Cleanup disabled nodes at
  SoC dtsi level
 
 The device tree standard states that when the status property is
@@ -121,5 +121,5 @@ index 937dd7280c7a..8c082af489f5 100644
 +	status = "disabled";
 +};
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0005-arm64-dts-ti-am65-j721e-Fix-up-un-necessary-status-s.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0005-arm64-dts-ti-am65-j721e-Fix-up-un-necessary-status-s.patch
@@ -1,7 +1,7 @@
-From b29aa4d5a00e412d8fe79c2caa7db42c1ab4dcfa Mon Sep 17 00:00:00 2001
+From d7b2031f0f44a7b2bd683a682619d60affaa9104 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Fri, 13 Nov 2020 15:18:24 -0600
-Subject: [PATCH 005/116] arm64: dts: ti: am65/j721e: Fix up un-necessary
+Subject: [PATCH 005/117] arm64: dts: ti: am65/j721e: Fix up un-necessary
  status set to "okay" for crypto
 
 The default state of a device tree node is "okay". There is no specific
@@ -44,5 +44,5 @@ index 6ffdebd60122..d386b38b5b0b 100644
  				<&main_udmap 0x4001>;
  		dma-names = "tx", "rx1", "rx2";
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0006-arm64-dts-ti-k3-mmc-fix-dtbs_check-warnings.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0006-arm64-dts-ti-k3-mmc-fix-dtbs_check-warnings.patch
@@ -1,7 +1,7 @@
-From 1b151cfd61f581bb844e9265f9d9a5d4da050fa7 Mon Sep 17 00:00:00 2001
+From df5cf9b56fabb10493c09657166717dcf53f1caa Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 15 Jan 2021 21:30:16 +0200
-Subject: [PATCH 006/116] arm64: dts: ti: k3: mmc: fix dtbs_check warnings
+Subject: [PATCH 006/117] arm64: dts: ti: k3: mmc: fix dtbs_check warnings
 
 Now the dtbs_check produces below warnings
  sdhci@4f80000: clock-names:0: 'clk_ahb' was expected
@@ -129,5 +129,5 @@ index d386b38b5b0b..4f8bbad8731c 100644
  		assigned-clock-parents = <&k3_clks 93 1>;
  		ti,otap-del-sel = <0x2>;
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0007-arm64-dts-ti-k3-am65-main-Add-device_type-to-pcie-_r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0007-arm64-dts-ti-k3-am65-main-Add-device_type-to-pcie-_r.patch
@@ -1,7 +1,7 @@
-From 997140e1e68654b14dbabfc41c7b69c9faea3b9b Mon Sep 17 00:00:00 2001
+From f94f2be8c06c5f99e248e89d891daa182e163689 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Feb 2021 20:32:56 +0100
-Subject: [PATCH 007/116] arm64: dts: ti: k3-am65-main: Add device_type to
+Subject: [PATCH 007/117] arm64: dts: ti: k3-am65-main: Add device_type to
  pcie*_rc nodes
 
 This is demanded by the parent binding of ti,am654-pcie-rc, see
@@ -36,5 +36,5 @@ index 29c647f35464..00cd06ff98ee 100644
  
  	pcie1_ep: pcie-ep@5600000 {
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0008-arm64-dts-ti-k3-am65-main-Add-ICSSG-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0008-arm64-dts-ti-k3-am65-main-Add-ICSSG-nodes.patch
@@ -1,7 +1,7 @@
-From 558dd13ea7c23057fd262c88dc19d181d68b8dd3 Mon Sep 17 00:00:00 2001
+From a7ae95fe81b86fd0e87450c84854ae9785976b3a Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Thu, 4 Mar 2021 10:07:11 -0600
-Subject: [PATCH 008/116] arm64: dts: ti: k3-am65-main: Add ICSSG nodes
+Subject: [PATCH 008/117] arm64: dts: ti: k3-am65-main: Add ICSSG nodes
 
 Add the DT nodes for the ICSSG0, ICSSG1 and ICSSG2 processor subsystems
 that are present on the K3 AM65x SoCs. The three ICSSGs are identical
@@ -475,5 +475,5 @@ index 00cd06ff98ee..67047f108130 100644
 +	};
  };
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0009-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0009-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
@@ -1,7 +1,7 @@
-From 2429ba79c7d88326f195db1d03a5b3b7ccb323fc Mon Sep 17 00:00:00 2001
+From 2a763fd5fe8d3b73853f8c34e5f5c0c2dba93201 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 20 Feb 2021 13:49:51 +0100
-Subject: [PATCH 009/116] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
+Subject: [PATCH 009/117] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
 
 Add the DT entry for a watchdog based on RTI1.
 
@@ -37,5 +37,5 @@ index 7454c8cec0cc..0388c02c2203 100644
 +	};
  };
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0010-arm64-dts-ti-Add-support-for-Siemens-IOT2050-boards.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0010-arm64-dts-ti-Add-support-for-Siemens-IOT2050-boards.patch
@@ -1,7 +1,7 @@
-From f222526be26acb66e41dc947a62feca32cef45b8 Mon Sep 17 00:00:00 2001
+From 5bfcc76544ade43c53fa9d80737f2bc058d22d38 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Mar 2021 15:33:43 +0100
-Subject: [PATCH 010/116] arm64: dts: ti: Add support for Siemens IOT2050
+Subject: [PATCH 010/117] arm64: dts: ti: Add support for Siemens IOT2050
  boards
 
 Add support for two Siemens SIMATIC IOT2050 variants, Basic and
@@ -836,5 +836,5 @@ index 000000000000..ec9617c13cdb
 +	status = "disabled";
 +};
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0011-arm64-dts-ti-k3-am65-j721e-am64-Map-the-dma-navigato.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0011-arm64-dts-ti-k3-am65-j721e-am64-Map-the-dma-navigato.patch
@@ -1,7 +1,7 @@
-From e042909d3f91dfbaa52db7fd9acb2e457c5ce37b Mon Sep 17 00:00:00 2001
+From 1e3ded6bbf425bbd716101e68fafc42bf8776405 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Mon, 10 May 2021 09:54:29 -0500
-Subject: [PATCH 011/116] arm64: dts: ti: k3-am65|j721e|am64: Map the dma /
+Subject: [PATCH 011/117] arm64: dts: ti: k3-am65|j721e|am64: Map the dma /
  navigator subsystem via explicit ranges
 
 Instead of using empty ranges property, lets map explicitly the address
@@ -102,5 +102,5 @@ index e581cb1d87ee..d766c7fe02af 100644
  		dma-ranges;
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0012-arm64-dts-ti-k3-Introduce-reg-definition-for-interru.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0012-arm64-dts-ti-k3-Introduce-reg-definition-for-interru.patch
@@ -1,7 +1,7 @@
-From 33efb510838ad45e53631b85eba71d636633d88f Mon Sep 17 00:00:00 2001
+From 5bb4677b47b69705ab5e249646ac1b9cd9c7d28b Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Tue, 11 May 2021 14:48:21 -0500
-Subject: [PATCH 012/116] arm64: dts: ti: k3*: Introduce reg definition for
+Subject: [PATCH 012/117] arm64: dts: ti: k3*: Introduce reg definition for
  interrupt routers
 
 Interrupt routers are memory mapped peripherals, that are organized
@@ -162,5 +162,5 @@ index d766c7fe02af..282bbdc359ac 100644
  		interrupt-controller;
  		interrupt-parent = <&gic500>;
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0013-mmc-sdhci_am654-Use-pm_runtime_resume_and_get-to-rep.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0013-mmc-sdhci_am654-Use-pm_runtime_resume_and_get-to-rep.patch
@@ -1,7 +1,7 @@
-From 891b86f183969b6a38fbd6763249b29ccd26250f Mon Sep 17 00:00:00 2001
+From 43d8b5e6159606b9c16fef325ea33001c30219c1 Mon Sep 17 00:00:00 2001
 From: Tian Tao <tiantao6@hisilicon.com>
 Date: Fri, 21 May 2021 08:59:35 +0800
-Subject: [PATCH 013/116] mmc: sdhci_am654: Use pm_runtime_resume_and_get() to
+Subject: [PATCH 013/117] mmc: sdhci_am654: Use pm_runtime_resume_and_get() to
  replace open coding
 
 use pm_runtime_resume_and_get() to replace pm_runtime_get_sync and
@@ -34,5 +34,5 @@ index a64ea143d185..c4799a16a61f 100644
  	base = devm_platform_ioremap_resource(pdev, 1);
  	if (IS_ERR(base)) {
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0014-arm64-dts-ti-k3-am65-iot2050-common-Disable-mailbox-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0014-arm64-dts-ti-k3-am65-iot2050-common-Disable-mailbox-.patch
@@ -1,7 +1,7 @@
-From 42d38a24e818034fc232ff1b1ffe0bb4eca71444 Mon Sep 17 00:00:00 2001
+From 298911f4da4268a10ebd1be89bb3dcb39303f01d Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 14 May 2021 16:20:16 -0500
-Subject: [PATCH 014/116] arm64: dts: ti: k3-am65-iot2050-common: Disable
+Subject: [PATCH 014/117] arm64: dts: ti: k3-am65-iot2050-common: Disable
  mailbox nodes
 
 There are no sub-mailbox devices defined currently for both the
@@ -80,5 +80,5 @@ index de763ca9251c..f4ec9ed52939 100644
 +	status = "disabled";
 +};
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0015-arm64-dts-ti-k3-am65-Add-support-for-UHS-I-modes-in-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0015-arm64-dts-ti-k3-am65-Add-support-for-UHS-I-modes-in-.patch
@@ -1,7 +1,7 @@
-From 5d0f351d889b0628f35184a085c0114a352cf024 Mon Sep 17 00:00:00 2001
+From 3b4b0e433dcc4391ff6f0c76f4bbf3b973ff3f1c Mon Sep 17 00:00:00 2001
 From: Aswath Govindraju <a-govindraju@ti.com>
 Date: Sat, 29 May 2021 09:07:49 +0530
-Subject: [PATCH 015/116] arm64: dts: ti: k3-am65: Add support for UHS-I modes
+Subject: [PATCH 015/117] arm64: dts: ti: k3-am65: Add support for UHS-I modes
  in MMCSD1 subsystem
 
 UHS-I speed modes are supported in AM65 S.R. 2.0 SoC[1].
@@ -108,5 +108,5 @@ index 8c082af489f5..fea6a8243d75 100644
  	pinctrl-0 = <&main_mmc1_pins_default>;
  	ti,driver-strength-ohm = <50>;
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0016-arm64-dts-ti-k3-am65-main-Add-ICSSG-MDIO-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0016-arm64-dts-ti-k3-am65-main-Add-ICSSG-MDIO-nodes.patch
@@ -1,7 +1,7 @@
-From e75253d1123b86ca97ff2f893ff310ec6e225e79 Mon Sep 17 00:00:00 2001
+From 3d9def3afcc96a9242c7231e72d40a1fbe18b869 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 1 Jun 2021 10:00:31 -0500
-Subject: [PATCH 016/116] arm64: dts: ti: k3-am65-main: Add ICSSG MDIO nodes
+Subject: [PATCH 016/117] arm64: dts: ti: k3-am65-main: Add ICSSG MDIO nodes
 
 The ICSSGs on K3 AM65x SoCs contain an MDIO controller that can
 be used to control external PHYs associated with the Industrial
@@ -125,5 +125,5 @@ index fea6a8243d75..b47fc2a1e59d 100644
 +	status = "disabled";
 +};
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0017-arm64-dts-ti-iot2050-Configure-r5f-cluster-on-basic-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0017-arm64-dts-ti-iot2050-Configure-r5f-cluster-on-basic-.patch
@@ -1,7 +1,7 @@
-From c52d516f095d40fbcbff996ba62be0e808fe71e5 Mon Sep 17 00:00:00 2001
+From f3778a427303d235356923de346a42d268271b81 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 2 Jun 2021 08:56:15 +0200
-Subject: [PATCH 017/116] arm64: dts: ti: iot2050: Configure r5f cluster on
+Subject: [PATCH 017/117] arm64: dts: ti: iot2050: Configure r5f cluster on
  basic variant in split mode
 
 Lockstep mode is not supported here. So turn it off to avoid warnings
@@ -28,5 +28,5 @@ index 4f7e3f2a6265..94bb5dd39122 100644
 +	ti,cluster-mode = <0>;
 +};
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0018-arm64-dts-ti-am65-align-ti-pindir-d0-out-d1-in-prope.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0018-arm64-dts-ti-am65-align-ti-pindir-d0-out-d1-in-prope.patch
@@ -1,7 +1,7 @@
-From e58ee2ede15eae19a01e65911cbe051ced3aa7a8 Mon Sep 17 00:00:00 2001
+From 95b942997616dff5501b94f00a1446dcadded6f1 Mon Sep 17 00:00:00 2001
 From: Aswath Govindraju <a-govindraju@ti.com>
 Date: Tue, 8 Jun 2021 10:44:13 +0530
-Subject: [PATCH 018/116] arm64: dts: ti: am65: align ti,pindir-d0-out-d1-in
+Subject: [PATCH 018/117] arm64: dts: ti: am65: align ti,pindir-d0-out-d1-in
  property with dt-shema
 
 ti,pindir-d0-out-d1-in property is expected to be of type boolean.
@@ -46,5 +46,5 @@ index b47fc2a1e59d..56dc855a5f13 100644
  	flash@0{
  		compatible = "jedec,spi-nor";
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0019-firmware-ti_sci-rm-Add-support-for-tx_tdtype-paramet.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0019-firmware-ti_sci-rm-Add-support-for-tx_tdtype-paramet.patch
@@ -1,7 +1,7 @@
-From 22d2dbcc367a794afdcc6ab7b486d8f3a27061a3 Mon Sep 17 00:00:00 2001
+From fdf8abd101a3f39cdb1d31b649ce89a63e7052bc Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:02 -0700
-Subject: [PATCH 019/116] firmware: ti_sci: rm: Add support for tx_tdtype
+Subject: [PATCH 019/117] firmware: ti_sci: rm: Add support for tx_tdtype
  parameter for tx channel
 
 The system controller's resource manager have support for configuring the
@@ -86,5 +86,5 @@ index cf27b080e148..d254d99fd45b 100644
  
  /**
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0020-firmware-ti_sci-Use-struct-ti_sci_resource_desc-in-g.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0020-firmware-ti_sci-Use-struct-ti_sci_resource_desc-in-g.patch
@@ -1,7 +1,7 @@
-From b651e23a3f40e43ef55e0590efa28d3936f45c64 Mon Sep 17 00:00:00 2001
+From 78ed019cb042c668898a5d13cfddc6450d87c6cc Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:03 -0700
-Subject: [PATCH 020/116] firmware: ti_sci: Use struct ti_sci_resource_desc in
+Subject: [PATCH 020/117] firmware: ti_sci: Use struct ti_sci_resource_desc in
  get_range ops
 
 Use the ti_sci_resource_desc directly and update it's start and num members
@@ -177,5 +177,5 @@ index d254d99fd45b..6cd537db4d33 100644
   * struct ti_sci_resource - Structure representing a resource assigned
   *			    to a device.
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0021-firmware-ti_sci-rm-Add-support-for-second-resource-r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0021-firmware-ti_sci-rm-Add-support-for-second-resource-r.patch
@@ -1,7 +1,7 @@
-From 1a34fd3a6e48f42d23259775fc97c8b7307dfc19 Mon Sep 17 00:00:00 2001
+From 27a3b6ee209cd346d2a80563de283eb851ac58b8 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:03 -0700
-Subject: [PATCH 021/116] firmware: ti_sci: rm: Add support for second resource
+Subject: [PATCH 021/117] firmware: ti_sci: rm: Add support for second resource
  range
 
 Sysfw added support for a second range in the resource range API to be able
@@ -174,5 +174,5 @@ index 6cd537db4d33..9699b260de59 100644
  };
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0022-soc-ti-ti_sci_inta_msi-Add-support-for-second-range-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0022-soc-ti-ti_sci_inta_msi-Add-support-for-second-range-.patch
@@ -1,7 +1,7 @@
-From 76e16364c745f87dab9fb13787fd41acd14bb49c Mon Sep 17 00:00:00 2001
+From 39d977f5d9a95c5691796f34afba1d0d7dbc4261 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:04 -0700
-Subject: [PATCH 022/116] soc: ti: ti_sci_inta_msi: Add support for second
+Subject: [PATCH 022/117] soc: ti: ti_sci_inta_msi: Add support for second
  range in resource ranges
 
 Allocate MSI entries for both first and second range if they are valid
@@ -36,5 +36,5 @@ index 0eb9462f609e..a1d9c027022a 100644
  
  	return count;
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0023-firmware-ti_sci-rm-Add-support-for-extended_ch_type-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0023-firmware-ti_sci-rm-Add-support-for-extended_ch_type-.patch
@@ -1,7 +1,7 @@
-From 3de69b809366689a28017e38fe962b5f26ccaab1 Mon Sep 17 00:00:00 2001
+From d91de6df040cb83e256026c0bb29ad8fd663b3fb Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:05 -0700
-Subject: [PATCH 023/116] firmware: ti_sci: rm: Add support for
+Subject: [PATCH 023/117] firmware: ti_sci: rm: Add support for
  extended_ch_type for tx channel
 
 Sysfw added 'extended_ch_type' to the tx_ch_cfg_req message which should be
@@ -91,5 +91,5 @@ index 9699b260de59..6978afc00823 100644
  
  /**
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0024-firmware-ti_sci-rm-Remove-ring_get_config-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0024-firmware-ti_sci-rm-Remove-ring_get_config-support.patch
@@ -1,7 +1,7 @@
-From 498416ef41bbac631881fece40b48895081a9a1b Mon Sep 17 00:00:00 2001
+From fd5a492effcc64d95ccfa5cbb01187a08a4aca19 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:05 -0700
-Subject: [PATCH 024/116] firmware: ti_sci: rm: Remove ring_get_config support
+Subject: [PATCH 024/117] firmware: ti_sci: rm: Remove ring_get_config support
 
 The ring_get_cfg (0x1111 message) is not used and it is not supported by
 sysfw for a long time.
@@ -200,5 +200,5 @@ index 6978afc00823..6710d7ac7a72 100644
  
  /**
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0025-firmware-ti_sci-rm-Add-new-ops-for-ring-configuratio.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0025-firmware-ti_sci-rm-Add-new-ops-for-ring-configuratio.patch
@@ -1,7 +1,7 @@
-From f939190c60e15d46b2bb95bcdf01782876091a61 Mon Sep 17 00:00:00 2001
+From 6838ed9854f2fdfdd0d6b128a8e78c003336e665 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:06 -0700
-Subject: [PATCH 025/116] firmware: ti_sci: rm: Add new ops for ring
+Subject: [PATCH 025/117] firmware: ti_sci: rm: Add new ops for ring
  configuration
 
 The sysfw ring configuration message has been extended to include virtid
@@ -198,5 +198,5 @@ index 6710d7ac7a72..d1711050cd9d 100644
  
  /**
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0026-soc-ti-k3-ringacc-Use-the-ti_sci-set_cfg-callback-fo.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0026-soc-ti-k3-ringacc-Use-the-ti_sci-set_cfg-callback-fo.patch
@@ -1,7 +1,7 @@
-From 57c1a5940bf76b099c718ae10ec952e84a0016f4 Mon Sep 17 00:00:00 2001
+From 6941d2bdc05a1a0ff1efa25b8fae0f6597654fbc Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:07 -0700
-Subject: [PATCH 026/116] soc: ti: k3-ringacc: Use the ti_sci set_cfg callback
+Subject: [PATCH 026/117] soc: ti: k3-ringacc: Use the ti_sci set_cfg callback
  for ring configuration
 
 Switch to the new set_cfg to configure the ring.
@@ -142,5 +142,5 @@ index 1147dc4c1d59..9ddd77113c5a 100644
  	return ret;
  }
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0027-firmware-ti_sci-rm-Remove-unused-config-from-ti_sci_.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0027-firmware-ti_sci-rm-Remove-unused-config-from-ti_sci_.patch
@@ -1,7 +1,7 @@
-From ff498916e5e2c7b218daee828b227dbc4107bae0 Mon Sep 17 00:00:00 2001
+From 80177c300d4a8c4e398b3fa43f865ca607565337 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:07 -0700
-Subject: [PATCH 027/116] firmware: ti_sci: rm: Remove unused config() from
+Subject: [PATCH 027/117] firmware: ti_sci: rm: Remove unused config() from
  ti_sci_rm_ringacc_ops
 
 The ringacc driver has been converted to use the new set_cfg function to
@@ -127,5 +127,5 @@ index d1711050cd9d..0aad7009b50e 100644
  		       const struct ti_sci_msg_rm_ring_cfg *params);
  };
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0028-soc-ti-k3-ringacc-Use-correct-device-for-allocation-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0028-soc-ti-k3-ringacc-Use-correct-device-for-allocation-.patch
@@ -1,7 +1,7 @@
-From f116332f65eaaa2f0e04bd534b91e837f3fda5eb Mon Sep 17 00:00:00 2001
+From 2af52724b9dcca133e701f26f78f31339886249e Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:22 -0700
-Subject: [PATCH 028/116] soc: ti: k3-ringacc: Use correct device for
+Subject: [PATCH 028/117] soc: ti: k3-ringacc: Use correct device for
  allocation in RING mode
 
 In RING mode the ringacc does not access the ring memory. In this access
@@ -126,5 +126,5 @@ index 5a472eca5ee4..658dc71d2901 100644
  
  #define K3_RINGACC_RING_ID_ANY (-1)
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0029-soc-ti-pruss-Remove-wrong-check-against-get_match_da.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0029-soc-ti-pruss-Remove-wrong-check-against-get_match_da.patch
@@ -1,7 +1,7 @@
-From 586bdb5596127f7d69773146228c2dd7d036e7a5 Mon Sep 17 00:00:00 2001
+From 6b7155a84afb51c4cc0f2fd71d1a9596085fd7f9 Mon Sep 17 00:00:00 2001
 From: Grzegorz Jaszczyk <grzegorz.jaszczyk@linaro.org>
 Date: Sat, 21 Nov 2020 19:22:25 -0800
-Subject: [PATCH 029/116] soc: ti: pruss: Remove wrong check against
+Subject: [PATCH 029/117] soc: ti: pruss: Remove wrong check against
  *get_match_data return value
 
 Since the of_device_get_match_data() doesn't return error code, remove
@@ -43,5 +43,5 @@ index cc0b4ad7a3d3..5d6e7132a5c4 100644
  	ret = dma_set_coherent_mask(dev, DMA_BIT_MASK(32));
  	if (ret) {
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0030-soc-ti-pruss-Correct-the-pruss_clk_init-error-trace-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0030-soc-ti-pruss-Correct-the-pruss_clk_init-error-trace-.patch
@@ -1,7 +1,7 @@
-From 2503ea0ec1bdf6e00048536382dbd619cb4b97ed Mon Sep 17 00:00:00 2001
+From 3bb4eedf0550cc012a46c78b3c368d8e89119a9b Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 24 Jan 2021 20:51:37 -0800
-Subject: [PATCH 030/116] soc: ti: pruss: Correct the pruss_clk_init error
+Subject: [PATCH 030/117] soc: ti: pruss: Correct the pruss_clk_init error
  trace text
 
 The pruss_clk_init() function can register more than one clock.
@@ -28,5 +28,5 @@ index 5d6e7132a5c4..1d6890134312 100644
  	}
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0031-soc-ti-pruss-Refactor-the-CFG-sub-module-init.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0031-soc-ti-pruss-Refactor-the-CFG-sub-module-init.patch
@@ -1,7 +1,7 @@
-From 03f60028b3f7d16264ae193fb5a6b794a4ca82aa Mon Sep 17 00:00:00 2001
+From e298734d2cfd75aa5d0afac963a3832d50ffd38f Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 31 Jan 2021 20:53:43 -0800
-Subject: [PATCH 031/116] soc: ti: pruss: Refactor the CFG sub-module init
+Subject: [PATCH 031/117] soc: ti: pruss: Refactor the CFG sub-module init
 
 The CFG sub-module is not present on some earlier SoCs like the
 DA850/OMAPL-138 in the TI Davinci family. Refactor out the CFG
@@ -134,5 +134,5 @@ index 1d6890134312..f22ac1edbdd0 100644
  	pm_runtime_put_sync(dev);
  rpm_disable:
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0032-soc-ti-k3-ringacc-Use-of_device_get_match_data.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0032-soc-ti-k3-ringacc-Use-of_device_get_match_data.patch
@@ -1,7 +1,7 @@
-From c6806cb3b46939546487b8b072cd94350caa2fcb Mon Sep 17 00:00:00 2001
+From 8cf713de6807a6c11725c4bb4d0174512ba11d0e Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 31 Jan 2021 20:58:49 -0800
-Subject: [PATCH 032/116] soc: ti: k3-ringacc: Use of_device_get_match_data()
+Subject: [PATCH 032/117] soc: ti: k3-ringacc: Use of_device_get_match_data()
 
 Simplify the retrieval of getting the match data in the probe
 function by directly using of_device_get_match_data() instead
@@ -44,5 +44,5 @@ index 7fdb688452f7..db3f705da7a0 100644
  	ringacc = devm_kzalloc(dev, sizeof(*ringacc), GFP_KERNEL);
  	if (!ringacc)
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0033-remoteproc-ti_k3-fix-Wcast-function-type-warning.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0033-remoteproc-ti_k3-fix-Wcast-function-type-warning.patch
@@ -1,7 +1,7 @@
-From 289f91185dee8d36abfc941f6186a7e3e77ee618 Mon Sep 17 00:00:00 2001
+From ba2923514205313ef9acbf0b06d7b13687ebe32e Mon Sep 17 00:00:00 2001
 From: Arnd Bergmann <arnd@arndb.de>
 Date: Mon, 26 Oct 2020 17:05:23 +0100
-Subject: [PATCH 033/116] remoteproc: ti_k3: fix -Wcast-function-type warning
+Subject: [PATCH 033/117] remoteproc: ti_k3: fix -Wcast-function-type warning
 
 The function cast causes a warning with "make W=1"
 
@@ -79,5 +79,5 @@ index afeb9d6e4313..b68384455726 100644
  		return ret;
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0034-remoteproc-Add-a-rproc_set_firmware-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0034-remoteproc-Add-a-rproc_set_firmware-API.patch
@@ -1,7 +1,7 @@
-From 8a2da00f94e19564afa2f74027f1465a3df7c4db Mon Sep 17 00:00:00 2001
+From e87a34c01ca4e678d2690d95e70925b6ff03952e Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 20 Nov 2020 21:20:42 -0600
-Subject: [PATCH 034/116] remoteproc: Add a rproc_set_firmware() API
+Subject: [PATCH 034/117] remoteproc: Add a rproc_set_firmware() API
 
 A new API, rproc_set_firmware() is added to allow the remoteproc platform
 drivers and remoteproc client drivers to be able to configure a custom
@@ -159,5 +159,5 @@ index 3fa3ba6498e8..e8ac041c64d9 100644
  int rproc_coredump_add_segment(struct rproc *rproc, dma_addr_t da, size_t size);
  int rproc_coredump_add_custom_segment(struct rproc *rproc,
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0035-remoteproc-pru-Add-a-PRU-remoteproc-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0035-remoteproc-pru-Add-a-PRU-remoteproc-driver.patch
@@ -1,7 +1,7 @@
-From 7e918c0d3821dbad7c29041f277afef0141143b8 Mon Sep 17 00:00:00 2001
+From cb100236ae2ce3eae70cdab14130f9227d3f58d8 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:09:58 +0100
-Subject: [PATCH 035/116] remoteproc: pru: Add a PRU remoteproc driver
+Subject: [PATCH 035/117] remoteproc: pru: Add a PRU remoteproc driver
 
 The Programmable Real-Time Unit Subsystem (PRUSS) consists of
 dual 32-bit RISC cores (Programmable Real-Time Units, or PRUs)
@@ -524,5 +524,5 @@ index 000000000000..d33392bbd8af
 +MODULE_DESCRIPTION("PRU-ICSS Remote Processor Driver");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0036-remoteproc-pru-Add-support-for-PRU-specific-interrup.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0036-remoteproc-pru-Add-support-for-PRU-specific-interrup.patch
@@ -1,7 +1,7 @@
-From cb464e63b6aefdcd0dda0c4662cb6a9ff6d10cf2 Mon Sep 17 00:00:00 2001
+From 7afa99e79c80398ebf2ac7cef160945f76941a40 Mon Sep 17 00:00:00 2001
 From: Grzegorz Jaszczyk <grzegorz.jaszczyk@linaro.org>
 Date: Tue, 8 Dec 2020 15:09:59 +0100
-Subject: [PATCH 036/116] remoteproc: pru: Add support for PRU specific
+Subject: [PATCH 036/117] remoteproc: pru: Add support for PRU specific
  interrupt configuration
 
 The firmware blob can contain optional ELF sections: .resource_table
@@ -352,5 +352,5 @@ index 000000000000..8ee9c3171610
 +
 +#endif	/* _PRU_RPROC_H_ */
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0037-remoteproc-pru-Add-pru-specific-debugfs-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0037-remoteproc-pru-Add-pru-specific-debugfs-support.patch
@@ -1,7 +1,7 @@
-From f945aba4b4661d7c24dcdc99c9fdb5dbbe8b3a7d Mon Sep 17 00:00:00 2001
+From e5ea6e9748ebdc1c0e36e1f87a7dd738ce9b4c12 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:10:00 +0100
-Subject: [PATCH 037/116] remoteproc: pru: Add pru-specific debugfs support
+Subject: [PATCH 037/117] remoteproc: pru: Add pru-specific debugfs support
 
 The remoteproc core creates certain standard debugfs entries,
 that does not give a whole lot of useful information for the
@@ -223,5 +223,5 @@ index 72e64d15f0dc..59240fd82f56 100644
  
  	return 0;
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0038-remoteproc-pru-Add-support-for-various-PRU-cores-on-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0038-remoteproc-pru-Add-support-for-various-PRU-cores-on-.patch
@@ -1,7 +1,7 @@
-From ace82bd1ec7626b7b157e41ec4bbd567c14647b0 Mon Sep 17 00:00:00 2001
+From 9f1d4084a9a81c07f25c00cb37c9091fd861ba70 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:10:01 +0100
-Subject: [PATCH 038/116] remoteproc: pru: Add support for various PRU cores on
+Subject: [PATCH 038/117] remoteproc: pru: Add support for various PRU cores on
  K3 AM65x SoCs
 
 The K3 AM65x family of SoCs have the next generation of the PRU-ICSS
@@ -294,5 +294,5 @@ index 59240fd82f56..421ebbc1c02d 100644
  };
  MODULE_DEVICE_TABLE(of, pru_rproc_match);
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0039-remoteproc-pru-Fix-loading-of-GNU-Binutils-ELF.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0039-remoteproc-pru-Fix-loading-of-GNU-Binutils-ELF.patch
@@ -1,7 +1,7 @@
-From 86634921448600fdb5f2140fbbeb293f229defc2 Mon Sep 17 00:00:00 2001
+From f8c8d520e55657b58e335b26b95d0246b9cfc16f Mon Sep 17 00:00:00 2001
 From: Dimitar Dimitrov <dimitar@dinux.eu>
 Date: Wed, 30 Dec 2020 12:50:05 +0200
-Subject: [PATCH 039/116] remoteproc: pru: Fix loading of GNU Binutils ELF
+Subject: [PATCH 039/117] remoteproc: pru: Fix loading of GNU Binutils ELF
 
 PRU port of GNU Binutils lacks support for separate address spaces.
 PRU IRAM addresses are marked with artificial offset to differentiate
@@ -48,5 +48,5 @@ index 421ebbc1c02d..a113e150d5d5 100644
  	    da + len <= PRU_IRAM_DA + pru->mem_regions[PRU_IOMEM_IRAM].size) {
  		offset = da - PRU_IRAM_DA;
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0040-remoteproc-pru-Fix-firmware-loading-crashes-on-K3-So.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0040-remoteproc-pru-Fix-firmware-loading-crashes-on-K3-So.patch
@@ -1,7 +1,7 @@
-From 0bbf1d354818732d76d60ea8ac53d2403e4563af Mon Sep 17 00:00:00 2001
+From 295536a7bf27f41854e57017e74e577bd10f8ce6 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Mon, 15 Mar 2021 15:58:59 -0500
-Subject: [PATCH 040/116] remoteproc: pru: Fix firmware loading crashes on K3
+Subject: [PATCH 040/117] remoteproc: pru: Fix firmware loading crashes on K3
  SoCs
 
 The K3 PRUs are 32-bit processors and in general have some limitations
@@ -36,5 +36,5 @@ index a113e150d5d5..21105592a83d 100644
  					       filesz);
  			if (ret) {
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0041-remoteproc-pru-Fixup-interrupt-parent-logic-for-fw-e.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0041-remoteproc-pru-Fixup-interrupt-parent-logic-for-fw-e.patch
@@ -1,7 +1,7 @@
-From f5b0d71543124d9a71373799f8cfdad56962c14b Mon Sep 17 00:00:00 2001
+From e7725e54f61f7a5d0a00051c5c2848f0716b0137 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:39 -0500
-Subject: [PATCH 041/116] remoteproc: pru: Fixup interrupt-parent logic for fw
+Subject: [PATCH 041/117] remoteproc: pru: Fixup interrupt-parent logic for fw
  events
 
 The PRU firmware interrupt mapping logic in pru_handle_intrmap() uses
@@ -74,5 +74,5 @@ index 21105592a83d..773c09d01958 100644
  	return ret;
  }
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0042-remoteproc-pru-Fix-wrong-success-return-value-for-fw.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0042-remoteproc-pru-Fix-wrong-success-return-value-for-fw.patch
@@ -1,7 +1,7 @@
-From 3a09d1469019f15c51a6f243d529ca929ec5b1dd Mon Sep 17 00:00:00 2001
+From 6ba06ee752ecf5d7b57eacb0afdde4ef27232fb4 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:40 -0500
-Subject: [PATCH 042/116] remoteproc: pru: Fix wrong success return value for
+Subject: [PATCH 042/117] remoteproc: pru: Fix wrong success return value for
  fw events
 
 The irq_create_fwspec_mapping() returns a proper virq value on success
@@ -41,5 +41,5 @@ index 773c09d01958..e0c5fce8bccd 100644
  		}
  	}
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0043-remoteproc-pru-Fix-and-cleanup-firmware-interrupt-ma.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0043-remoteproc-pru-Fix-and-cleanup-firmware-interrupt-ma.patch
@@ -1,7 +1,7 @@
-From 04318f4750655bbcc8d5743cff08fa3699ecfc50 Mon Sep 17 00:00:00 2001
+From 1d32bf9b137f437baf679931fbae0672745a0cf5 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:41 -0500
-Subject: [PATCH 043/116] remoteproc: pru: Fix and cleanup firmware interrupt
+Subject: [PATCH 043/117] remoteproc: pru: Fix and cleanup firmware interrupt
  mapping logic
 
 The PRU firmware interrupt mappings are configured and unconfigured in
@@ -95,5 +95,5 @@ index e0c5fce8bccd..d8597027a93e 100644
  	return 0;
  }
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0044-watchdog-Start-watchdog-in-watchdog_set_last_hw_keep.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0044-watchdog-Start-watchdog-in-watchdog_set_last_hw_keep.patch
@@ -1,7 +1,7 @@
-From 8aedfe807760f940e17e248e21e18e309cc5e39f Mon Sep 17 00:00:00 2001
+From 42ba64f21f867826347eba6bc278870427795b6b Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 30 Jul 2021 21:19:38 +0200
-Subject: [PATCH 044/116] watchdog: Start watchdog in
+Subject: [PATCH 044/117] watchdog: Start watchdog in
  watchdog_set_last_hw_keepalive only if appropriate
 
 We must not pet a running watchdog when handle_boot_enabled is off
@@ -33,5 +33,5 @@ index 2946f3a63110..2ee017442dfc 100644
  EXPORT_SYMBOL_GPL(watchdog_set_last_hw_keepalive);
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0045-arm64-dts-ti-iot2050-Flip-mmc-device-ordering-on-Adv.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0045-arm64-dts-ti-iot2050-Flip-mmc-device-ordering-on-Adv.patch
@@ -1,7 +1,7 @@
-From 8115a5cf79a7042530fda8505245f05f77a0c0f9 Mon Sep 17 00:00:00 2001
+From 0383fb98d98d880534365b3d2141ee2874cee50f Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 1 Sep 2021 21:52:11 +0200
-Subject: [PATCH 045/116] arm64: dts: ti: iot2050: Flip mmc device ordering on
+Subject: [PATCH 045/117] arm64: dts: ti: iot2050: Flip mmc device ordering on
  Advanced devices
 
 This ensures that the SD card will remain mmc0 across Basic and Advanced
@@ -27,5 +27,5 @@ index 1008e9162ba2..6261ca8ee2d8 100644
  
  	chosen {
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0046-arm64-dts-ti-iot2050-Disable-SR2.0-only-PRUs.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0046-arm64-dts-ti-iot2050-Disable-SR2.0-only-PRUs.patch
@@ -1,7 +1,7 @@
-From c407d7b9a95a95883a0dbbfd3b3393a4b5fd3468 Mon Sep 17 00:00:00 2001
+From 7c02d936eaac020b5ecaf0d3c9631020f8edbcfb Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 1 Sep 2021 19:58:30 +0200
-Subject: [PATCH 046/116] arm64: dts: ti: iot2050: Disable SR2.0-only PRUs
+Subject: [PATCH 046/117] arm64: dts: ti: iot2050: Disable SR2.0-only PRUs
 
 The IOT2050 devices described so far are using SR1.0 silicon, thus do
 not have the additional PRUs of the ICSSG of the SR2.0. Disable them.
@@ -44,5 +44,5 @@ index 6261ca8ee2d8..58c8e64d5885 100644
 +	status = "disabled";
 +};
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0047-arm64-dts-ti-iot2050-Add-enabled-mailboxes-and-carve.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0047-arm64-dts-ti-iot2050-Add-enabled-mailboxes-and-carve.patch
@@ -1,7 +1,7 @@
-From f0ee3b0b14e6cfb646612c000a01debd15d36139 Mon Sep 17 00:00:00 2001
+From e2b87751e046646d68b61ac1a62b6bb3b321859e Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 9 Sep 2021 08:01:16 +0200
-Subject: [PATCH 047/116] arm64: dts: ti: iot2050: Add/enabled mailboxes and
+Subject: [PATCH 047/117] arm64: dts: ti: iot2050: Add/enabled mailboxes and
  carve-outs for R5F cores
 
 Analogously to the am654-base-board, configure the mailboxes for the the
@@ -62,5 +62,5 @@ index 58c8e64d5885..b29537088289 100644
  	status = "disabled";
  };
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0048-arm64-dts-ti-iot2050-Prepare-for-adding-2nd-generati.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0048-arm64-dts-ti-iot2050-Prepare-for-adding-2nd-generati.patch
@@ -1,7 +1,7 @@
-From 262a03dff963109aec6ebfb3fcfa5dc38f0d989c Mon Sep 17 00:00:00 2001
+From 5662c9a5f1c58c6303daffe2db34af0096046641 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 7 Sep 2021 17:49:55 +0200
-Subject: [PATCH 048/116] arm64: dts: ti: iot2050: Prepare for adding
+Subject: [PATCH 048/117] arm64: dts: ti: iot2050: Prepare for adding
  2nd-generation boards
 
 The current IOT2050 devices are Product Generation 1 (PG1), using SR1.0
@@ -417,5 +417,5 @@ index ec9617c13cdb..077f165bdc68 100644
 -	status = "disabled";
  };
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
@@ -1,7 +1,7 @@
-From 471fd8fdb3007155117fd8a2a3896192a2fd24c8 Mon Sep 17 00:00:00 2001
+From 1c7eb751df346ec3ec1ba4b19f9da5796ca1f36b Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 21 Jun 2021 11:04:56 +0200
-Subject: [PATCH 049/116] arm64: dts: ti: iot2050: Add support for product
+Subject: [PATCH 049/117] arm64: dts: ti: iot2050: Add support for product
  generation 2 boards
 
 This adds the devices trees for IOT2050 Product Generation 2 (PG2)
@@ -158,5 +158,5 @@ index 000000000000..f00dc86d01b9
 +	ti,cluster-mode = <0>;
 +};
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
@@ -1,7 +1,7 @@
-From 3a83e68fc9295ebae2d31f2770185d5432414765 Mon Sep 17 00:00:00 2001
+From 300067fadb298c721ff4737194ead02d197408ae Mon Sep 17 00:00:00 2001
 From: Tomi Valkeinen <tomi.valkeinen@ti.com>
 Date: Mon, 31 May 2021 16:31:35 +0530
-Subject: [PATCH 050/116] arm64: dts: ti: k3-am65-main: fix DSS irq trigger
+Subject: [PATCH 050/117] arm64: dts: ti: k3-am65-main: fix DSS irq trigger
  type
 
 DSS irq trigger type is set to IRQ_TYPE_EDGE_RISING. For some reason this
@@ -35,5 +35,5 @@ index 9338f1042232..9b1a016162b2 100644
  		dma-coherent;
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0051-irqdomain-Export-of_phandle_args_to_fwspec.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0051-irqdomain-Export-of_phandle_args_to_fwspec.patch
@@ -1,7 +1,7 @@
-From 453e4c873269d9cecc35a7785bd31625887f99dc Mon Sep 17 00:00:00 2001
+From 56b75d3dc135bc4121cff25a3f7bf4ea933d7c71 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:46 +0530
-Subject: [PATCH 051/116] irqdomain: Export of_phandle_args_to_fwspec()
+Subject: [PATCH 051/117] irqdomain: Export of_phandle_args_to_fwspec()
 
 Export of_phandle_args_to_fwspec() to be used by drivers.
 of_phandle_args_to_fwspec() can be used by drivers to get irq specifier
@@ -55,5 +55,5 @@ index c6b419db68ef..a17e4ce3811d 100644
  unsigned int irq_create_fwspec_mapping(struct irq_fwspec *fwspec)
  {
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0052-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0052-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
@@ -1,7 +1,7 @@
-From f60fd72ebfb3529450fd927fe708c78afec219c8 Mon Sep 17 00:00:00 2001
+From 1e3c0bfca0c19aa1b03afe1606bba04733ec8f80 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:47 +0530
-Subject: [PATCH 052/116] PCI: keystone: Convert to using hierarchy domain for
+Subject: [PATCH 052/117] PCI: keystone: Convert to using hierarchy domain for
  legacy interrupts
 
 K2G provides separate IRQ lines for each of the four legacy interrupts.
@@ -318,5 +318,5 @@ index 90482d5246ff..0493e43ba416 100644
  err:
  	of_node_put(intc_np);
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
@@ -1,7 +1,7 @@
-From 9d724394f54485a61a10990532371670479d0c8d Mon Sep 17 00:00:00 2001
+From f480dcf24f3ce1836d657b85a4d25d9cc3502811 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:48 +0530
-Subject: [PATCH 053/116] PCI: keystone: Add PCI legacy interrupt support for
+Subject: [PATCH 053/117] PCI: keystone: Add PCI legacy interrupt support for
  AM654
 
 Add PCI legacy interrupt support for AM654. AM654 has a single HW
@@ -135,5 +135,5 @@ index 0493e43ba416..0460ed2a277a 100644
  		return ret;
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
@@ -1,7 +1,7 @@
-From bb4cb3d49447d32d9ad144b27883a4a48ecec5ff Mon Sep 17 00:00:00 2001
+From 166282ff3fd43d060bb4ad0e413ce7199f23e864 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:49 +0530
-Subject: [PATCH 054/116] PCI: keystone: Add workaround for Errata #i2037
+Subject: [PATCH 054/117] PCI: keystone: Add workaround for Errata #i2037
  (AM65x SR 1.0)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -110,5 +110,5 @@ index 0460ed2a277a..bb7190400ba8 100644
  DECLARE_PCI_FIXUP_ENABLE(PCI_ANY_ID, PCI_ANY_ID, ks_pcie_quirk);
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0055-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0055-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
@@ -1,7 +1,7 @@
-From c40be9099b52f979e53c75920c5f8461cf4e23f2 Mon Sep 17 00:00:00 2001
+From d360383f1a3a556289d762ed03885e5a8fb9ccae Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:38:07 +0530
-Subject: [PATCH 055/116] arm64: dts: ti: k3-am65-main: Add properties to
+Subject: [PATCH 055/117] arm64: dts: ti: k3-am65-main: Add properties to
  support legacy interrupts
 
 Add DT properties in PCIe DT node to support legacy interrupts.
@@ -82,5 +82,5 @@ index 9b1a016162b2..b786daed9639 100644
  
  	pcie1_ep: pcie-ep@5600000 {
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0056-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0056-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
@@ -1,7 +1,7 @@
-From 42a18ea79d6f6652d7ea968bc3a3d4dda603d84c Mon Sep 17 00:00:00 2001
+From 83f653bfc2bd83e41dec96f385956513b23147cc Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 20 Nov 2020 21:01:54 -0600
-Subject: [PATCH 056/116] remoteproc: Fix unbalanced boot with sysfs for no
+Subject: [PATCH 056/117] remoteproc: Fix unbalanced boot with sysfs for no
  auto-boot rprocs
 
 The remoteproc core performs automatic boot and shutdown of a remote
@@ -73,5 +73,5 @@ index 1dbef895e65e..3b05230641c8 100644
  		dev_err(&rproc->dev, "Unrecognised option: %s\n", buf);
  		ret = -EINVAL;
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Introduce-deny_sysfs_ops-flag.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Introduce-deny_sysfs_ops-flag.patch
@@ -1,7 +1,7 @@
-From 4589f836c8967133227bee8a36b3b1a667aaac0f Mon Sep 17 00:00:00 2001
+From 7a78ff1b4bdece07569a4afcccc9e23bb2055b0e Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 13:05:28 -0500
-Subject: [PATCH 057/116] remoteproc: Introduce deny_sysfs_ops flag
+Subject: [PATCH 057/117] remoteproc: Introduce deny_sysfs_ops flag
 
 The remoteproc framework provides sysfs interfaces for changing the
 firmware name and for starting/stopping a remote processor through
@@ -95,5 +95,5 @@ index e8ac041c64d9..02425aac6100 100644
  	int nb_vdev;
  	u8 elf_class;
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
@@ -1,7 +1,7 @@
-From 61deb22e4f5754eee60be0d224cc518a6f18312d Mon Sep 17 00:00:00 2001
+From 91a7f5c9bb42a8b437a4fbf91dc491f3cd1b50e9 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:32:29 -0500
-Subject: [PATCH 058/116] remoteproc: pru: Add APIs to get and put the PRU
+Subject: [PATCH 058/117] remoteproc: pru: Add APIs to get and put the PRU
  cores
 
 Add two new APIs, pru_rproc_get() and pru_rproc_put(), to the PRU
@@ -279,5 +279,5 @@ index 000000000000..1a97856b463a
 +
 +#endif /* __LINUX_PRUSS_H */
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
@@ -1,7 +1,7 @@
-From c0449b202016b2feca39f2a5516df8d9663a5fc6 Mon Sep 17 00:00:00 2001
+From 89f0c3125b98acf46558fde1328e62c52f02a850 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 16 Dec 2020 17:52:37 +0100
-Subject: [PATCH 059/116] remoteproc: pru: Deny rproc sysfs ops for PRU client
+Subject: [PATCH 059/117] remoteproc: pru: Deny rproc sysfs ops for PRU client
  driven boots
 
 The PRU remoteproc driver is not configured for 'auto-boot' by default,
@@ -41,5 +41,5 @@ index 0b57b3f7747f..8fac021adc52 100644
  
  	put_device(&rproc->dev);
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
@@ -1,7 +1,7 @@
-From b9809c0e54d05cf24d3ad3331d2ffa278b05365a Mon Sep 17 00:00:00 2001
+From 330e14d16d756466ea5340a5c7a3d8bf125c9214 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Fri, 26 Mar 2021 15:43:53 -0500
-Subject: [PATCH 060/116] remoteproc: pru: Add pru_rproc_set_ctable() function
+Subject: [PATCH 060/117] remoteproc: pru: Add pru_rproc_set_ctable() function
 
 Some firmwares expect the OS drivers to configure the CTABLE
 entries publishing dynamically allocated memory regions. For
@@ -182,5 +182,5 @@ index 1a97856b463a..e1740ff06962 100644
  
  static inline bool is_pru_rproc(struct device *dev)
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Configure-firmware-based-on-client-se.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Configure-firmware-based-on-client-se.patch
@@ -1,7 +1,7 @@
-From a34bcaf922a727ba7486163eae17b137188f3a12 Mon Sep 17 00:00:00 2001
+From 67ff020c98a27658cd230ee008b9f806c7a3982a Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:50:14 -0500
-Subject: [PATCH 061/116] remoteproc: pru: Configure firmware based on client
+Subject: [PATCH 061/117] remoteproc: pru: Configure firmware based on client
  setup
 
 Client device node property firmware-name is now used to configure
@@ -104,5 +104,5 @@ index 90c097ebc27e..c346899d5e3b 100644
  	pru->client_np = NULL;
  	rproc->deny_sysfs_ops = false;
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0062-soc-ti-pruss-Add-pruss_get-put-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0062-soc-ti-pruss-Add-pruss_get-put-API.patch
@@ -1,7 +1,7 @@
-From 00affafb5370efe9d80a4474666ef344087250b1 Mon Sep 17 00:00:00 2001
+From a427cddd1302a8d03ca3a51cdd322e826fd2dfe3 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:58:00 -0500
-Subject: [PATCH 062/116] soc: ti: pruss: Add pruss_get()/put() API
+Subject: [PATCH 062/117] soc: ti: pruss: Add pruss_get()/put() API
 
 Add two new get and put API, pruss_get() and pruss_put() to the
 PRUSS platform driver to allow client drivers to request a handle
@@ -176,5 +176,5 @@ index ecfded30ed05..4d1321f0d326 100644
  
  /*
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
@@ -1,7 +1,7 @@
-From 24b1c2058fdd89498647586ba46af251adaa08ae Mon Sep 17 00:00:00 2001
+From b8501c77dd100393d6a590e162c0da90d7f5154d Mon Sep 17 00:00:00 2001
 From: "Andrew F. Davis" <afd@ti.com>
 Date: Fri, 26 Mar 2021 16:11:42 -0500
-Subject: [PATCH 063/116] soc: ti: pruss: Add
+Subject: [PATCH 063/117] soc: ti: pruss: Add
  pruss_{request,release}_mem_region() API
 
 Add two new API - pruss_request_mem_region() & pruss_release_mem_region(),
@@ -236,5 +236,5 @@ index 4d1321f0d326..f1d1197fd91a 100644
  	struct clk *iep_clk_mux;
  };
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
@@ -1,7 +1,7 @@
-From e7f7e24b315b6d7da585efc8724a733860920036 Mon Sep 17 00:00:00 2001
+From 4a7255e8a5cb4230ba2cdb2e890ee5ed08e1c3b3 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:27:34 -0500
-Subject: [PATCH 064/116] soc: ti: pruss: Add pruss_cfg_read()/update() API
+Subject: [PATCH 064/117] soc: ti: pruss: Add pruss_cfg_read()/update() API
 
 Add two new generic API pruss_cfg_read() and pruss_cfg_update() to
 the PRUSS platform driver to allow other drivers to read and program
@@ -209,5 +209,5 @@ index 40de553d4446..a4f59a46c331 100644
  
  #if IS_ENABLED(CONFIG_PRU_REMOTEPROC)
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
@@ -1,7 +1,7 @@
-From f3abbc9d186151a63fb5f416eddff5013e0e8e64 Mon Sep 17 00:00:00 2001
+From 22054ae8c8225bb7b349696d58628a11c027d145 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 11 Dec 2020 19:48:09 +0100
-Subject: [PATCH 065/116] soc: ti: pruss: Add helper functions to set GPI mode,
+Subject: [PATCH 065/117] soc: ti: pruss: Add helper functions to set GPI mode,
  MII_RT_event and XFR
 
 The PRUSS CFG module is represented as a syscon node and is currently
@@ -82,5 +82,5 @@ index a4f59a46c331..ba5b728d5015 100644
 +
  #endif /* __LINUX_PRUSS_H */
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
@@ -1,7 +1,7 @@
-From 3207317180889a69b60c30b96186f78c1e16684b Mon Sep 17 00:00:00 2001
+From c9432f24bb7aaf198838d587bd8b52aee6426abc Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:38:11 -0500
-Subject: [PATCH 066/116] soc: ti: pruss: Add helper function to enable OCP
+Subject: [PATCH 066/117] soc: ti: pruss: Add helper function to enable OCP
  master ports
 
 The PRU-ICSS subsystem on OMAP-architecture based SoCS (AM33xx, AM437x
@@ -178,5 +178,5 @@ index ba5b728d5015..5fdd6f03446d 100644
  
  #if IS_ENABLED(CONFIG_PRU_REMOTEPROC)
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
@@ -1,7 +1,7 @@
-From aca173a16a5d4f412172fb4c7e6422b34de4fd45 Mon Sep 17 00:00:00 2001
+From ce754eb32ffbf8ac191adcbe62bab227693b6f6d Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 09:24:51 -0500
-Subject: [PATCH 067/116] soc: ti: pruss: Add helper functions to get/set
+Subject: [PATCH 067/117] soc: ti: pruss: Add helper functions to get/set
  PRUSS_CFG_GPMUX
 
 Add two new helper functions pruss_cfg_get_gpmux() & pruss_cfg_set_gpmux()
@@ -71,5 +71,5 @@ index f1d1197fd91a..d6abfdd17631 100644
 +
  #endif	/* _PRUSS_DRIVER_H_ */
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0068-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0068-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
@@ -1,7 +1,7 @@
-From 2cccf8035953dd9a274edd977d44491c56904a3d Mon Sep 17 00:00:00 2001
+From 89f59117b5e77c473d1c16fc211ca7fb3a795ebe Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 10:11:42 -0500
-Subject: [PATCH 068/116] remoteproc/pru: add support for configuring GPMUX
+Subject: [PATCH 068/117] remoteproc/pru: add support for configuring GPMUX
  based on client setup
 
 Client device node property ti,pruss-gp-mux-sel can now be used to
@@ -75,5 +75,5 @@ index c346899d5e3b..7ef176170b18 100644
  
  	mutex_lock(&pru->lock);
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0069-net-ethernet-ti-prueth-Add-IEP-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0069-net-ethernet-ti-prueth-Add-IEP-driver.patch
@@ -1,7 +1,7 @@
-From 027d132920acaceaf99026b9e5d04ed2a29b5860 Mon Sep 17 00:00:00 2001
+From 5a4993fe2cf8b050ce2c87d873d934cd576cb11c Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 20 Apr 2021 13:17:30 +0530
-Subject: [PATCH 069/116] net: ethernet: ti: prueth: Add IEP driver
+Subject: [PATCH 069/117] net: ethernet: ti: prueth: Add IEP driver
 
 Add a driver for Industrial Ethernet Peripheral (IEP) block of PRUSS to
 support timestamping of ethernet packets and thus support PTP and PPS
@@ -1146,5 +1146,5 @@ index 000000000000..a41e18df666e
 +
 +#endif /* __NET_TI_ICSS_IEP_H */
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0070-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0070-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
@@ -1,7 +1,7 @@
-From ebf8d21995d8624a247a30dfc71079d64f9cdf55 Mon Sep 17 00:00:00 2001
+From b3a73239499f705c61f85d154aacb2df7358d06a Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Tue, 20 Apr 2021 13:17:31 +0530
-Subject: [PATCH 070/116] HACK: net: ethernet: ti: icss-iep: Fix sync0
+Subject: [PATCH 070/117] HACK: net: ethernet: ti: icss-iep: Fix sync0
  generation on a compare event
 
 commit 41e5c46849b5 ("net: ethernet: ti: icss-iep: Add support for generating
@@ -119,5 +119,5 @@ index 234972a034a9..22034d41c988 100644
  EXPORT_SYMBOL_GPL(icss_iep_put);
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0071-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0071-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
@@ -1,7 +1,7 @@
-From f8b5ae2cef8898d3ed37a72540e95304748475a6 Mon Sep 17 00:00:00 2001
+From 795bd62e98732dc54b90eed72e34e2ce94643e31 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:28 +0300
-Subject: [PATCH 071/116] net: ethernet: ti: icss_iep: drop
+Subject: [PATCH 071/117] net: ethernet: ti: icss_iep: drop
  ICSS_IEP_CAPx_FALL_REGy
 
 ICSS_IEP_CAPx_FALL_REGy are not used, but cause indexation issues in
@@ -80,5 +80,5 @@ index 22034d41c988..60a284c6c0c9 100644
  		[ICSS_IEP_CMP_CFG_REG] = 0x40,
  		[ICSS_IEP_CMP_STAT_REG] = 0x44,
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
@@ -1,7 +1,7 @@
-From 79660be71868c8d305e0a1039b127981250ae412 Mon Sep 17 00:00:00 2001
+From 4afcf2f7fc9669ca4c4507480ca083af695090fb Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:29 +0300
-Subject: [PATCH 072/116] net: ethernet: ti: icss_iep: fix access to x_REG1 in
+Subject: [PATCH 072/117] net: ethernet: ti: icss_iep: fix access to x_REG1 in
  non 64bit mode
 
 Do not access x_REG1 registers in non 64bit mode.
@@ -93,5 +93,5 @@ index 60a284c6c0c9..73c0a31e8245 100644
  			pevent.type = PTP_CLOCK_EXTTS;
  			pevent.index = i;
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
@@ -1,7 +1,7 @@
-From 0339118a256447b1d9df60449eb2ade78e9780dc Mon Sep 17 00:00:00 2001
+From 0fc710cc35fca2806d3b6516362906743735ab39 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:30 +0300
-Subject: [PATCH 073/116] net: ethernet: ti: icss_iep: disable extts and pps if
+Subject: [PATCH 073/117] net: ethernet: ti: icss_iep: disable extts and pps if
  no slow compensation or non 64bit mode
 
 Disable extts and pps if no slow compensation support or non 64bit mode.
@@ -37,5 +37,5 @@ index 73c0a31e8245..c0bcb1d1180a 100644
  
  put_iep_device:
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
@@ -1,7 +1,7 @@
-From 30a085109e66db87a7a7057d00eacff72a1f41b5 Mon Sep 17 00:00:00 2001
+From 2e22afeae8d3f0384ddee7c78a201de150fddc78 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:31 +0300
-Subject: [PATCH 074/116] net: ethernet: ti: icss_iep: fix pps irq race vs pps
+Subject: [PATCH 074/117] net: ethernet: ti: icss_iep: fix pps irq race vs pps
  disable
 
 When PPS is disabled the PPS IRQ can be running and PPS timer started which
@@ -123,5 +123,5 @@ index c0bcb1d1180a..ead1e7c94021 100644
  	mutex_unlock(&iep->ptp_clk_mutex);
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
@@ -1,7 +1,7 @@
-From 18eb60af0c76883188edcaaf957a81d7060ca45d Mon Sep 17 00:00:00 2001
+From cf7cfabad0625afe04c7e7801379f3f66efab217 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:32 +0300
-Subject: [PATCH 075/116] net: ethernet: ti: icss_iep: improve icss_iep_gettime
+Subject: [PATCH 075/117] net: ethernet: ti: icss_iep: improve icss_iep_gettime
 
 There are few issues with icss_iep_gettime():
 - it has to be very fast, but it's not protected from interruption
@@ -69,5 +69,5 @@ index ead1e7c94021..cbec01328a71 100644
  
  static void icss_iep_enable(struct icss_iep *iep)
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
@@ -1,7 +1,7 @@
-From d56570c4be5b7d97edd9785eafce86cdcd3575ec Mon Sep 17 00:00:00 2001
+From 535a491cb0db7e62e74fe08919aa7d19b277406a Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:33 +0300
-Subject: [PATCH 076/116] net: ethernet: ti: icss_iep: simplify peroutput
+Subject: [PATCH 076/117] net: ethernet: ti: icss_iep: simplify peroutput
  processing
 
 simplify peroutput processing
@@ -114,5 +114,5 @@ index cbec01328a71..b39d4c08c6c9 100644
  		hrtimer_start(&iep->sync_timer, ms_to_ktime(110), /* 100ms + buffer */
  			      HRTIMER_MODE_REL);
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
@@ -1,7 +1,7 @@
-From f77d3d4fc159a60f1d8615f6c7ed6be3e6fec9d7 Mon Sep 17 00:00:00 2001
+From 65b9659dde466acca350e95dd8f08eb755d612fe Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:34 +0300
-Subject: [PATCH 077/116] net: ethernet: ti: icss_iep: use readl/writel in
+Subject: [PATCH 077/117] net: ethernet: ti: icss_iep: use readl/writel in
  cap_cmp_handler
 
 Use readl/writel in cap_cmp_handler and timer handler instead of regmap
@@ -102,5 +102,5 @@ index b39d4c08c6c9..e2663dd5cf38 100644
  	return HRTIMER_NORESTART;
  }
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
@@ -1,7 +1,7 @@
-From 668a7d614c71db72aa4a0d6bab7175772ce74e0f Mon Sep 17 00:00:00 2001
+From 076b663dc9f13fba916a7f3a10ac2db53283bb21 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:35 +0300
-Subject: [PATCH 078/116] net: ethernet: ti: icss_iep: switch to .gettimex64()
+Subject: [PATCH 078/117] net: ethernet: ti: icss_iep: switch to .gettimex64()
 
 The .gettime64() is deprecated by commit 916444df305e ("ptp: deprecate
 gettime64() in favor of gettimex64()").
@@ -95,5 +95,5 @@ index e2663dd5cf38..c0497b448d68 100644
  	.enable		= icss_iep_ptp_enable,
  };
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
@@ -1,7 +1,7 @@
-From c06ad7ba1e9e45df9868a98e13eaab04acce242b Mon Sep 17 00:00:00 2001
+From 136383e17d52e2eae8871df2d03e6a37acccc26a Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Thu, 29 Apr 2021 18:13:36 +0300
-Subject: [PATCH 079/116] net: ethernet: ti: icss_iep: Update compare registers
+Subject: [PATCH 079/117] net: ethernet: ti: icss_iep: Update compare registers
  after changing ptp clock time
 
 Consider the scenario where PPS is enabled, then iep set_time or adjust_time is
@@ -60,5 +60,5 @@ index c0497b448d68..8bad9c86775a 100644
  
  static u64 icss_iep_gettime(struct icss_iep *iep,
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
@@ -1,7 +1,7 @@
-From 8218d69c400d6ff9d3504f13487f693ebe6075f2 Mon Sep 17 00:00:00 2001
+From 3411da318c531d45613d6b63d008001b2a19c24e Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:37 +0300
-Subject: [PATCH 080/116] net: ethernet: ti: icss_iep: request cmp_cap irq from
+Subject: [PATCH 080/117] net: ethernet: ti: icss_iep: request cmp_cap irq from
  probe
 
 The current INTC design allows to define IEP cmp_cap IRQ explicitly for IEP
@@ -106,5 +106,5 @@ index 8bad9c86775a..df74b5fd17e9 100644
  	if (IS_ERR(iep_clk))
  		return PTR_ERR(iep_clk);
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
@@ -1,7 +1,7 @@
-From 74f63476a6c8f513e97fe57ed70f3f1ea85e25e2 Mon Sep 17 00:00:00 2001
+From f3ced8a45574b102424275929877531b7fe33200 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:38 +0300
-Subject: [PATCH 081/116] net: ethernet: ti: icss_iep: set phc time to system
+Subject: [PATCH 081/117] net: ethernet: ti: icss_iep: set phc time to system
  time on init
 
 Following customer feedback IEP PHC time has to be set to system time on
@@ -28,5 +28,5 @@ index df74b5fd17e9..08b456f0bc12 100644
  	iep->clk_tick_time = def_inc;
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
@@ -1,7 +1,7 @@
-From 1b5b9f3bd2747b3786d1571ab46e8303ae0f3ae0 Mon Sep 17 00:00:00 2001
+From 86bd8117fdf1fcb2cd32871c7b5a6dabf1667485 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:39 +0300
-Subject: [PATCH 082/116] net: ethernet: ti: icss_iep: use
+Subject: [PATCH 082/117] net: ethernet: ti: icss_iep: use
  devm_platform_ioremap_resource
 
 Use devm_platform_ioremap_resource() in probe to simplify code.
@@ -35,5 +35,5 @@ index 08b456f0bc12..640f483854d0 100644
  		return -ENODEV;
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0083-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0083-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
@@ -1,7 +1,7 @@
-From 48d33938e66ef28217dbcfb422fc8b7a0a53f63a Mon Sep 17 00:00:00 2001
+From 58c68f824983077a042ab4c637eb998f128727b0 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 16 Mar 2021 18:00:25 -0500
-Subject: [PATCH 083/116] arm64: dts: ti: k3-am65-main: Add ICSSG IEP nodes
+Subject: [PATCH 083/117] arm64: dts: ti: k3-am65-main: Add ICSSG IEP nodes
 
 The ICSSG IP on AM65x SoCs have two Industrial Ethernet Peripherals (IEPs)
 to manage/generate Industrial Ethernet functions such as time stamping.
@@ -77,5 +77,5 @@ index b786daed9639..d0e565fb5e12 100644
  			compatible = "ti,pruss-mii", "syscon";
  			reg = <0x32000 0x100>;
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0084-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0084-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
@@ -1,7 +1,7 @@
-From 1e389c8a9d3e0d0d45371d5803ae9321a036af32 Mon Sep 17 00:00:00 2001
+From 6d56d9ef7db247174ad40c86024fe073a274392d Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:22 +0300
-Subject: [PATCH 084/116] dt-bindings: net: Add binding for ti,icssg-prueth
+Subject: [PATCH 084/117] dt-bindings: net: Add binding for ti,icssg-prueth
  device
 
 This is the DT binding document for the ICSSG Dual-EMAC Ethernet
@@ -149,5 +149,5 @@ index 000000000000..67609e26afa5
 +		};
 +	};
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0085-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0085-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
@@ -1,7 +1,7 @@
-From 25dc558d045bd6956a4617bcd5f48e1642f8c93a Mon Sep 17 00:00:00 2001
+From 9ac2ff3611960db8f9ce26c03499f2850413c20a Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:23 +0300
-Subject: [PATCH 085/116] net: ti: icssg-prueth: Add ICSSG ethernet driver
+Subject: [PATCH 085/117] net: ti: icssg-prueth: Add ICSSG ethernet driver
 
 This is the Ethernet driver for TI SoCs with the
 ICSSG PRU Sub-system running dual-EMAC firmware.
@@ -4497,5 +4497,5 @@ index 5fdd6f03446d..2a034c08b4c2 100644
  /*
   * enum pruss_gp_mux_sel - PRUSS GPI/O Mux modes for the
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0086-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0086-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
@@ -1,7 +1,7 @@
-From 233ec86faf1c7191897cd1334af1d939656c1892 Mon Sep 17 00:00:00 2001
+From 1e6fd9b8f8e3fb9e4696283cd2fd0d60c30a9252 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:24 +0300
-Subject: [PATCH 086/116] net: ethernet: ti: icssg_prueth: add 10M full duplex
+Subject: [PATCH 086/117] net: ethernet: ti: icssg_prueth: add 10M full duplex
  support
 
 For 10M support RGMII need to be configured in inband mode and FW has to be
@@ -250,5 +250,5 @@ index bf52d350bdd0..644a22b53424 100644
  #define TAS_GATE_MASK_LIST0                                0x0100
  /*TAS gate mask for windows list1*/
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
@@ -1,7 +1,7 @@
-From b8578a2a208ddb70f159a59ece6fb0c8c9e674e1 Mon Sep 17 00:00:00 2001
+From 8c119383f751e60f48a3a83fea47f25c9f9263fd Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:25 +0300
-Subject: [PATCH 087/116] net: ethernet: ti: icssg_prueth: Use DMA device for
+Subject: [PATCH 087/117] net: ethernet: ti: icssg_prueth: Use DMA device for
  DMA API
 
 For DMA API the DMA device should be used as cpsw does not accesses to
@@ -342,5 +342,5 @@ index 69c558eb004d..2e8d45c8c25d 100644
  	struct k3_udma_glue_rx_channel *rx_chn;
  	u32 descs_num;
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
@@ -1,7 +1,7 @@
-From caa778642db76df295ee110120b510cdefadc7f5 Mon Sep 17 00:00:00 2001
+From 61800549eb9f6223d51eb28e1417860c85f81448 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:26 +0300
-Subject: [PATCH 088/116] net: ethernet: ti: icss_iep: add icss_iep_get_idx()
+Subject: [PATCH 088/117] net: ethernet: ti: icss_iep: add icss_iep_get_idx()
  api
 
 Add icss_iep_get_idx() API to allow retrieve IEP from phandle list in DT.
@@ -59,5 +59,5 @@ index a41e18df666e..eefc8c8bd8cc 100644
  int icss_iep_init(struct icss_iep *iep, const struct icss_iep_clockops *clkops,
  		  void *clockops_data, u32 cycle_time_ns);
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
@@ -1,7 +1,7 @@
-From 184b7ebaca759e9dcf3f3d062c1ea25e5625dbf2 Mon Sep 17 00:00:00 2001
+From d6b4b9cb7e0ae4df3cccaedf1d3623bfd792bcce Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:27 +0300
-Subject: [PATCH 089/116] net: ethernet: ti: icss_iep: use readl() in
+Subject: [PATCH 089/117] net: ethernet: ti: icss_iep: use readl() in
  icss_iep_get_count_low/hi()
 
 Use readl() in icss_iep_get_count_low/hi() to speed up hot path.
@@ -35,5 +35,5 @@ index 51f8717fc446..23e72e0ffe46 100644
  	return val;
  }
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
@@ -1,7 +1,7 @@
-From 196ccfc7a0cc6e7c29e3f21ec6adbc3897ac49ff Mon Sep 17 00:00:00 2001
+From 8208bd299b3e426bbd211f60a4fc8780224e723a Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:28 +0300
-Subject: [PATCH 090/116] net: ethernet: ti: icss_iep: fix init for sr2.0
+Subject: [PATCH 090/117] net: ethernet: ti: icss_iep: fix init for sr2.0
 
 There are two issues with IEP initialization for ICSSG SR2.0 where only one
 IEP0 is used in shadow mode:
@@ -147,5 +147,5 @@ index 23e72e0ffe46..eec7e9fb1f61 100644
  	dev_set_drvdata(dev, iep);
  	icss_iep_disable(iep);
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
@@ -1,7 +1,7 @@
-From f94d3159e92321db554d35aa27da77b8779673ff Mon Sep 17 00:00:00 2001
+From 7b2b9ba6701a8d5077b84260417226eb1259d9c8 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:29 +0300
-Subject: [PATCH 091/116] net: ethernet: ti: icss_iep: sr2.0 fix NULL pointer
+Subject: [PATCH 091/117] net: ethernet: ti: icss_iep: sr2.0 fix NULL pointer
  exception on pps stop
 
 The NULL pointer exception is observed on pps stop - fix it as timer is not
@@ -38,5 +38,5 @@ index eec7e9fb1f61..0ed54c8251e2 100644
  	}
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0092-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0092-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
@@ -1,7 +1,7 @@
-From a142c398d05803280f37ed78fabef57cf4b52673 Mon Sep 17 00:00:00 2001
+From bfa8432d3ef27e0f74b85a88b689e24d6cf916ac Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:30 +0300
-Subject: [PATCH 092/116] net: ti: ethernet: icssg-prueth: add packet
+Subject: [PATCH 092/117] net: ti: ethernet: icssg-prueth: add packet
  timestamping and ptp support
 
 Add packet timestamping TS and PTP PHC clock support.
@@ -856,5 +856,5 @@ index 2e8d45c8c25d..156716bf0a76 100644
  
  struct emac_tx_ts_response_sr1 {
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0093-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0093-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
@@ -1,7 +1,7 @@
-From 7fe19921deaedc3c69190b10d759371d186d2262 Mon Sep 17 00:00:00 2001
+From a55c51ac21e05459596a94440969e375011aa011 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:33 +0300
-Subject: [PATCH 093/116] net: ethernet: ti: icssg_prueth: add am64x icssg
+Subject: [PATCH 093/117] net: ethernet: ti: icssg_prueth: add am64x icssg
  support
 
 Add AM64x ICSSG support which is similar to am65x SR2.0, but required:
@@ -120,5 +120,5 @@ index 156716bf0a76..b536ac5ec0bf 100644
  
  struct emac_tx_ts_response_sr1 {
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
@@ -1,7 +1,7 @@
-From 8c9d57c440a9f84e0487d65e203a01c67191e2ca Mon Sep 17 00:00:00 2001
+From 12f51f24602c53c7a576466b3e673bdff61ce266 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 19 May 2021 19:31:36 +0300
-Subject: [PATCH 094/116] net: ethernet: ti: icssg_prueth: am65x SR2.0 add 10M
+Subject: [PATCH 094/117] net: ethernet: ti: icssg_prueth: am65x SR2.0 add 10M
  full duplex support
 
 For for AM65x SR2.0 it's required to enable IEP1 in raw 64bit mode which is
@@ -158,5 +158,5 @@ index b536ac5ec0bf..7cc81c67bf72 100644
  
  /**
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0095-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0095-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
@@ -1,7 +1,7 @@
-From 18ea22e5f2a76dcfc855d90a6df97360abf697aa Mon Sep 17 00:00:00 2001
+From 900d37e253c2b00f3cf9417516c704722f550573 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Mon, 21 Jun 2021 15:47:49 +0530
-Subject: [PATCH 095/116] net: ti: icssg_prueth: Free desc pool before DMA
+Subject: [PATCH 095/117] net: ti: icssg_prueth: Free desc pool before DMA
  channel release
 
 Release DMA desc pool associated with channel before releasing the
@@ -48,5 +48,5 @@ index ef7392a2b9da..38d151dca81c 100644
  		 * end after all channel resources are freed
  		 */
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0096-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0096-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
@@ -1,7 +1,7 @@
-From 44aa753795d955a085bd83d59c3595e963b3f9c8 Mon Sep 17 00:00:00 2001
+From 76d073c6038e3563a23ea638a53eb9008b61ebdc Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:47 +0300
-Subject: [PATCH 096/116] net: ethernet: icssg-prueth: fix rgmii tx delay
+Subject: [PATCH 096/117] net: ethernet: icssg-prueth: fix rgmii tx delay
  configuration
 
 The driver enables RGMII TX delay without checking specified
@@ -125,5 +125,5 @@ index 38d151dca81c..d19a05fd8b06 100644
  		if (ret)
  			goto put_cores;
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
@@ -1,7 +1,7 @@
-From 145877b43639748cd3a602da51bce2e1f035c406 Mon Sep 17 00:00:00 2001
+From 5299479646bc1e7250fbf6dd4bfe51c0c43ebb51 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:48 +0300
-Subject: [PATCH 097/116] net: ethernet: icssg-prueth: enable "fixed-link"
+Subject: [PATCH 097/117] net: ethernet: icssg-prueth: enable "fixed-link"
  connection
 
 The ICSSG has incomplete and incorrect "fixed-link" connection type
@@ -71,5 +71,5 @@ index d19a05fd8b06..3b1769a5e2b3 100644
  		ret = -EPROBE_DEFER;
  		goto free;
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
@@ -1,7 +1,7 @@
-From 7ead1b6daf15fa16a618dff1d6e2b11003aa8843 Mon Sep 17 00:00:00 2001
+From 335f3ad1111bfeae47373baf2aa24afe0f780deb Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:12 +0300
-Subject: [PATCH 098/116] net: ethernet: icssg-prueth: fix bug 'scheduling
+Subject: [PATCH 098/117] net: ethernet: icssg-prueth: fix bug 'scheduling
  while atomic' from emac_ndo_set_rx_mode()
 
 The .ndo_set_rx_mode() is called with BH disabled and should be atomic, but
@@ -133,5 +133,5 @@ index 7cc81c67bf72..59dec45a3c86 100644
  	struct pruss_mem_region dram;
  };
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
@@ -1,7 +1,7 @@
-From 36f246396aa2d44d4d96e7316bb8e5aac99d616f Mon Sep 17 00:00:00 2001
+From cfea1cb070e70e43b28f723c4151a75f170f7982 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:13 +0300
-Subject: [PATCH 099/116] net: ethernet: icssg-prueth: fix enabling/disabling
+Subject: [PATCH 099/117] net: ethernet: icssg-prueth: fix enabling/disabling
  port in emac_adjust_link()
 
 The port state is set to FORWARD in emac_ndo_open() and never changed, but
@@ -59,5 +59,5 @@ index f212e5904afc..abd062bedebb 100644
  
  reset_tx_chan:
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0100-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0100-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
@@ -1,7 +1,7 @@
-From 69a0c275b5a148d857f8748934aaf4f8b9c72ddd Mon Sep 17 00:00:00 2001
+From beb85b125dc8df2a7fe2aa77a31b22ccc0a5331b Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 27 Jun 2020 10:53:13 +0200
-Subject: [PATCH 100/116] arm64: dts: ti: iot2050: Add icssg-prueth nodes for
+Subject: [PATCH 100/117] arm64: dts: ti: iot2050: Add icssg-prueth nodes for
  PG1 and PG2 devices
 
 Add the required nodes to enable ICSSG SR1.0 and SR2.0 based prueth
@@ -206,5 +206,5 @@ index 65da226847f4..2faefccca7a9 100644
  
  &icssg1_mdio {
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0101-HACK-setting-the-RJ45-port-led-behavior.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0101-HACK-setting-the-RJ45-port-led-behavior.patch
@@ -1,7 +1,7 @@
-From 7803d41538b257887078d392fec539eeda638ead Mon Sep 17 00:00:00 2001
+From 01a82140da1504d36916e37ce23f3947c00e77ec Mon Sep 17 00:00:00 2001
 From: zengchao <chao.zeng@siemens.com>
 Date: Wed, 6 Nov 2019 11:21:49 +0800
-Subject: [PATCH 101/116] HACK: setting the RJ45 port led behavior
+Subject: [PATCH 101/117] HACK: setting the RJ45 port led behavior
 
 Temporary needed until we have a proper, likely LED-class based
 solution upstream.
@@ -37,5 +37,5 @@ index c716074fdef0..9ee2375782b3 100644
  }
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0102-WIP-feat-extend-led-panic-indicator-on-and-off.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0102-WIP-feat-extend-led-panic-indicator-on-and-off.patch
@@ -1,7 +1,7 @@
-From 07eb0c0db6e68355b7afb9d5bc743d77f8e667e4 Mon Sep 17 00:00:00 2001
+From 5c58c1c7dd1d6240792a7caf2ed67540e2bc1dde Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Tue, 22 Dec 2020 15:05:56 +0800
-Subject: [PATCH 102/116] WIP: feat:extend led panic-indicator on and off
+Subject: [PATCH 102/117] WIP: feat:extend led panic-indicator on and off
 
 WIP because upstream strategy is still under discussion.
 
@@ -124,5 +124,5 @@ index 6a8d6409c993..d84423d42f89 100644
  	int 		num_leds;
  	const struct gpio_led *leds;
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0103-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0103-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
@@ -1,7 +1,7 @@
-From 20606211f83ef718e31c8c671c3b332764f98147 Mon Sep 17 00:00:00 2001
+From 87a5ab0fac9c11116c8993ec2e994f3547f4089a Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Mar 2021 15:28:21 +0100
-Subject: [PATCH 103/116] WIP: arm64: dts: ti: iot2050: Add node for generic
+Subject: [PATCH 103/117] WIP: arm64: dts: ti: iot2050: Add node for generic
  spidev
 
 This allows to use mcu_spi0 via userspace spidev.
@@ -33,5 +33,5 @@ index 2faefccca7a9..3510948e9d41 100644
  
  &tscadc0 {
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0104-watchdog-rti-wdt-Provide-set_timeout-handler-to-make.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0104-watchdog-rti-wdt-Provide-set_timeout-handler-to-make.patch
@@ -1,7 +1,7 @@
-From 4cdc7709ed27c977d6e20f806e155b522a240b4f Mon Sep 17 00:00:00 2001
+From 26b13cfff751fbf7ec153160f43df876b7cc9c33 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 13 Sep 2021 12:27:17 +0200
-Subject: [PATCH 104/116] watchdog: rti-wdt: Provide set_timeout handler to
+Subject: [PATCH 104/117] watchdog: rti-wdt: Provide set_timeout handler to
  make existing userspace happy
 
 Prominent userspace - systemd - cannot handle watchdogs without
@@ -57,5 +57,5 @@ index 359302f71f7e..365255b15a0d 100644
  };
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0105-dt-bindings-net-ti-icssg-prueth-Add-documentation-fo.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0105-dt-bindings-net-ti-icssg-prueth-Add-documentation-fo.patch
@@ -1,7 +1,7 @@
-From cfde63d4e0422f9771be393c0b3b3f5268c77f48 Mon Sep 17 00:00:00 2001
+From e711ed4c41afde0bbb4b1418c7bbf5fb039a917e Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Tue, 12 Oct 2021 13:54:41 +0300
-Subject: [PATCH 105/116] dt-bindings: net: ti, icssg-prueth: Add documentation
+Subject: [PATCH 105/117] dt-bindings: net: ti, icssg-prueth: Add documentation
  for half duplex
 
 In order to support half-duplex operation at 10M and 100M link speeds, the
@@ -37,5 +37,5 @@ index 125a204ef2d2..41cba6907fc9 100644
  Example (k3-am654 base board SR2.0, dual-emac):
  ==============================================
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0106-net-ethernet-icssg-prueth-sr1.0-add-support-for-half.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0106-net-ethernet-icssg-prueth-sr1.0-add-support-for-half.patch
@@ -1,7 +1,7 @@
-From e085a3bd27b1660e6952be40d617fe779fddb8f1 Mon Sep 17 00:00:00 2001
+From 3396600d6c25abb7b925243acf46a49ac5d16289 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 12 Oct 2021 13:54:42 +0300
-Subject: [PATCH 106/116] net: ethernet: icssg-prueth: sr1.0: add support for
+Subject: [PATCH 106/117] net: ethernet: icssg-prueth: sr1.0: add support for
  half duplex operation
 
 This patch adds support for half duplex operation at 10M and 100M link
@@ -103,5 +103,5 @@ index 59dec45a3c86..917c6f9a2514 100644
  	/* DMA related */
  	struct prueth_tx_chn tx_chns[PRUETH_MAX_TX_QUEUES];
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0107-net-ethernet-icssg-prueth-sr2.0-add-support-for-half.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0107-net-ethernet-icssg-prueth-sr2.0-add-support-for-half.patch
@@ -1,7 +1,7 @@
-From 453f34a8c848f3060339bf1edb00c35680bd04df Mon Sep 17 00:00:00 2001
+From 767bec9760c39358a4ad6e5c8709ca36a931754b Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 12 Oct 2021 13:54:43 +0300
-Subject: [PATCH 107/116] net: ethernet: icssg-prueth: sr2.0: add support for
+Subject: [PATCH 107/117] net: ethernet: icssg-prueth: sr2.0: add support for
  half duplex operation
 
 This patch adds support for half duplex operation at 10M and 100M link
@@ -135,5 +135,5 @@ index 644a22b53424..99225d0f1582 100644
  /* Memory Usage of : DMEM1
   *
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0108-arm64-dts-ti-add-the-support-for-the-half-duplex.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0108-arm64-dts-ti-add-the-support-for-the-half-duplex.patch
@@ -1,7 +1,7 @@
-From 7839f5faa70144f7f3ee3c72abed1f1a0c3ea796 Mon Sep 17 00:00:00 2001
+From 4e6316f7293ec46ac7960e429ebf3b903bb04515 Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Fri, 22 Oct 2021 13:37:22 +0800
-Subject: [PATCH 108/116] arm64: dts: ti: add the support for the half-duplex
+Subject: [PATCH 108/117] arm64: dts: ti: add the support for the half-duplex
 
 origin from TI and add the dts property to support the half-duplex for ethernet port
 
@@ -31,5 +31,5 @@ index 3510948e9d41..34a4bcec204a 100644
  			local-mac-address = [00 00 00 00 00 00];
  		};
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0109-USB-serial-cp210x-return-early-on-unchanged-termios.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0109-USB-serial-cp210x-return-early-on-unchanged-termios.patch
@@ -1,7 +1,7 @@
-From a5d1fe3ede8bd9484c48855ee3a8f09343601011 Mon Sep 17 00:00:00 2001
+From d1faa633d39fc5acf68b4ef07aaaf06212937dd8 Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:21 +0100
-Subject: [PATCH 109/116] USB: serial: cp210x: return early on unchanged
+Subject: [PATCH 109/117] USB: serial: cp210x: return early on unchanged
  termios
 
 Return early from set_termios() in case no relevant terminal settings
@@ -46,5 +46,5 @@ index 329fc25f78a4..a9f732c563c8 100644
  	old_cflag = old_termios->c_cflag;
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0110-USB-serial-cp210x-clean-up-line-control-handling.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0110-USB-serial-cp210x-clean-up-line-control-handling.patch
@@ -1,7 +1,7 @@
-From b1bd79da6ea2aa3010cc2f5493d143959033f758 Mon Sep 17 00:00:00 2001
+From a1af74bb74b831b77e179349a905c883bc029d0c Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:22 +0100
-Subject: [PATCH 110/116] USB: serial: cp210x: clean up line-control handling
+Subject: [PATCH 110/117] USB: serial: cp210x: clean up line-control handling
 
 Update the line-control settings in one request unconditionally instead
 of setting the word-length, parity and stop-bit settings separately.
@@ -151,5 +151,5 @@ index a9f732c563c8..7a7078de4b5c 100644
  		struct cp210x_flow_ctl flow_ctl;
  		u32 ctl_hs;
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0111-USB-serial-cp210x-set-terminal-settings-on-open.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0111-USB-serial-cp210x-set-terminal-settings-on-open.patch
@@ -1,7 +1,7 @@
-From 8355d93cbeead07911012dde4c4fe7e6e0e1fd5c Mon Sep 17 00:00:00 2001
+From 1a10ff79eb4053abf9ccbfb8b885dd4069db3687 Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:23 +0100
-Subject: [PATCH 111/116] USB: serial: cp210x: set terminal settings on open
+Subject: [PATCH 111/117] USB: serial: cp210x: set terminal settings on open
 
 Unlike other drivers cp210x have been retrieving the current terminal
 settings from the device on open and reflecting those in termios.
@@ -398,5 +398,5 @@ index 7a7078de4b5c..b0543b2b7423 100644
  }
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0112-USB-serial-cp210x-drop-flow-control-debugging.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0112-USB-serial-cp210x-drop-flow-control-debugging.patch
@@ -1,7 +1,7 @@
-From ff20783b325ba0f4d6201e2ffedf43fe47738b17 Mon Sep 17 00:00:00 2001
+From 0e39b5cc2a91c8e654f79718ae8ea84a2f8a4e2a Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:24 +0100
-Subject: [PATCH 112/116] USB: serial: cp210x: drop flow-control debugging
+Subject: [PATCH 112/117] USB: serial: cp210x: drop flow-control debugging
 
 Drop some unnecessary flow-control debugging.
 
@@ -43,5 +43,5 @@ index b0543b2b7423..899c854d65d5 100644
  		flow_ctl.ulControlHandshake = cpu_to_le32(ctl_hs);
  		flow_ctl.ulFlowReplace = cpu_to_le32(flow_repl);
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0113-USB-serial-cp210x-refactor-flow-control-handling.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0113-USB-serial-cp210x-refactor-flow-control-handling.patch
@@ -1,7 +1,7 @@
-From e48fbc039d4490a7b07ff27034ef261bb332e605 Mon Sep 17 00:00:00 2001
+From d46b6f8efe4dee7bf06bf182133fc5fcb8567b4e Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:25 +0100
-Subject: [PATCH 113/116] USB: serial: cp210x: refactor flow-control handling
+Subject: [PATCH 113/117] USB: serial: cp210x: refactor flow-control handling
 
 Add a helper function to be used to configure flow control.
 
@@ -152,5 +152,5 @@ index 899c854d65d5..19666329f386 100644
  	/*
  	 * Enable event-insertion mode only if input parity checking is
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0114-USB-serial-cp210x-clean-up-dtr_rts.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0114-USB-serial-cp210x-clean-up-dtr_rts.patch
@@ -1,7 +1,7 @@
-From 2efa8e0987353b6be26e8274086e19bc4aa4d41a Mon Sep 17 00:00:00 2001
+From ddc20eabba156b4f45d31cf3d269cfb961d7445e Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:26 +0100
-Subject: [PATCH 114/116] USB: serial: cp210x: clean up dtr_rts()
+Subject: [PATCH 114/117] USB: serial: cp210x: clean up dtr_rts()
 
 Clean up dtr_rts() by renaming the port parameter and adding missing
 whitespace.
@@ -41,5 +41,5 @@ index 19666329f386..68b30960f441 100644
  
  static int cp210x_tiocmget(struct tty_struct *tty)
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0115-USB-serial-cp210x-add-support-for-software-flow-cont.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0115-USB-serial-cp210x-add-support-for-software-flow-cont.patch
@@ -1,7 +1,7 @@
-From 2727fb7a507e1b7479ad2bc6905c20fe96f8fde4 Mon Sep 17 00:00:00 2001
+From 820ffc83b372517480d10bed8e39090df52229bc Mon Sep 17 00:00:00 2001
 From: Wang Sheng Long <shenglong.wang.ext@siemens.com>
 Date: Mon, 18 Jan 2021 12:13:26 +0100
-Subject: [PATCH 115/116] USB: serial: cp210x: add support for software flow
+Subject: [PATCH 115/117] USB: serial: cp210x: add support for software flow
  control
 
 When data is transmitted between two serial ports, the phenomenon of
@@ -139,5 +139,5 @@ index 68b30960f441..a1c1a52b8680 100644
  			__func__, ctl_hs, flow_repl);
  
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0116-USB-serial-cp210x-fix-control-characters-error-handl.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0116-USB-serial-cp210x-fix-control-characters-error-handl.patch
@@ -1,7 +1,7 @@
-From e88bbb701628cd783bda08e707b1e82f792636f6 Mon Sep 17 00:00:00 2001
+From 08bacc0bc2febc194750d947221f6b0455eb3c37 Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 5 Jul 2021 10:20:10 +0200
-Subject: [PATCH 116/116] USB: serial: cp210x: fix control-characters error
+Subject: [PATCH 116/117] USB: serial: cp210x: fix control-characters error
  handling
 
 In the unlikely event that setting the software flow-control characters
@@ -49,5 +49,5 @@ index a1c1a52b8680..4308f37c61bc 100644
  
  	ret = cp210x_read_reg_block(port, CP210X_GET_FLOW, &flow_ctl,
 -- 
-2.33.1
+2.25.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0117-Revert-serial-8250-Don-t-touch-RTS-modem-control-whi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0117-Revert-serial-8250-Don-t-touch-RTS-modem-control-whi.patch
@@ -1,0 +1,49 @@
+From df91a5f865fab96ed5c0c3f0e2b941d629bc845a Mon Sep 17 00:00:00 2001
+From: Su Bao Cheng <baocheng.su@siemens.com>
+Date: Mon, 22 Nov 2021 15:59:01 +0800
+Subject: [PATCH 117/117] Revert "serial: 8250: Don't touch RTS modem control
+ while in rs485 mode"
+
+This reverts commit f45709df7731ad36306a28a3e1af7309d55c35f5.
+
+The mcr register is not always reflect the significant value, so
+checking against it will mislead.
+
+The direct issue is RS485/422 does not fully work on 8250 serial, the
+root cause is that the original patch added a fucntion to avoid user
+space trigged changes but this change incorrectly blocked also valid
+kernel-originated changes because it hooked into the wrong function.
+
+Details refer to the bottom link.
+
+Aleady reported to upstream and Lukas is working on a formal fix and
+after that is accepted by upstream, this reverting will be replace by
+the formal fix.
+
+Signed-off-by: Su Bao Cheng <baocheng.su@siemens.com>
+Link: https://lore.kernel.org/r/20211027111644.1996921-1-baocheng.su@siemens.com
+---
+ drivers/tty/serial/8250/8250_port.c | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/drivers/tty/serial/8250/8250_port.c b/drivers/tty/serial/8250/8250_port.c
+index 3de0a16e055a..37e859da7d60 100644
+--- a/drivers/tty/serial/8250/8250_port.c
++++ b/drivers/tty/serial/8250/8250_port.c
+@@ -2028,13 +2028,6 @@ void serial8250_do_set_mctrl(struct uart_port *port, unsigned int mctrl)
+ 	struct uart_8250_port *up = up_to_u8250p(port);
+ 	unsigned char mcr;
+ 
+-	if (port->rs485.flags & SER_RS485_ENABLED) {
+-		if (serial8250_in_MCR(up) & UART_MCR_RTS)
+-			mctrl |= TIOCM_RTS;
+-		else
+-			mctrl &= ~TIOCM_RTS;
+-	}
+-
+ 	mcr = serial8250_TIOCM_to_MCR(mctrl);
+ 
+ 	mcr = (mcr & up->mcr_mask) | up->mcr_force | up->mcr;
+-- 
+2.25.1
+


### PR DESCRIPTION
An issue is observed on 8250 tty that under the RS485 or RS422 mode, the
RX/TX does not work. For RS485 the RX does not work meanwhile for RS422
the TX does not work.

This issue was introduced in the kernel driver when Lukas Wunner added
commit f45709df7731 to prevent the userspace interfering w/ RS485.
However this commit breaks the RS485.

Meanwhile there are some mis-configuration in the switchserialmode tool,
which may covered some potential problems in the past.