### PR TITLE
systemd-services: Remove deprecated switches in unit files

### DIFF
--- a/recipes-app/node-red/files/node-red.service
+++ b/recipes-app/node-red/files/node-red.service
@@ -5,7 +5,6 @@ After=syslog.target network.target
 [Service]
 Type=idle
 ExecStart=/usr/bin/node-red -u %h/.node-red
-StandardOutput=syslog
 
 [Install]
 WantedBy=multi-user.target

--- a/recipes-core/install-on-emmc/files/install-on-emmc-on-first-boot.service
+++ b/recipes-core/install-on-emmc/files/install-on-emmc-on-first-boot.service
@@ -16,8 +16,8 @@ Before=systemd-remount-fs.service shutdown.target
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/share/install-on-emmc/install-on-emmc.sh
-StandardOutput=syslog+console
-StandardError=syslog+console
+StandardOutput=journal+console
+StandardError=journal+console
 
 [Install]
 WantedBy=systemd-remount-fs.service

--- a/recipes-core/regen-rootfs-uuid/files/regen-rootfs-uuid-on-first-boot.service
+++ b/recipes-core/regen-rootfs-uuid/files/regen-rootfs-uuid-on-first-boot.service
@@ -19,8 +19,6 @@ Type=simple
 RemainAfterExit=yes
 ExecStart=/usr/share/regen-rootfs-uuid/regen-rootfs-uuid.sh
 ExecStartPost=-/bin/systemctl disable regen-rootfs-uuid-on-first-boot.service
-StandardOutput=syslog
-StandardError=syslog
 
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
StandardOutput=syslog, StandardError=syslog and
StandardOutput=syslog+console are deprecated with
systemd version 247[1].

This avoids the following Messages during boot up:
```
[    4.232889] systemd[1]: /lib/systemd/system/install-on-emmc-on-first-boot.service:19: Standard output type syslog+console is obsolete, automatically updating to journal+console. Please update your unit file, and consider removing the setting altogether.
[    4.255347] systemd[1]: /lib/systemd/system/install-on-emmc-on-first-boot.service:20: Standard
output type syslog+console is obsolete, automatically updating to journal+console. Please update
your unit file,
[    4.488344] systemd[1]: /lib/systemd/system/node-red.service:8: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.
[    4.690642] systemd[1]: /lib/systemd/system/regen-rootfs-uuid-on-first-boot.service:22: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.
[    4.711875] systemd[1]: /lib/systemd/system/regen-rootfs-uuid-on-first-boot.service:23: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.
```

[1]: https://github.com/systemd/systemd/blob/6706384a89ae0c462e7172588c80667190c4d9e2/NEWS#L724

Signed-off-by: Quirin Gylstorff <quirin.gylstorff@siemens.com>