### PR TITLE
kernel: net : fix ethernet half-duplex bugs

### DIFF
--- a/recipes-kernel/linux/files/patches-5.10/0001-dmaengine-ti-k3-udma-glue-Add-function-to-get-device.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0001-dmaengine-ti-k3-udma-glue-Add-function-to-get-device.patch
@@ -1,7 +1,7 @@
-From 7a3f7901ac78495fd2deeae885f91cfc784d015f Mon Sep 17 00:00:00 2001
+From f91d9ec0fd20c299ec830a552a251df5ee795068 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Tue, 8 Dec 2020 11:04:24 +0200
-Subject: [PATCH 001/104] dmaengine: ti: k3-udma-glue: Add function to get
+Subject: [PATCH 001/108] dmaengine: ti: k3-udma-glue: Add function to get
  device pointer for DMA API
 
 Glue layer users should use the device of the DMA for DMA mapping and
@@ -99,5 +99,5 @@ index 5eb34ad973a7..d7c12f31377c 100644
  
  #endif /* K3_UDMA_GLUE_H_ */
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0002-arm64-dts-ti-k3-am65-ringacc-drop-ti-dma-ring-reset-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0002-arm64-dts-ti-k3-am65-ringacc-drop-ti-dma-ring-reset-.patch
@@ -1,7 +1,7 @@
-From 96fa6368bb1f631e3f0007332f3b3e1c9b87acc3 Mon Sep 17 00:00:00 2001
+From 4fe95bfad8dc7007894b05210cc19839d409c6e0 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Sat, 29 Aug 2020 21:41:39 +0300
-Subject: [PATCH 002/104] arm64: dts: ti: k3-am65: ringacc: drop ti,
+Subject: [PATCH 002/108] arm64: dts: ti: k3-am65: ringacc: drop ti,
  dma-ring-reset-quirk
 
 Remove obsolete "ti,dma-ring-reset-quirk" Ringacc DT property.
@@ -39,5 +39,5 @@ index 29aaf8dca6f6..044042b166d9 100644
  			ti,sci-dev-id = <195>;
  			msi-parent = <&inta_main_udmass>;
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0003-arm64-dts-ti-k3-am65-mcu-Add-MCU-domain-R5F-cluster-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0003-arm64-dts-ti-k3-am65-mcu-Add-MCU-domain-R5F-cluster-.patch
@@ -1,7 +1,7 @@
-From abb99fe6362ea754030fefbb1132fe178b4f3de6 Mon Sep 17 00:00:00 2001
+From 387183b2de2b174767328fab6934794e6be4f97a Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 28 Oct 2020 22:37:55 -0500
-Subject: [PATCH 003/104] arm64: dts: ti: k3-am65-mcu: Add MCU domain R5F
+Subject: [PATCH 003/108] arm64: dts: ti: k3-am65-mcu: Add MCU domain R5F
  cluster node
 
 The AM65x SoCs have a single dual-core Arm Cortex-R5F processor (R5FSS)
@@ -95,5 +95,5 @@ index 044042b166d9..7454c8cec0cc 100644
 +	};
  };
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0004-arm64-dts-ti-k3-am65-Cleanup-disabled-nodes-at-SoC-d.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0004-arm64-dts-ti-k3-am65-Cleanup-disabled-nodes-at-SoC-d.patch
@@ -1,7 +1,7 @@
-From 4302aec87ffcd04b3b427cf2c6dd7329e16cd639 Mon Sep 17 00:00:00 2001
+From 1156fabd02fa65e7372d82b00fbae07360267909 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Fri, 13 Nov 2020 15:18:22 -0600
-Subject: [PATCH 004/104] arm64: dts: ti: k3-am65*: Cleanup disabled nodes at
+Subject: [PATCH 004/108] arm64: dts: ti: k3-am65*: Cleanup disabled nodes at
  SoC dtsi level
 
 The device tree standard states that when the status property is
@@ -121,5 +121,5 @@ index 937dd7280c7a..8c082af489f5 100644
 +	status = "disabled";
 +};
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0005-arm64-dts-ti-am65-j721e-Fix-up-un-necessary-status-s.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0005-arm64-dts-ti-am65-j721e-Fix-up-un-necessary-status-s.patch
@@ -1,7 +1,7 @@
-From 7e6d0d38dbb9ecaec40c6bd114a190c3c70db701 Mon Sep 17 00:00:00 2001
+From 86d7dc66a1fc2dc696b03b3803ea5f12c721fb5c Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Fri, 13 Nov 2020 15:18:24 -0600
-Subject: [PATCH 005/104] arm64: dts: ti: am65/j721e: Fix up un-necessary
+Subject: [PATCH 005/108] arm64: dts: ti: am65/j721e: Fix up un-necessary
  status set to "okay" for crypto
 
 The default state of a device tree node is "okay". There is no specific
@@ -44,5 +44,5 @@ index 6ffdebd60122..d386b38b5b0b 100644
  				<&main_udmap 0x4001>;
  		dma-names = "tx", "rx1", "rx2";
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0006-arm64-dts-ti-k3-mmc-fix-dtbs_check-warnings.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0006-arm64-dts-ti-k3-mmc-fix-dtbs_check-warnings.patch
@@ -1,7 +1,7 @@
-From 1e9e0ce5f597a81cb06fe2c9fd6afa6e1b40f28e Mon Sep 17 00:00:00 2001
+From 789d88914fb0a5cbe3840de41faf399c03e1812b Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 15 Jan 2021 21:30:16 +0200
-Subject: [PATCH 006/104] arm64: dts: ti: k3: mmc: fix dtbs_check warnings
+Subject: [PATCH 006/108] arm64: dts: ti: k3: mmc: fix dtbs_check warnings
 
 Now the dtbs_check produces below warnings
  sdhci@4f80000: clock-names:0: 'clk_ahb' was expected
@@ -129,5 +129,5 @@ index d386b38b5b0b..4f8bbad8731c 100644
  		assigned-clock-parents = <&k3_clks 93 1>;
  		ti,otap-del-sel = <0x2>;
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0007-arm64-dts-ti-k3-am65-main-Add-device_type-to-pcie-_r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0007-arm64-dts-ti-k3-am65-main-Add-device_type-to-pcie-_r.patch
@@ -1,7 +1,7 @@
-From df5654b83079b816f97e59f22442451783c7ee16 Mon Sep 17 00:00:00 2001
+From 4a1e53464d690b7d92768b3264da54eb4f01ea52 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Feb 2021 20:32:56 +0100
-Subject: [PATCH 007/104] arm64: dts: ti: k3-am65-main: Add device_type to
+Subject: [PATCH 007/108] arm64: dts: ti: k3-am65-main: Add device_type to
  pcie*_rc nodes
 
 This is demanded by the parent binding of ti,am654-pcie-rc, see
@@ -36,5 +36,5 @@ index 29c647f35464..00cd06ff98ee 100644
  
  	pcie1_ep: pcie-ep@5600000 {
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0008-arm64-dts-ti-k3-am65-main-Add-ICSSG-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0008-arm64-dts-ti-k3-am65-main-Add-ICSSG-nodes.patch
@@ -1,7 +1,7 @@
-From 4e181216098a40fb76f7c63e0798e56d47282c22 Mon Sep 17 00:00:00 2001
+From 8e58c3ddc89a6d755abc406e6f6bbbbcd8899058 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Thu, 4 Mar 2021 10:07:11 -0600
-Subject: [PATCH 008/104] arm64: dts: ti: k3-am65-main: Add ICSSG nodes
+Subject: [PATCH 008/108] arm64: dts: ti: k3-am65-main: Add ICSSG nodes
 
 Add the DT nodes for the ICSSG0, ICSSG1 and ICSSG2 processor subsystems
 that are present on the K3 AM65x SoCs. The three ICSSGs are identical
@@ -475,5 +475,5 @@ index 00cd06ff98ee..67047f108130 100644
 +	};
  };
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0009-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0009-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
@@ -1,7 +1,7 @@
-From 6826a5ba8b482fc4bb5becef8f96c1b3db910724 Mon Sep 17 00:00:00 2001
+From 01ae9ae1848ad9e4ec2ee63e1414c890d7c5f866 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 20 Feb 2021 13:49:51 +0100
-Subject: [PATCH 009/104] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
+Subject: [PATCH 009/108] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
 
 Add the DT entry for a watchdog based on RTI1.
 
@@ -37,5 +37,5 @@ index 7454c8cec0cc..0388c02c2203 100644
 +	};
  };
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0010-arm64-dts-ti-Add-support-for-Siemens-IOT2050-boards.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0010-arm64-dts-ti-Add-support-for-Siemens-IOT2050-boards.patch
@@ -1,7 +1,7 @@
-From 1d669c763d4615e124e9bb7dc69d2e2ceff06f1b Mon Sep 17 00:00:00 2001
+From 07de3abce9def7a8a54b6f362d8aea72f761cc45 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Mar 2021 15:33:43 +0100
-Subject: [PATCH 010/104] arm64: dts: ti: Add support for Siemens IOT2050
+Subject: [PATCH 010/108] arm64: dts: ti: Add support for Siemens IOT2050
  boards
 
 Add support for two Siemens SIMATIC IOT2050 variants, Basic and
@@ -836,5 +836,5 @@ index 000000000000..ec9617c13cdb
 +	status = "disabled";
 +};
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0011-arm64-dts-ti-k3-am65-j721e-am64-Map-the-dma-navigato.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0011-arm64-dts-ti-k3-am65-j721e-am64-Map-the-dma-navigato.patch
@@ -1,7 +1,7 @@
-From 4f6a29565478e48baca234f7db41423f24b369e7 Mon Sep 17 00:00:00 2001
+From b1eddaf33322c8121a6887f4d2cc8e599216c0a6 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Mon, 10 May 2021 09:54:29 -0500
-Subject: [PATCH 011/104] arm64: dts: ti: k3-am65|j721e|am64: Map the dma /
+Subject: [PATCH 011/108] arm64: dts: ti: k3-am65|j721e|am64: Map the dma /
  navigator subsystem via explicit ranges
 
 Instead of using empty ranges property, lets map explicitly the address
@@ -102,5 +102,5 @@ index e581cb1d87ee..d766c7fe02af 100644
  		dma-ranges;
  
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0012-arm64-dts-ti-k3-Introduce-reg-definition-for-interru.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0012-arm64-dts-ti-k3-Introduce-reg-definition-for-interru.patch
@@ -1,7 +1,7 @@
-From 9459f7de770e30b4e1c6cb3497878980ae201dbb Mon Sep 17 00:00:00 2001
+From a09dc72824e58c25c03aaa4137684c2d6f35a443 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Tue, 11 May 2021 14:48:21 -0500
-Subject: [PATCH 012/104] arm64: dts: ti: k3*: Introduce reg definition for
+Subject: [PATCH 012/108] arm64: dts: ti: k3*: Introduce reg definition for
  interrupt routers
 
 Interrupt routers are memory mapped peripherals, that are organized
@@ -162,5 +162,5 @@ index d766c7fe02af..282bbdc359ac 100644
  		interrupt-controller;
  		interrupt-parent = <&gic500>;
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0013-mmc-sdhci_am654-Use-pm_runtime_resume_and_get-to-rep.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0013-mmc-sdhci_am654-Use-pm_runtime_resume_and_get-to-rep.patch
@@ -1,7 +1,7 @@
-From 7dece4acefd346f3d91dac239f472fa677a03cc8 Mon Sep 17 00:00:00 2001
+From 02727ec6c09897692372b752f06d370254732ccb Mon Sep 17 00:00:00 2001
 From: Tian Tao <tiantao6@hisilicon.com>
 Date: Fri, 21 May 2021 08:59:35 +0800
-Subject: [PATCH 013/104] mmc: sdhci_am654: Use pm_runtime_resume_and_get() to
+Subject: [PATCH 013/108] mmc: sdhci_am654: Use pm_runtime_resume_and_get() to
  replace open coding
 
 use pm_runtime_resume_and_get() to replace pm_runtime_get_sync and
@@ -34,5 +34,5 @@ index a64ea143d185..c4799a16a61f 100644
  	base = devm_platform_ioremap_resource(pdev, 1);
  	if (IS_ERR(base)) {
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0014-arm64-dts-ti-k3-am65-iot2050-common-Disable-mailbox-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0014-arm64-dts-ti-k3-am65-iot2050-common-Disable-mailbox-.patch
@@ -1,7 +1,7 @@
-From d9f8c6d7080aa8afa64c5a62e2f31bed8bb1cec9 Mon Sep 17 00:00:00 2001
+From b081a3d2405a815b206d1901b24c959a55bd8903 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 14 May 2021 16:20:16 -0500
-Subject: [PATCH 014/104] arm64: dts: ti: k3-am65-iot2050-common: Disable
+Subject: [PATCH 014/108] arm64: dts: ti: k3-am65-iot2050-common: Disable
  mailbox nodes
 
 There are no sub-mailbox devices defined currently for both the
@@ -80,5 +80,5 @@ index de763ca9251c..f4ec9ed52939 100644
 +	status = "disabled";
 +};
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0015-arm64-dts-ti-k3-am65-Add-support-for-UHS-I-modes-in-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0015-arm64-dts-ti-k3-am65-Add-support-for-UHS-I-modes-in-.patch
@@ -1,7 +1,7 @@
-From 439502cf5032deed64467ae37e47ff9ecc9bee25 Mon Sep 17 00:00:00 2001
+From 777e79db9b48318f77bc50392ccf53a6c0338219 Mon Sep 17 00:00:00 2001
 From: Aswath Govindraju <a-govindraju@ti.com>
 Date: Sat, 29 May 2021 09:07:49 +0530
-Subject: [PATCH 015/104] arm64: dts: ti: k3-am65: Add support for UHS-I modes
+Subject: [PATCH 015/108] arm64: dts: ti: k3-am65: Add support for UHS-I modes
  in MMCSD1 subsystem
 
 UHS-I speed modes are supported in AM65 S.R. 2.0 SoC[1].
@@ -108,5 +108,5 @@ index 8c082af489f5..fea6a8243d75 100644
  	pinctrl-0 = <&main_mmc1_pins_default>;
  	ti,driver-strength-ohm = <50>;
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0016-arm64-dts-ti-k3-am65-main-Add-ICSSG-MDIO-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0016-arm64-dts-ti-k3-am65-main-Add-ICSSG-MDIO-nodes.patch
@@ -1,7 +1,7 @@
-From 868dc7de7c92cb29d6302760fa77c73bf16e6248 Mon Sep 17 00:00:00 2001
+From 12471d335137a5783a5ae3b5ba71a1e9cdc570e5 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 1 Jun 2021 10:00:31 -0500
-Subject: [PATCH 016/104] arm64: dts: ti: k3-am65-main: Add ICSSG MDIO nodes
+Subject: [PATCH 016/108] arm64: dts: ti: k3-am65-main: Add ICSSG MDIO nodes
 
 The ICSSGs on K3 AM65x SoCs contain an MDIO controller that can
 be used to control external PHYs associated with the Industrial
@@ -125,5 +125,5 @@ index fea6a8243d75..b47fc2a1e59d 100644
 +	status = "disabled";
 +};
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0017-arm64-dts-ti-iot2050-Configure-r5f-cluster-on-basic-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0017-arm64-dts-ti-iot2050-Configure-r5f-cluster-on-basic-.patch
@@ -1,7 +1,7 @@
-From d73a5ea673496131b8478859308e9f12d4c438e5 Mon Sep 17 00:00:00 2001
+From e6cdbb2f52f00dba2ef65ae1f4bc730cc3596708 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 2 Jun 2021 08:56:15 +0200
-Subject: [PATCH 017/104] arm64: dts: ti: iot2050: Configure r5f cluster on
+Subject: [PATCH 017/108] arm64: dts: ti: iot2050: Configure r5f cluster on
  basic variant in split mode
 
 Lockstep mode is not supported here. So turn it off to avoid warnings
@@ -28,5 +28,5 @@ index 4f7e3f2a6265..94bb5dd39122 100644
 +	ti,cluster-mode = <0>;
 +};
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0018-arm64-dts-ti-am65-align-ti-pindir-d0-out-d1-in-prope.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0018-arm64-dts-ti-am65-align-ti-pindir-d0-out-d1-in-prope.patch
@@ -1,7 +1,7 @@
-From 78d7a8954f39ac89d7a86fb379286878cc09cfa6 Mon Sep 17 00:00:00 2001
+From abf58c4f6abe3e40b8609d7c15a74e389bbc4279 Mon Sep 17 00:00:00 2001
 From: Aswath Govindraju <a-govindraju@ti.com>
 Date: Tue, 8 Jun 2021 10:44:13 +0530
-Subject: [PATCH 018/104] arm64: dts: ti: am65: align ti,pindir-d0-out-d1-in
+Subject: [PATCH 018/108] arm64: dts: ti: am65: align ti,pindir-d0-out-d1-in
  property with dt-shema
 
 ti,pindir-d0-out-d1-in property is expected to be of type boolean.
@@ -46,5 +46,5 @@ index b47fc2a1e59d..56dc855a5f13 100644
  	flash@0{
  		compatible = "jedec,spi-nor";
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0019-firmware-ti_sci-rm-Add-support-for-tx_tdtype-paramet.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0019-firmware-ti_sci-rm-Add-support-for-tx_tdtype-paramet.patch
@@ -1,7 +1,7 @@
-From 201581a7c6ca8d91135a3b594ae3c903d4e205f6 Mon Sep 17 00:00:00 2001
+From 0f5310a6f8bc4c28f2f2a6ea6e27663150cb0259 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:02 -0700
-Subject: [PATCH 019/104] firmware: ti_sci: rm: Add support for tx_tdtype
+Subject: [PATCH 019/108] firmware: ti_sci: rm: Add support for tx_tdtype
  parameter for tx channel
 
 The system controller's resource manager have support for configuring the
@@ -86,5 +86,5 @@ index cf27b080e148..d254d99fd45b 100644
  
  /**
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0020-firmware-ti_sci-Use-struct-ti_sci_resource_desc-in-g.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0020-firmware-ti_sci-Use-struct-ti_sci_resource_desc-in-g.patch
@@ -1,7 +1,7 @@
-From a964810f23910b5c1c0a85ee7ea6f1ade83d05ba Mon Sep 17 00:00:00 2001
+From e1b42d7a877e39afe84a9423efdce3fe355dc17f Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:03 -0700
-Subject: [PATCH 020/104] firmware: ti_sci: Use struct ti_sci_resource_desc in
+Subject: [PATCH 020/108] firmware: ti_sci: Use struct ti_sci_resource_desc in
  get_range ops
 
 Use the ti_sci_resource_desc directly and update it's start and num members
@@ -177,5 +177,5 @@ index d254d99fd45b..6cd537db4d33 100644
   * struct ti_sci_resource - Structure representing a resource assigned
   *			    to a device.
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0021-firmware-ti_sci-rm-Add-support-for-second-resource-r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0021-firmware-ti_sci-rm-Add-support-for-second-resource-r.patch
@@ -1,7 +1,7 @@
-From 77148768c1ca36782540b068bdfb8e7b7632fcc7 Mon Sep 17 00:00:00 2001
+From 9bd667d113e13db0fcaa07ccddef74859923cd74 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:03 -0700
-Subject: [PATCH 021/104] firmware: ti_sci: rm: Add support for second resource
+Subject: [PATCH 021/108] firmware: ti_sci: rm: Add support for second resource
  range
 
 Sysfw added support for a second range in the resource range API to be able
@@ -174,5 +174,5 @@ index 6cd537db4d33..9699b260de59 100644
  };
  
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0022-soc-ti-ti_sci_inta_msi-Add-support-for-second-range-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0022-soc-ti-ti_sci_inta_msi-Add-support-for-second-range-.patch
@@ -1,7 +1,7 @@
-From 3ad8a348de3d87f0a47ad87b6088a922bd4d02d3 Mon Sep 17 00:00:00 2001
+From 0c1081ff2727912a7c1801c330267a26de14e016 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:04 -0700
-Subject: [PATCH 022/104] soc: ti: ti_sci_inta_msi: Add support for second
+Subject: [PATCH 022/108] soc: ti: ti_sci_inta_msi: Add support for second
  range in resource ranges
 
 Allocate MSI entries for both first and second range if they are valid
@@ -36,5 +36,5 @@ index 0eb9462f609e..a1d9c027022a 100644
  
  	return count;
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0023-firmware-ti_sci-rm-Add-support-for-extended_ch_type-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0023-firmware-ti_sci-rm-Add-support-for-extended_ch_type-.patch
@@ -1,7 +1,7 @@
-From 9f3de90dc04ed00b3185b4c9c3a476968329f350 Mon Sep 17 00:00:00 2001
+From d0fb670643ee2d8e1bb14e9e582c7e7340e258b7 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:05 -0700
-Subject: [PATCH 023/104] firmware: ti_sci: rm: Add support for
+Subject: [PATCH 023/108] firmware: ti_sci: rm: Add support for
  extended_ch_type for tx channel
 
 Sysfw added 'extended_ch_type' to the tx_ch_cfg_req message which should be
@@ -91,5 +91,5 @@ index 9699b260de59..6978afc00823 100644
  
  /**
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0024-firmware-ti_sci-rm-Remove-ring_get_config-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0024-firmware-ti_sci-rm-Remove-ring_get_config-support.patch
@@ -1,7 +1,7 @@
-From 3a14e51fc33f0a5cdde74486ca6785b53c44e56b Mon Sep 17 00:00:00 2001
+From 6968dd022b8bd7b9351d2d82bf8619f7eb1586f9 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:05 -0700
-Subject: [PATCH 024/104] firmware: ti_sci: rm: Remove ring_get_config support
+Subject: [PATCH 024/108] firmware: ti_sci: rm: Remove ring_get_config support
 
 The ring_get_cfg (0x1111 message) is not used and it is not supported by
 sysfw for a long time.
@@ -200,5 +200,5 @@ index 6978afc00823..6710d7ac7a72 100644
  
  /**
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0025-firmware-ti_sci-rm-Add-new-ops-for-ring-configuratio.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0025-firmware-ti_sci-rm-Add-new-ops-for-ring-configuratio.patch
@@ -1,7 +1,7 @@
-From c59c747aea59df711bf35a368ccecb8ed6970792 Mon Sep 17 00:00:00 2001
+From 37580ba6588e7973af52118373f1f4326d3f76c1 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:06 -0700
-Subject: [PATCH 025/104] firmware: ti_sci: rm: Add new ops for ring
+Subject: [PATCH 025/108] firmware: ti_sci: rm: Add new ops for ring
  configuration
 
 The sysfw ring configuration message has been extended to include virtid
@@ -198,5 +198,5 @@ index 6710d7ac7a72..d1711050cd9d 100644
  
  /**
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0026-soc-ti-k3-ringacc-Use-the-ti_sci-set_cfg-callback-fo.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0026-soc-ti-k3-ringacc-Use-the-ti_sci-set_cfg-callback-fo.patch
@@ -1,7 +1,7 @@
-From e67f7ab42c598740da245f461cb44e63ad743440 Mon Sep 17 00:00:00 2001
+From 5b3ad66e982f2548a47e68326ef42a3396499bba Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:07 -0700
-Subject: [PATCH 026/104] soc: ti: k3-ringacc: Use the ti_sci set_cfg callback
+Subject: [PATCH 026/108] soc: ti: k3-ringacc: Use the ti_sci set_cfg callback
  for ring configuration
 
 Switch to the new set_cfg to configure the ring.
@@ -142,5 +142,5 @@ index 1147dc4c1d59..9ddd77113c5a 100644
  	return ret;
  }
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0027-firmware-ti_sci-rm-Remove-unused-config-from-ti_sci_.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0027-firmware-ti_sci-rm-Remove-unused-config-from-ti_sci_.patch
@@ -1,7 +1,7 @@
-From b52a49d481aedcfee6a30b772b39038fd9c83a12 Mon Sep 17 00:00:00 2001
+From bbb650f291fcf762038fdb3d80885e5685a63044 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:07 -0700
-Subject: [PATCH 027/104] firmware: ti_sci: rm: Remove unused config() from
+Subject: [PATCH 027/108] firmware: ti_sci: rm: Remove unused config() from
  ti_sci_rm_ringacc_ops
 
 The ringacc driver has been converted to use the new set_cfg function to
@@ -127,5 +127,5 @@ index d1711050cd9d..0aad7009b50e 100644
  		       const struct ti_sci_msg_rm_ring_cfg *params);
  };
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0028-soc-ti-k3-ringacc-Use-correct-device-for-allocation-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0028-soc-ti-k3-ringacc-Use-correct-device-for-allocation-.patch
@@ -1,7 +1,7 @@
-From 0178e1728745fc4a911b02c347eef9692ee84013 Mon Sep 17 00:00:00 2001
+From f00021165844ad4cbeaec641f1da2df739217936 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:22 -0700
-Subject: [PATCH 028/104] soc: ti: k3-ringacc: Use correct device for
+Subject: [PATCH 028/108] soc: ti: k3-ringacc: Use correct device for
  allocation in RING mode
 
 In RING mode the ringacc does not access the ring memory. In this access
@@ -126,5 +126,5 @@ index 5a472eca5ee4..658dc71d2901 100644
  
  #define K3_RINGACC_RING_ID_ANY (-1)
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0029-soc-ti-pruss-Remove-wrong-check-against-get_match_da.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0029-soc-ti-pruss-Remove-wrong-check-against-get_match_da.patch
@@ -1,7 +1,7 @@
-From 3c43cf32b8651a36ee609e9e8d38c3cf93ed94c1 Mon Sep 17 00:00:00 2001
+From 353ed0d85a74bca6994ee7f842500c41886df9a9 Mon Sep 17 00:00:00 2001
 From: Grzegorz Jaszczyk <grzegorz.jaszczyk@linaro.org>
 Date: Sat, 21 Nov 2020 19:22:25 -0800
-Subject: [PATCH 029/104] soc: ti: pruss: Remove wrong check against
+Subject: [PATCH 029/108] soc: ti: pruss: Remove wrong check against
  *get_match_data return value
 
 Since the of_device_get_match_data() doesn't return error code, remove
@@ -43,5 +43,5 @@ index cc0b4ad7a3d3..5d6e7132a5c4 100644
  	ret = dma_set_coherent_mask(dev, DMA_BIT_MASK(32));
  	if (ret) {
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0030-soc-ti-pruss-Correct-the-pruss_clk_init-error-trace-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0030-soc-ti-pruss-Correct-the-pruss_clk_init-error-trace-.patch
@@ -1,7 +1,7 @@
-From 09f68ee7d4a5be640db99ed9c56baa9cff032e98 Mon Sep 17 00:00:00 2001
+From 85c6db483ab50e33ec673a9e4198be65b6f45f1b Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 24 Jan 2021 20:51:37 -0800
-Subject: [PATCH 030/104] soc: ti: pruss: Correct the pruss_clk_init error
+Subject: [PATCH 030/108] soc: ti: pruss: Correct the pruss_clk_init error
  trace text
 
 The pruss_clk_init() function can register more than one clock.
@@ -28,5 +28,5 @@ index 5d6e7132a5c4..1d6890134312 100644
  	}
  
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0031-soc-ti-pruss-Refactor-the-CFG-sub-module-init.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0031-soc-ti-pruss-Refactor-the-CFG-sub-module-init.patch
@@ -1,7 +1,7 @@
-From 408da169fd05954f67422b69c182c59543570327 Mon Sep 17 00:00:00 2001
+From e786e6f52e259a46250512d2beb725d0b2a9dac2 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 31 Jan 2021 20:53:43 -0800
-Subject: [PATCH 031/104] soc: ti: pruss: Refactor the CFG sub-module init
+Subject: [PATCH 031/108] soc: ti: pruss: Refactor the CFG sub-module init
 
 The CFG sub-module is not present on some earlier SoCs like the
 DA850/OMAPL-138 in the TI Davinci family. Refactor out the CFG
@@ -134,5 +134,5 @@ index 1d6890134312..f22ac1edbdd0 100644
  	pm_runtime_put_sync(dev);
  rpm_disable:
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0032-soc-ti-k3-ringacc-Use-of_device_get_match_data.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0032-soc-ti-k3-ringacc-Use-of_device_get_match_data.patch
@@ -1,7 +1,7 @@
-From e75c57ddd0d2dca8a719d1c7de1664692cceccb4 Mon Sep 17 00:00:00 2001
+From 306c28cc4c76edf8f4fb036d242be280bfb4b5e0 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 31 Jan 2021 20:58:49 -0800
-Subject: [PATCH 032/104] soc: ti: k3-ringacc: Use of_device_get_match_data()
+Subject: [PATCH 032/108] soc: ti: k3-ringacc: Use of_device_get_match_data()
 
 Simplify the retrieval of getting the match data in the probe
 function by directly using of_device_get_match_data() instead
@@ -44,5 +44,5 @@ index 7fdb688452f7..db3f705da7a0 100644
  	ringacc = devm_kzalloc(dev, sizeof(*ringacc), GFP_KERNEL);
  	if (!ringacc)
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0033-remoteproc-ti_k3-fix-Wcast-function-type-warning.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0033-remoteproc-ti_k3-fix-Wcast-function-type-warning.patch
@@ -1,7 +1,7 @@
-From 780cbbda3b4d6844474068cc0b9b96b574944829 Mon Sep 17 00:00:00 2001
+From e6da21a6df8c569c60ec68a2410936f4d13efb3f Mon Sep 17 00:00:00 2001
 From: Arnd Bergmann <arnd@arndb.de>
 Date: Mon, 26 Oct 2020 17:05:23 +0100
-Subject: [PATCH 033/104] remoteproc: ti_k3: fix -Wcast-function-type warning
+Subject: [PATCH 033/108] remoteproc: ti_k3: fix -Wcast-function-type warning
 
 The function cast causes a warning with "make W=1"
 
@@ -79,5 +79,5 @@ index afeb9d6e4313..b68384455726 100644
  		return ret;
  
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0034-remoteproc-Add-a-rproc_set_firmware-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0034-remoteproc-Add-a-rproc_set_firmware-API.patch
@@ -1,7 +1,7 @@
-From 45c511cd51003520e278a4d9ef58f4eec6873cdf Mon Sep 17 00:00:00 2001
+From fa744e6fbc2fb61eb8bc0e911f612b8e8a0a51e0 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 20 Nov 2020 21:20:42 -0600
-Subject: [PATCH 034/104] remoteproc: Add a rproc_set_firmware() API
+Subject: [PATCH 034/108] remoteproc: Add a rproc_set_firmware() API
 
 A new API, rproc_set_firmware() is added to allow the remoteproc platform
 drivers and remoteproc client drivers to be able to configure a custom
@@ -159,5 +159,5 @@ index 3fa3ba6498e8..e8ac041c64d9 100644
  int rproc_coredump_add_segment(struct rproc *rproc, dma_addr_t da, size_t size);
  int rproc_coredump_add_custom_segment(struct rproc *rproc,
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0035-remoteproc-pru-Add-a-PRU-remoteproc-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0035-remoteproc-pru-Add-a-PRU-remoteproc-driver.patch
@@ -1,7 +1,7 @@
-From f8f8c77fc640e76591c659ed34ce024c70f940c8 Mon Sep 17 00:00:00 2001
+From ae292983f7e1e50eecb9319f986490ef66615bc0 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:09:58 +0100
-Subject: [PATCH 035/104] remoteproc: pru: Add a PRU remoteproc driver
+Subject: [PATCH 035/108] remoteproc: pru: Add a PRU remoteproc driver
 
 The Programmable Real-Time Unit Subsystem (PRUSS) consists of
 dual 32-bit RISC cores (Programmable Real-Time Units, or PRUs)
@@ -524,5 +524,5 @@ index 000000000000..d33392bbd8af
 +MODULE_DESCRIPTION("PRU-ICSS Remote Processor Driver");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0036-remoteproc-pru-Add-support-for-PRU-specific-interrup.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0036-remoteproc-pru-Add-support-for-PRU-specific-interrup.patch
@@ -1,7 +1,7 @@
-From 689e7258ae463d74c1d0d11818407e0f3993cd8f Mon Sep 17 00:00:00 2001
+From 774ac7b71a7c8d999044d64aea010d1fbfb77a60 Mon Sep 17 00:00:00 2001
 From: Grzegorz Jaszczyk <grzegorz.jaszczyk@linaro.org>
 Date: Tue, 8 Dec 2020 15:09:59 +0100
-Subject: [PATCH 036/104] remoteproc: pru: Add support for PRU specific
+Subject: [PATCH 036/108] remoteproc: pru: Add support for PRU specific
  interrupt configuration
 
 The firmware blob can contain optional ELF sections: .resource_table
@@ -352,5 +352,5 @@ index 000000000000..8ee9c3171610
 +
 +#endif	/* _PRU_RPROC_H_ */
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0037-remoteproc-pru-Add-pru-specific-debugfs-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0037-remoteproc-pru-Add-pru-specific-debugfs-support.patch
@@ -1,7 +1,7 @@
-From 3d9f8312393731a7cc7fee70364e98a29ef4399f Mon Sep 17 00:00:00 2001
+From 1dd226fed64077e490141df98bb2f078088dd702 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:10:00 +0100
-Subject: [PATCH 037/104] remoteproc: pru: Add pru-specific debugfs support
+Subject: [PATCH 037/108] remoteproc: pru: Add pru-specific debugfs support
 
 The remoteproc core creates certain standard debugfs entries,
 that does not give a whole lot of useful information for the
@@ -223,5 +223,5 @@ index 72e64d15f0dc..59240fd82f56 100644
  
  	return 0;
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0038-remoteproc-pru-Add-support-for-various-PRU-cores-on-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0038-remoteproc-pru-Add-support-for-various-PRU-cores-on-.patch
@@ -1,7 +1,7 @@
-From 3dd1224abd96d69a312a3fd5b87523570296fdb0 Mon Sep 17 00:00:00 2001
+From da251bc46f842c184491c890fd963bfafa4477fd Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:10:01 +0100
-Subject: [PATCH 038/104] remoteproc: pru: Add support for various PRU cores on
+Subject: [PATCH 038/108] remoteproc: pru: Add support for various PRU cores on
  K3 AM65x SoCs
 
 The K3 AM65x family of SoCs have the next generation of the PRU-ICSS
@@ -294,5 +294,5 @@ index 59240fd82f56..421ebbc1c02d 100644
  };
  MODULE_DEVICE_TABLE(of, pru_rproc_match);
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0039-remoteproc-pru-Fix-loading-of-GNU-Binutils-ELF.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0039-remoteproc-pru-Fix-loading-of-GNU-Binutils-ELF.patch
@@ -1,7 +1,7 @@
-From 74f1f0137b0dc47119f03920083b24b6d07c9cc9 Mon Sep 17 00:00:00 2001
+From 5262ec84ba2fbc50aca52f104e453cb4d5a7c15c Mon Sep 17 00:00:00 2001
 From: Dimitar Dimitrov <dimitar@dinux.eu>
 Date: Wed, 30 Dec 2020 12:50:05 +0200
-Subject: [PATCH 039/104] remoteproc: pru: Fix loading of GNU Binutils ELF
+Subject: [PATCH 039/108] remoteproc: pru: Fix loading of GNU Binutils ELF
 
 PRU port of GNU Binutils lacks support for separate address spaces.
 PRU IRAM addresses are marked with artificial offset to differentiate
@@ -48,5 +48,5 @@ index 421ebbc1c02d..a113e150d5d5 100644
  	    da + len <= PRU_IRAM_DA + pru->mem_regions[PRU_IOMEM_IRAM].size) {
  		offset = da - PRU_IRAM_DA;
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0040-remoteproc-pru-Fix-firmware-loading-crashes-on-K3-So.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0040-remoteproc-pru-Fix-firmware-loading-crashes-on-K3-So.patch
@@ -1,7 +1,7 @@
-From 2fdf087d6ea8bdf0d79f1f028c88aff534a7682f Mon Sep 17 00:00:00 2001
+From 3202417c0d11ca4eb8822ca94e321802cba40733 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Mon, 15 Mar 2021 15:58:59 -0500
-Subject: [PATCH 040/104] remoteproc: pru: Fix firmware loading crashes on K3
+Subject: [PATCH 040/108] remoteproc: pru: Fix firmware loading crashes on K3
  SoCs
 
 The K3 PRUs are 32-bit processors and in general have some limitations
@@ -36,5 +36,5 @@ index a113e150d5d5..21105592a83d 100644
  					       filesz);
  			if (ret) {
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0041-remoteproc-pru-Fixup-interrupt-parent-logic-for-fw-e.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0041-remoteproc-pru-Fixup-interrupt-parent-logic-for-fw-e.patch
@@ -1,7 +1,7 @@
-From 73cf263b9f828611c8a9bb8cc4146e5b5e1f53fd Mon Sep 17 00:00:00 2001
+From ae838770678e6f24e2b83377180953be9aebf9fb Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:39 -0500
-Subject: [PATCH 041/104] remoteproc: pru: Fixup interrupt-parent logic for fw
+Subject: [PATCH 041/108] remoteproc: pru: Fixup interrupt-parent logic for fw
  events
 
 The PRU firmware interrupt mapping logic in pru_handle_intrmap() uses
@@ -74,5 +74,5 @@ index 21105592a83d..773c09d01958 100644
  	return ret;
  }
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0042-remoteproc-pru-Fix-wrong-success-return-value-for-fw.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0042-remoteproc-pru-Fix-wrong-success-return-value-for-fw.patch
@@ -1,7 +1,7 @@
-From f8decd3cc37f9b4058336e905537ef13d26a778e Mon Sep 17 00:00:00 2001
+From 673d998e57440bd53322bb6381f9d27154c97c12 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:40 -0500
-Subject: [PATCH 042/104] remoteproc: pru: Fix wrong success return value for
+Subject: [PATCH 042/108] remoteproc: pru: Fix wrong success return value for
  fw events
 
 The irq_create_fwspec_mapping() returns a proper virq value on success
@@ -41,5 +41,5 @@ index 773c09d01958..e0c5fce8bccd 100644
  		}
  	}
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0043-remoteproc-pru-Fix-and-cleanup-firmware-interrupt-ma.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0043-remoteproc-pru-Fix-and-cleanup-firmware-interrupt-ma.patch
@@ -1,7 +1,7 @@
-From 24dffa08a60dd035ca7ebc84c2ff1f24ea1c02ba Mon Sep 17 00:00:00 2001
+From daa1cebc311e672adbc670e8358220b37b6e92c4 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:41 -0500
-Subject: [PATCH 043/104] remoteproc: pru: Fix and cleanup firmware interrupt
+Subject: [PATCH 043/108] remoteproc: pru: Fix and cleanup firmware interrupt
  mapping logic
 
 The PRU firmware interrupt mappings are configured and unconfigured in
@@ -95,5 +95,5 @@ index e0c5fce8bccd..d8597027a93e 100644
  	return 0;
  }
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0044-watchdog-Start-watchdog-in-watchdog_set_last_hw_keep.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0044-watchdog-Start-watchdog-in-watchdog_set_last_hw_keep.patch
@@ -1,7 +1,7 @@
-From a70f71435aeb270461b903fbac329c5dbe5b8f53 Mon Sep 17 00:00:00 2001
+From e018a676923c133b92ee6680c6d9c34240fa8299 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 30 Jul 2021 21:19:38 +0200
-Subject: [PATCH 044/104] watchdog: Start watchdog in
+Subject: [PATCH 044/108] watchdog: Start watchdog in
  watchdog_set_last_hw_keepalive only if appropriate
 
 We must not pet a running watchdog when handle_boot_enabled is off
@@ -33,5 +33,5 @@ index 2946f3a63110..2ee017442dfc 100644
  EXPORT_SYMBOL_GPL(watchdog_set_last_hw_keepalive);
  
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0045-arm64-dts-ti-iot2050-Flip-mmc-device-ordering-on-Adv.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0045-arm64-dts-ti-iot2050-Flip-mmc-device-ordering-on-Adv.patch
@@ -1,7 +1,7 @@
-From abc18492a5539993d5285a556e4a9126b96a2570 Mon Sep 17 00:00:00 2001
+From d451afb66f37f553afd6cc2e9d0a396e0c146da9 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 1 Sep 2021 21:52:11 +0200
-Subject: [PATCH 045/104] arm64: dts: ti: iot2050: Flip mmc device ordering on
+Subject: [PATCH 045/108] arm64: dts: ti: iot2050: Flip mmc device ordering on
  Advanced devices
 
 This ensures that the SD card will remain mmc0 across Basic and Advanced
@@ -27,5 +27,5 @@ index 1008e9162ba2..6261ca8ee2d8 100644
  
  	chosen {
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0046-arm64-dts-ti-iot2050-Disable-SR2.0-only-PRUs.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0046-arm64-dts-ti-iot2050-Disable-SR2.0-only-PRUs.patch
@@ -1,7 +1,7 @@
-From 2fb0050859879e563c0a76dfd461decb9cfc95a7 Mon Sep 17 00:00:00 2001
+From 598fddf8c0e906c56fd8fb7ad061200ffedf683c Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 1 Sep 2021 19:58:30 +0200
-Subject: [PATCH 046/104] arm64: dts: ti: iot2050: Disable SR2.0-only PRUs
+Subject: [PATCH 046/108] arm64: dts: ti: iot2050: Disable SR2.0-only PRUs
 
 The IOT2050 devices described so far are using SR1.0 silicon, thus do
 not have the additional PRUs of the ICSSG of the SR2.0. Disable them.
@@ -44,5 +44,5 @@ index 6261ca8ee2d8..58c8e64d5885 100644
 +	status = "disabled";
 +};
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0047-arm64-dts-ti-iot2050-Add-enabled-mailboxes-and-carve.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0047-arm64-dts-ti-iot2050-Add-enabled-mailboxes-and-carve.patch
@@ -1,7 +1,7 @@
-From cdf6fc8692ded5de1f07b5bf57b913f8d09fcb71 Mon Sep 17 00:00:00 2001
+From 10b99593f25c0c844423467d5e5a945019f3da12 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 9 Sep 2021 08:01:16 +0200
-Subject: [PATCH 047/104] arm64: dts: ti: iot2050: Add/enabled mailboxes and
+Subject: [PATCH 047/108] arm64: dts: ti: iot2050: Add/enabled mailboxes and
  carve-outs for R5F cores
 
 Analogously to the am654-base-board, configure the mailboxes for the the
@@ -62,5 +62,5 @@ index 58c8e64d5885..b29537088289 100644
  	status = "disabled";
  };
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0048-arm64-dts-ti-iot2050-Prepare-for-adding-2nd-generati.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0048-arm64-dts-ti-iot2050-Prepare-for-adding-2nd-generati.patch
@@ -1,7 +1,7 @@
-From fe440dc4af4e1455d7d8aeb593061561a53f1de0 Mon Sep 17 00:00:00 2001
+From a0fc6ab1d2e2b4749ddca15de843a2d5ec9ebd52 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 7 Sep 2021 17:49:55 +0200
-Subject: [PATCH 048/104] arm64: dts: ti: iot2050: Prepare for adding
+Subject: [PATCH 048/108] arm64: dts: ti: iot2050: Prepare for adding
  2nd-generation boards
 
 The current IOT2050 devices are Product Generation 1 (PG1), using SR1.0
@@ -14,16 +14,16 @@ dts files.
 
 Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
 ---
- .../dts/ti/k3-am65-iot2050-common-pg1.dtsi    | 46 +++++++++++++++
- .../boot/dts/ti/k3-am65-iot2050-common.dtsi   | 35 +-----------
- ...ts => k3-am6528-iot2050-basic-common.dtsi} | 12 +---
- .../boot/dts/ti/k3-am6528-iot2050-basic.dts   | 56 +++----------------
- ...=> k3-am6548-iot2050-advanced-common.dtsi} |  8 +--
- .../dts/ti/k3-am6548-iot2050-advanced.dts     | 50 +++--------------
- 6 files changed, 67 insertions(+), 140 deletions(-)
+ .../dts/ti/k3-am65-iot2050-common-pg1.dtsi    | 46 ++++++++++++++
+ .../boot/dts/ti/k3-am65-iot2050-common.dtsi   | 35 +----------
+ .../ti/k3-am6528-iot2050-basic-common.dtsi    | 60 +++++++++++++++++++
+ .../boot/dts/ti/k3-am6528-iot2050-basic.dts   | 56 +++--------------
+ .../ti/k3-am6548-iot2050-advanced-common.dtsi | 56 +++++++++++++++++
+ .../dts/ti/k3-am6548-iot2050-advanced.dts     | 50 +++-------------
+ 6 files changed, 178 insertions(+), 125 deletions(-)
  create mode 100644 arch/arm64/boot/dts/ti/k3-am65-iot2050-common-pg1.dtsi
- copy arch/arm64/boot/dts/ti/{k3-am6528-iot2050-basic.dts => k3-am6528-iot2050-basic-common.dtsi} (80%)
- copy arch/arm64/boot/dts/ti/{k3-am6548-iot2050-advanced.dts => k3-am6548-iot2050-advanced-common.dtsi} (85%)
+ create mode 100644 arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-common.dtsi
+ create mode 100644 arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-common.dtsi
 
 diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050-common-pg1.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050-common-pg1.dtsi
 new file mode 100644
@@ -144,44 +144,72 @@ index b29537088289..65da226847f4 100644
 -&tx_pru2_1 {
 -	status = "disabled";
 -};
-diff --git a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-common.dtsi
-similarity index 80%
-copy from arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts
-copy to arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-common.dtsi
-index 94bb5dd39122..4a9bf7d7c07d 100644
---- a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts
+diff --git a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-common.dtsi b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-common.dtsi
+new file mode 100644
+index 000000000000..4a9bf7d7c07d
+--- /dev/null
 +++ b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-common.dtsi
-@@ -4,20 +4,14 @@
-  *
-  * Authors:
-  *   Le Jin <le.jin@siemens.com>
-- *   Jan Kiszka <jan.kiszk@siemens.com>
+@@ -0,0 +1,60 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (c) Siemens AG, 2018-2021
++ *
++ * Authors:
++ *   Le Jin <le.jin@siemens.com>
 + *   Jan Kiszka <jan.kiszka@siemens.com>
-  *
-- * AM6528-based (dual-core) IOT2050 Basic variant
-- * 1 GB RAM, no eMMC, main_uart0 on connector X30
++ *
 + * Common bits of the IOT2050 Basic variant, PG1 and PG2
-  */
- 
--/dts-v1/;
--
- #include "k3-am65-iot2050-common.dtsi"
- 
- / {
--	compatible = "siemens,iot2050-basic", "ti,am654";
--	model = "SIMATIC IOT2050 Basic";
--
- 	memory@80000000 {
- 		device_type = "memory";
- 		/* 1G RAM */
-@@ -61,6 +55,6 @@ &main_uart0 {
- };
- 
- &mcu_r5fss0 {
--	/* lock-step mode not supported on this board */
++ */
++
++#include "k3-am65-iot2050-common.dtsi"
++
++/ {
++	memory@80000000 {
++		device_type = "memory";
++		/* 1G RAM */
++		reg = <0x00000000 0x80000000 0x00000000 0x40000000>;
++	};
++
++	cpus {
++		cpu-map {
++			/delete-node/ cluster1;
++		};
++		/delete-node/ cpu@100;
++		/delete-node/ cpu@101;
++	};
++
++	/delete-node/ l2-cache1;
++};
++
++/* eMMC */
++&sdhci0 {
++	status = "disabled";
++};
++
++&main_pmx0 {
++	main_uart0_pins_default: main-uart0-pins-default {
++		pinctrl-single,pins = <
++			AM65X_IOPAD(0x01e4, PIN_INPUT,  0)  /* (AF11) UART0_RXD */
++			AM65X_IOPAD(0x01e8, PIN_OUTPUT, 0)  /* (AE11) UART0_TXD */
++			AM65X_IOPAD(0x01ec, PIN_INPUT,  0)  /* (AG11) UART0_CTSn */
++			AM65X_IOPAD(0x01f0, PIN_OUTPUT, 0)  /* (AD11) UART0_RTSn */
++			AM65X_IOPAD(0x0188, PIN_INPUT,  1)  /* (D25) UART0_DCDn */
++			AM65X_IOPAD(0x018c, PIN_INPUT,  1)  /* (B26) UART0_DSRn */
++			AM65X_IOPAD(0x0190, PIN_OUTPUT, 1)  /* (A24) UART0_DTRn */
++			AM65X_IOPAD(0x0194, PIN_INPUT,  1)  /* (E24) UART0_RIN */
++		>;
++	};
++};
++
++&main_uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&main_uart0_pins_default>;
++};
++
++&mcu_r5fss0 {
 +	/* lock-step mode not supported on Basic boards */
- 	ti,cluster-mode = <0>;
- };
++	ti,cluster-mode = <0>;
++};
 diff --git a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts
 index 94bb5dd39122..87928ff28214 100644
 --- a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts
@@ -257,36 +285,68 @@ index 94bb5dd39122..87928ff28214 100644
 -	/* lock-step mode not supported on this board */
 -	ti,cluster-mode = <0>;
  };
-diff --git a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-common.dtsi
-similarity index 85%
-copy from arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts
-copy to arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-common.dtsi
-index ec9617c13cdb..d25e8b26187f 100644
---- a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts
+diff --git a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-common.dtsi b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-common.dtsi
+new file mode 100644
+index 000000000000..d25e8b26187f
+--- /dev/null
 +++ b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-common.dtsi
-@@ -4,10 +4,9 @@
-  *
-  * Authors:
-  *   Le Jin <le.jin@siemens.com>
-- *   Jan Kiszka <jan.kiszk@siemens.com>
+@@ -0,0 +1,56 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (c) Siemens AG, 2018-2021
++ *
++ * Authors:
++ *   Le Jin <le.jin@siemens.com>
 + *   Jan Kiszka <jan.kiszka@siemens.com>
-  *
-- * AM6548-based (quad-core) IOT2050 Advanced variant
-- * 2 GB RAM, 16 GB eMMC, USB-serial converter on connector X30
++ *
 + * Common bits of the IOT2050 Advanced variant, PG1 and PG2
-  */
- 
- /dts-v1/;
-@@ -15,9 +14,6 @@
- #include "k3-am65-iot2050-common.dtsi"
- 
- / {
--	compatible = "siemens,iot2050-advanced", "ti,am654";
--	model = "SIMATIC IOT2050 Advanced";
--
- 	memory@80000000 {
- 		device_type = "memory";
- 		/* 2G RAM */
++ */
++
++/dts-v1/;
++
++#include "k3-am65-iot2050-common.dtsi"
++
++/ {
++	memory@80000000 {
++		device_type = "memory";
++		/* 2G RAM */
++		reg = <0x00000000 0x80000000 0x00000000 0x80000000>;
++	};
++};
++
++&main_pmx0 {
++	main_mmc0_pins_default: main-mmc0-pins-default {
++		pinctrl-single,pins = <
++			AM65X_IOPAD(0x01a8, PIN_INPUT_PULLDOWN, 0)  /* (B25) MMC0_CLK */
++			AM65X_IOPAD(0x01ac, PIN_INPUT_PULLUP,   0)  /* (B27) MMC0_CMD */
++			AM65X_IOPAD(0x01a4, PIN_INPUT_PULLUP,   0)  /* (A26) MMC0_DAT0 */
++			AM65X_IOPAD(0x01a0, PIN_INPUT_PULLUP,   0)  /* (E25) MMC0_DAT1 */
++			AM65X_IOPAD(0x019c, PIN_INPUT_PULLUP,   0)  /* (C26) MMC0_DAT2 */
++			AM65X_IOPAD(0x0198, PIN_INPUT_PULLUP,   0)  /* (A25) MMC0_DAT3 */
++			AM65X_IOPAD(0x0194, PIN_INPUT_PULLUP,   0)  /* (E24) MMC0_DAT4 */
++			AM65X_IOPAD(0x0190, PIN_INPUT_PULLUP,   0)  /* (A24) MMC0_DAT5 */
++			AM65X_IOPAD(0x018c, PIN_INPUT_PULLUP,   0)  /* (B26) MMC0_DAT6 */
++			AM65X_IOPAD(0x0188, PIN_INPUT_PULLUP,   0)  /* (D25) MMC0_DAT7 */
++			AM65X_IOPAD(0x01b8, PIN_OUTPUT_PULLUP,  7)  /* (B23) MMC0_SDWP */
++			AM65X_IOPAD(0x01b4, PIN_INPUT_PULLUP,   0)  /* (A23) MMC0_SDCD */
++			AM65X_IOPAD(0x01b0, PIN_INPUT,          0)  /* (C25) MMC0_DS */
++		>;
++	};
++};
++
++/* eMMC */
++&sdhci0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&main_mmc0_pins_default>;
++	bus-width = <8>;
++	non-removable;
++	ti,driver-strength-ohm = <50>;
++	disable-wp;
++};
++
++&main_uart0 {
++	status = "disabled";
++};
 diff --git a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts
 index ec9617c13cdb..077f165bdc68 100644
 --- a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts
@@ -357,5 +417,5 @@ index ec9617c13cdb..077f165bdc68 100644
 -	status = "disabled";
  };
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
@@ -1,7 +1,7 @@
-From 18aff536825cb030c6684e05a41ccab22d4832bc Mon Sep 17 00:00:00 2001
+From ba2599d68371557c505dd4a46368290cb2217c7d Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 21 Jun 2021 11:04:56 +0200
-Subject: [PATCH 049/104] arm64: dts: ti: iot2050: Add support for product
+Subject: [PATCH 049/108] arm64: dts: ti: iot2050: Add support for product
  generation 2 boards
 
 This adds the devices trees for IOT2050 Product Generation 2 (PG2)
@@ -158,5 +158,5 @@ index 000000000000..f00dc86d01b9
 +	ti,cluster-mode = <0>;
 +};
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
@@ -1,7 +1,7 @@
-From d015fec92e923f9c2f5d06b89a5150932110b5b3 Mon Sep 17 00:00:00 2001
+From 4405fd659b8d61c7a54b0bf6863848c6a895b41b Mon Sep 17 00:00:00 2001
 From: Tomi Valkeinen <tomi.valkeinen@ti.com>
 Date: Mon, 31 May 2021 16:31:35 +0530
-Subject: [PATCH 050/104] arm64: dts: ti: k3-am65-main: fix DSS irq trigger
+Subject: [PATCH 050/108] arm64: dts: ti: k3-am65-main: fix DSS irq trigger
  type
 
 DSS irq trigger type is set to IRQ_TYPE_EDGE_RISING. For some reason this
@@ -35,5 +35,5 @@ index 9338f1042232..9b1a016162b2 100644
  		dma-coherent;
  
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0051-irqdomain-Export-of_phandle_args_to_fwspec.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0051-irqdomain-Export-of_phandle_args_to_fwspec.patch
@@ -1,7 +1,7 @@
-From e2e14f439f530b49f6aba20dd4b23d45e6af336b Mon Sep 17 00:00:00 2001
+From e3146d74676a36b7905e30498f87554127520241 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:46 +0530
-Subject: [PATCH 051/104] irqdomain: Export of_phandle_args_to_fwspec()
+Subject: [PATCH 051/108] irqdomain: Export of_phandle_args_to_fwspec()
 
 Export of_phandle_args_to_fwspec() to be used by drivers.
 of_phandle_args_to_fwspec() can be used by drivers to get irq specifier
@@ -55,5 +55,5 @@ index c6b419db68ef..a17e4ce3811d 100644
  unsigned int irq_create_fwspec_mapping(struct irq_fwspec *fwspec)
  {
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0052-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0052-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
@@ -1,7 +1,7 @@
-From 3ae60cd248a02fa9f2a1aed6e544fdebc585abfe Mon Sep 17 00:00:00 2001
+From aaabb423d0c8bf6ad042a24b4876b0bfa1c7c8d1 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:47 +0530
-Subject: [PATCH 052/104] PCI: keystone: Convert to using hierarchy domain for
+Subject: [PATCH 052/108] PCI: keystone: Convert to using hierarchy domain for
  legacy interrupts
 
 K2G provides separate IRQ lines for each of the four legacy interrupts.
@@ -318,5 +318,5 @@ index 90482d5246ff..0493e43ba416 100644
  err:
  	of_node_put(intc_np);
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
@@ -1,7 +1,7 @@
-From 6fbb01738fb415801007e25e6962e8c965f90580 Mon Sep 17 00:00:00 2001
+From 32021af50c37c33b8c82a58e5dbe41783adc35fb Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:48 +0530
-Subject: [PATCH 053/104] PCI: keystone: Add PCI legacy interrupt support for
+Subject: [PATCH 053/108] PCI: keystone: Add PCI legacy interrupt support for
  AM654
 
 Add PCI legacy interrupt support for AM654. AM654 has a single HW
@@ -135,5 +135,5 @@ index 0493e43ba416..0460ed2a277a 100644
  		return ret;
  
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
@@ -1,7 +1,7 @@
-From a42300009644e3549472ca14648b07ecfed243cf Mon Sep 17 00:00:00 2001
+From ed017c1f44c12b073ef5e419aaefc36b3f247e3f Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:49 +0530
-Subject: [PATCH 054/104] PCI: keystone: Add workaround for Errata #i2037
+Subject: [PATCH 054/108] PCI: keystone: Add workaround for Errata #i2037
  (AM65x SR 1.0)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -110,5 +110,5 @@ index 0460ed2a277a..bb7190400ba8 100644
  DECLARE_PCI_FIXUP_ENABLE(PCI_ANY_ID, PCI_ANY_ID, ks_pcie_quirk);
  
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0055-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0055-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
@@ -1,7 +1,7 @@
-From af16fed3807c9be3777284270ceed919d65ebf25 Mon Sep 17 00:00:00 2001
+From 5427d3ff876054957fe10e6ea74abb6db9680621 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:38:07 +0530
-Subject: [PATCH 055/104] arm64: dts: ti: k3-am65-main: Add properties to
+Subject: [PATCH 055/108] arm64: dts: ti: k3-am65-main: Add properties to
  support legacy interrupts
 
 Add DT properties in PCIe DT node to support legacy interrupts.
@@ -82,5 +82,5 @@ index 9b1a016162b2..b786daed9639 100644
  
  	pcie1_ep: pcie-ep@5600000 {
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0056-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0056-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
@@ -1,7 +1,7 @@
-From 0ee4d816ac51e946a4c2cf7d4ec8acb639f0b1a7 Mon Sep 17 00:00:00 2001
+From 59c3f633840a17727576f271ced5c1259b1fba4f Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 20 Nov 2020 21:01:54 -0600
-Subject: [PATCH 056/104] remoteproc: Fix unbalanced boot with sysfs for no
+Subject: [PATCH 056/108] remoteproc: Fix unbalanced boot with sysfs for no
  auto-boot rprocs
 
 The remoteproc core performs automatic boot and shutdown of a remote
@@ -73,5 +73,5 @@ index 1dbef895e65e..3b05230641c8 100644
  		dev_err(&rproc->dev, "Unrecognised option: %s\n", buf);
  		ret = -EINVAL;
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Introduce-deny_sysfs_ops-flag.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Introduce-deny_sysfs_ops-flag.patch
@@ -1,7 +1,7 @@
-From 9566b2e022f1cd74300ea8c7bdca737ec7b70485 Mon Sep 17 00:00:00 2001
+From f791815baf4cddf112aa069295aa9e6b8dc96b22 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 13:05:28 -0500
-Subject: [PATCH 057/104] remoteproc: Introduce deny_sysfs_ops flag
+Subject: [PATCH 057/108] remoteproc: Introduce deny_sysfs_ops flag
 
 The remoteproc framework provides sysfs interfaces for changing the
 firmware name and for starting/stopping a remote processor through
@@ -95,5 +95,5 @@ index e8ac041c64d9..02425aac6100 100644
  	int nb_vdev;
  	u8 elf_class;
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
@@ -1,7 +1,7 @@
-From 8fa387356193dd3f8dcd96889962d044e711ceb2 Mon Sep 17 00:00:00 2001
+From 305c7fb191a731e2afa3e1645c439b55ad4db105 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:32:29 -0500
-Subject: [PATCH 058/104] remoteproc: pru: Add APIs to get and put the PRU
+Subject: [PATCH 058/108] remoteproc: pru: Add APIs to get and put the PRU
  cores
 
 Add two new APIs, pru_rproc_get() and pru_rproc_put(), to the PRU
@@ -279,5 +279,5 @@ index 000000000000..1a97856b463a
 +
 +#endif /* __LINUX_PRUSS_H */
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
@@ -1,7 +1,7 @@
-From 4c88ce9f46c959ff426ca4137f8798d8b8b22f9f Mon Sep 17 00:00:00 2001
+From e76d8ba1ddf69d490f2dc623a35f869950ae3fc6 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 16 Dec 2020 17:52:37 +0100
-Subject: [PATCH 059/104] remoteproc: pru: Deny rproc sysfs ops for PRU client
+Subject: [PATCH 059/108] remoteproc: pru: Deny rproc sysfs ops for PRU client
  driven boots
 
 The PRU remoteproc driver is not configured for 'auto-boot' by default,
@@ -41,5 +41,5 @@ index 0b57b3f7747f..8fac021adc52 100644
  
  	put_device(&rproc->dev);
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
@@ -1,7 +1,7 @@
-From 62255f5c519ecf01ac4cd4f76c1647884d2fadb4 Mon Sep 17 00:00:00 2001
+From e2832bdfd25405fae98f80c70693cba08cc4bd36 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Fri, 26 Mar 2021 15:43:53 -0500
-Subject: [PATCH 060/104] remoteproc: pru: Add pru_rproc_set_ctable() function
+Subject: [PATCH 060/108] remoteproc: pru: Add pru_rproc_set_ctable() function
 
 Some firmwares expect the OS drivers to configure the CTABLE
 entries publishing dynamically allocated memory regions. For
@@ -182,5 +182,5 @@ index 1a97856b463a..e1740ff06962 100644
  
  static inline bool is_pru_rproc(struct device *dev)
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Configure-firmware-based-on-client-se.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Configure-firmware-based-on-client-se.patch
@@ -1,7 +1,7 @@
-From 3b6f5e3b257ee95ef065fd774ba01b4e21b1f474 Mon Sep 17 00:00:00 2001
+From 4859cf17ad3147075cc680656e9a0f7e0a7f96b0 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:50:14 -0500
-Subject: [PATCH 061/104] remoteproc: pru: Configure firmware based on client
+Subject: [PATCH 061/108] remoteproc: pru: Configure firmware based on client
  setup
 
 Client device node property firmware-name is now used to configure
@@ -104,5 +104,5 @@ index 90c097ebc27e..c346899d5e3b 100644
  	pru->client_np = NULL;
  	rproc->deny_sysfs_ops = false;
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0062-soc-ti-pruss-Add-pruss_get-put-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0062-soc-ti-pruss-Add-pruss_get-put-API.patch
@@ -1,7 +1,7 @@
-From 9fcfa8b94ca04ba0d7469776aa73064ffd9df7d2 Mon Sep 17 00:00:00 2001
+From 0b0b108db79e3906bd50836c9fd88d35697a0745 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:58:00 -0500
-Subject: [PATCH 062/104] soc: ti: pruss: Add pruss_get()/put() API
+Subject: [PATCH 062/108] soc: ti: pruss: Add pruss_get()/put() API
 
 Add two new get and put API, pruss_get() and pruss_put() to the
 PRUSS platform driver to allow client drivers to request a handle
@@ -176,5 +176,5 @@ index ecfded30ed05..4d1321f0d326 100644
  
  /*
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
@@ -1,7 +1,7 @@
-From 801663d092c00ba746890bf1788392f4c4c3af7d Mon Sep 17 00:00:00 2001
+From 2b79fb945194cc2aa277a1e86a3aa26865d3e32a Mon Sep 17 00:00:00 2001
 From: "Andrew F. Davis" <afd@ti.com>
 Date: Fri, 26 Mar 2021 16:11:42 -0500
-Subject: [PATCH 063/104] soc: ti: pruss: Add
+Subject: [PATCH 063/108] soc: ti: pruss: Add
  pruss_{request,release}_mem_region() API
 
 Add two new API - pruss_request_mem_region() & pruss_release_mem_region(),
@@ -236,5 +236,5 @@ index 4d1321f0d326..f1d1197fd91a 100644
  	struct clk *iep_clk_mux;
  };
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
@@ -1,7 +1,7 @@
-From ebe83c407096ff77435d0fabb727c5c422c76580 Mon Sep 17 00:00:00 2001
+From ec2e7d171ad311a9c00b5da7e6866162d30c275b Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:27:34 -0500
-Subject: [PATCH 064/104] soc: ti: pruss: Add pruss_cfg_read()/update() API
+Subject: [PATCH 064/108] soc: ti: pruss: Add pruss_cfg_read()/update() API
 
 Add two new generic API pruss_cfg_read() and pruss_cfg_update() to
 the PRUSS platform driver to allow other drivers to read and program
@@ -209,5 +209,5 @@ index 40de553d4446..a4f59a46c331 100644
  
  #if IS_ENABLED(CONFIG_PRU_REMOTEPROC)
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
@@ -1,7 +1,7 @@
-From f20835fa37b8ac3126bef948c5f9cba156dd7418 Mon Sep 17 00:00:00 2001
+From 7b014fd3936f9a9e5cd0685c83136e58fe339a23 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 11 Dec 2020 19:48:09 +0100
-Subject: [PATCH 065/104] soc: ti: pruss: Add helper functions to set GPI mode,
+Subject: [PATCH 065/108] soc: ti: pruss: Add helper functions to set GPI mode,
  MII_RT_event and XFR
 
 The PRUSS CFG module is represented as a syscon node and is currently
@@ -82,5 +82,5 @@ index a4f59a46c331..ba5b728d5015 100644
 +
  #endif /* __LINUX_PRUSS_H */
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
@@ -1,7 +1,7 @@
-From d103d01f3ed58361c07b339d17573cfc87cb9031 Mon Sep 17 00:00:00 2001
+From 1a8d17300e51fc4257f2e339abfe7e00601f88a9 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:38:11 -0500
-Subject: [PATCH 066/104] soc: ti: pruss: Add helper function to enable OCP
+Subject: [PATCH 066/108] soc: ti: pruss: Add helper function to enable OCP
  master ports
 
 The PRU-ICSS subsystem on OMAP-architecture based SoCS (AM33xx, AM437x
@@ -178,5 +178,5 @@ index ba5b728d5015..5fdd6f03446d 100644
  
  #if IS_ENABLED(CONFIG_PRU_REMOTEPROC)
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
@@ -1,7 +1,7 @@
-From 067a1552aec430e014f11b39e74cd0f615d86739 Mon Sep 17 00:00:00 2001
+From 535726e0ef46a478c6943421db999a28111cad94 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 09:24:51 -0500
-Subject: [PATCH 067/104] soc: ti: pruss: Add helper functions to get/set
+Subject: [PATCH 067/108] soc: ti: pruss: Add helper functions to get/set
  PRUSS_CFG_GPMUX
 
 Add two new helper functions pruss_cfg_get_gpmux() & pruss_cfg_set_gpmux()
@@ -71,5 +71,5 @@ index f1d1197fd91a..d6abfdd17631 100644
 +
  #endif	/* _PRUSS_DRIVER_H_ */
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0068-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0068-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
@@ -1,7 +1,7 @@
-From 745c3882f3c86cae59b7c1ba69855bd02d00c82c Mon Sep 17 00:00:00 2001
+From b22cac48856b2f40702b5967edceb1e6cee97c5e Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 10:11:42 -0500
-Subject: [PATCH 068/104] remoteproc/pru: add support for configuring GPMUX
+Subject: [PATCH 068/108] remoteproc/pru: add support for configuring GPMUX
  based on client setup
 
 Client device node property ti,pruss-gp-mux-sel can now be used to
@@ -75,5 +75,5 @@ index c346899d5e3b..7ef176170b18 100644
  
  	mutex_lock(&pru->lock);
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0069-net-ethernet-ti-prueth-Add-IEP-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0069-net-ethernet-ti-prueth-Add-IEP-driver.patch
@@ -1,7 +1,7 @@
-From 8f902858363f80034a21a89932139a42ad0bf0a2 Mon Sep 17 00:00:00 2001
+From ca03a84ccd41e5bb9a5c69e9778de14032337e33 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 20 Apr 2021 13:17:30 +0530
-Subject: [PATCH 069/104] net: ethernet: ti: prueth: Add IEP driver
+Subject: [PATCH 069/108] net: ethernet: ti: prueth: Add IEP driver
 
 Add a driver for Industrial Ethernet Peripheral (IEP) block of PRUSS to
 support timestamping of ethernet packets and thus support PTP and PPS
@@ -1146,5 +1146,5 @@ index 000000000000..a41e18df666e
 +
 +#endif /* __NET_TI_ICSS_IEP_H */
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0070-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0070-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
@@ -1,7 +1,7 @@
-From 78ad4241b67421e67c38c1c187c26dbb73b514d1 Mon Sep 17 00:00:00 2001
+From e374ff679350048e9fc70f13b9a5dec8ca304235 Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Tue, 20 Apr 2021 13:17:31 +0530
-Subject: [PATCH 070/104] HACK: net: ethernet: ti: icss-iep: Fix sync0
+Subject: [PATCH 070/108] HACK: net: ethernet: ti: icss-iep: Fix sync0
  generation on a compare event
 
 commit 41e5c46849b5 ("net: ethernet: ti: icss-iep: Add support for generating
@@ -119,5 +119,5 @@ index 234972a034a9..22034d41c988 100644
  EXPORT_SYMBOL_GPL(icss_iep_put);
  
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0071-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0071-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
@@ -1,7 +1,7 @@
-From 60b572e25d8e35e8ef3742e423b0a0742d01455a Mon Sep 17 00:00:00 2001
+From b87ceb6899df6870f25607ff68ff5fc928838257 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:28 +0300
-Subject: [PATCH 071/104] net: ethernet: ti: icss_iep: drop
+Subject: [PATCH 071/108] net: ethernet: ti: icss_iep: drop
  ICSS_IEP_CAPx_FALL_REGy
 
 ICSS_IEP_CAPx_FALL_REGy are not used, but cause indexation issues in
@@ -80,5 +80,5 @@ index 22034d41c988..60a284c6c0c9 100644
  		[ICSS_IEP_CMP_CFG_REG] = 0x40,
  		[ICSS_IEP_CMP_STAT_REG] = 0x44,
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
@@ -1,7 +1,7 @@
-From c74706ee3e3c437dbb884cfcdfc42106196f05ee Mon Sep 17 00:00:00 2001
+From 00d849170ad24c60fb94c6b70d940010b70718e6 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:29 +0300
-Subject: [PATCH 072/104] net: ethernet: ti: icss_iep: fix access to x_REG1 in
+Subject: [PATCH 072/108] net: ethernet: ti: icss_iep: fix access to x_REG1 in
  non 64bit mode
 
 Do not access x_REG1 registers in non 64bit mode.
@@ -93,5 +93,5 @@ index 60a284c6c0c9..73c0a31e8245 100644
  			pevent.type = PTP_CLOCK_EXTTS;
  			pevent.index = i;
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
@@ -1,7 +1,7 @@
-From 84642db14e786cd75b5e09cdc63b198b4106306a Mon Sep 17 00:00:00 2001
+From ae7a361f97a9384f19779849309b858276836d9c Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:30 +0300
-Subject: [PATCH 073/104] net: ethernet: ti: icss_iep: disable extts and pps if
+Subject: [PATCH 073/108] net: ethernet: ti: icss_iep: disable extts and pps if
  no slow compensation or non 64bit mode
 
 Disable extts and pps if no slow compensation support or non 64bit mode.
@@ -37,5 +37,5 @@ index 73c0a31e8245..c0bcb1d1180a 100644
  
  put_iep_device:
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
@@ -1,7 +1,7 @@
-From 7ae3ddd4b61c073a33161d2c16793eab8416f17f Mon Sep 17 00:00:00 2001
+From 662dfc831dad1b6baff4dfb8d2cfdf69d8002bdd Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:31 +0300
-Subject: [PATCH 074/104] net: ethernet: ti: icss_iep: fix pps irq race vs pps
+Subject: [PATCH 074/108] net: ethernet: ti: icss_iep: fix pps irq race vs pps
  disable
 
 When PPS is disabled the PPS IRQ can be running and PPS timer started which
@@ -123,5 +123,5 @@ index c0bcb1d1180a..ead1e7c94021 100644
  	mutex_unlock(&iep->ptp_clk_mutex);
  
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
@@ -1,7 +1,7 @@
-From 0961dd65d33fd3cfd9c6af60e2ec609e46394abb Mon Sep 17 00:00:00 2001
+From ce3c90ad7779bcdacae445bd940b8cb76824abfc Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:32 +0300
-Subject: [PATCH 075/104] net: ethernet: ti: icss_iep: improve icss_iep_gettime
+Subject: [PATCH 075/108] net: ethernet: ti: icss_iep: improve icss_iep_gettime
 
 There are few issues with icss_iep_gettime():
 - it has to be very fast, but it's not protected from interruption
@@ -69,5 +69,5 @@ index ead1e7c94021..cbec01328a71 100644
  
  static void icss_iep_enable(struct icss_iep *iep)
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
@@ -1,7 +1,7 @@
-From 9bf5e97a7e8181388cf518a7a6af2d49c4b68805 Mon Sep 17 00:00:00 2001
+From 2dfc6701cafaba0f15002c7e6fbb0352643a3d22 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:33 +0300
-Subject: [PATCH 076/104] net: ethernet: ti: icss_iep: simplify peroutput
+Subject: [PATCH 076/108] net: ethernet: ti: icss_iep: simplify peroutput
  processing
 
 simplify peroutput processing
@@ -114,5 +114,5 @@ index cbec01328a71..b39d4c08c6c9 100644
  		hrtimer_start(&iep->sync_timer, ms_to_ktime(110), /* 100ms + buffer */
  			      HRTIMER_MODE_REL);
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
@@ -1,7 +1,7 @@
-From a71ee9b5c0fc7f7d8c461f4a38a1b7235dc0ccd9 Mon Sep 17 00:00:00 2001
+From a035157ee5f05051479e8e2f81053c6436e2ed1e Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:34 +0300
-Subject: [PATCH 077/104] net: ethernet: ti: icss_iep: use readl/writel in
+Subject: [PATCH 077/108] net: ethernet: ti: icss_iep: use readl/writel in
  cap_cmp_handler
 
 Use readl/writel in cap_cmp_handler and timer handler instead of regmap
@@ -102,5 +102,5 @@ index b39d4c08c6c9..e2663dd5cf38 100644
  	return HRTIMER_NORESTART;
  }
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
@@ -1,7 +1,7 @@
-From eb458f3b70173d21ff0151bc7e1e5c0d041aa06c Mon Sep 17 00:00:00 2001
+From dcbf67b080f2add568e74731dadef382df5d1623 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:35 +0300
-Subject: [PATCH 078/104] net: ethernet: ti: icss_iep: switch to .gettimex64()
+Subject: [PATCH 078/108] net: ethernet: ti: icss_iep: switch to .gettimex64()
 
 The .gettime64() is deprecated by commit 916444df305e ("ptp: deprecate
 gettime64() in favor of gettimex64()").
@@ -95,5 +95,5 @@ index e2663dd5cf38..c0497b448d68 100644
  	.enable		= icss_iep_ptp_enable,
  };
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
@@ -1,7 +1,7 @@
-From 8600a63674b05b345f2c5dac2e9e632f4d3bd9dd Mon Sep 17 00:00:00 2001
+From f1b206a2404908c872fec8c4c793e00f3c421a4c Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Thu, 29 Apr 2021 18:13:36 +0300
-Subject: [PATCH 079/104] net: ethernet: ti: icss_iep: Update compare registers
+Subject: [PATCH 079/108] net: ethernet: ti: icss_iep: Update compare registers
  after changing ptp clock time
 
 Consider the scenario where PPS is enabled, then iep set_time or adjust_time is
@@ -60,5 +60,5 @@ index c0497b448d68..8bad9c86775a 100644
  
  static u64 icss_iep_gettime(struct icss_iep *iep,
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
@@ -1,7 +1,7 @@
-From 32ea082d2e162b7a5ce913484bde9d4ed3031c87 Mon Sep 17 00:00:00 2001
+From 504d65cb7c251fbd2146e4172a8aca3d8cdbde6e Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:37 +0300
-Subject: [PATCH 080/104] net: ethernet: ti: icss_iep: request cmp_cap irq from
+Subject: [PATCH 080/108] net: ethernet: ti: icss_iep: request cmp_cap irq from
  probe
 
 The current INTC design allows to define IEP cmp_cap IRQ explicitly for IEP
@@ -106,5 +106,5 @@ index 8bad9c86775a..df74b5fd17e9 100644
  	if (IS_ERR(iep_clk))
  		return PTR_ERR(iep_clk);
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
@@ -1,7 +1,7 @@
-From 0c4ae8ea3bb385129eaaf0c84ff05ca67f9f8f0c Mon Sep 17 00:00:00 2001
+From 9384987c10db9053a36932c9827d7fb7c9414b72 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:38 +0300
-Subject: [PATCH 081/104] net: ethernet: ti: icss_iep: set phc time to system
+Subject: [PATCH 081/108] net: ethernet: ti: icss_iep: set phc time to system
  time on init
 
 Following customer feedback IEP PHC time has to be set to system time on
@@ -28,5 +28,5 @@ index df74b5fd17e9..08b456f0bc12 100644
  	iep->clk_tick_time = def_inc;
  
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
@@ -1,7 +1,7 @@
-From ba0fb92955b85a0bf90d2ad73f9c0481adbc2e1f Mon Sep 17 00:00:00 2001
+From 9a199a422d0f6eea6bd95aea420cb44d348b7aca Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:39 +0300
-Subject: [PATCH 082/104] net: ethernet: ti: icss_iep: use
+Subject: [PATCH 082/108] net: ethernet: ti: icss_iep: use
  devm_platform_ioremap_resource
 
 Use devm_platform_ioremap_resource() in probe to simplify code.
@@ -35,5 +35,5 @@ index 08b456f0bc12..640f483854d0 100644
  		return -ENODEV;
  
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0083-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0083-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
@@ -1,7 +1,7 @@
-From 043a134d8d46f1bd497db5e114d0bbe326e46378 Mon Sep 17 00:00:00 2001
+From 8e1eed2b2e52bb8ab738b9abe1d7699a86bb0a8b Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 16 Mar 2021 18:00:25 -0500
-Subject: [PATCH 083/104] arm64: dts: ti: k3-am65-main: Add ICSSG IEP nodes
+Subject: [PATCH 083/108] arm64: dts: ti: k3-am65-main: Add ICSSG IEP nodes
 
 The ICSSG IP on AM65x SoCs have two Industrial Ethernet Peripherals (IEPs)
 to manage/generate Industrial Ethernet functions such as time stamping.
@@ -77,5 +77,5 @@ index b786daed9639..d0e565fb5e12 100644
  			compatible = "ti,pruss-mii", "syscon";
  			reg = <0x32000 0x100>;
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0084-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0084-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
@@ -1,7 +1,7 @@
-From 352dc62c5c36c6d2ad23c7429ecca275af836a3e Mon Sep 17 00:00:00 2001
+From 18b980c152c5d58e3fe0f0a595788d4990c2115f Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:22 +0300
-Subject: [PATCH 084/104] dt-bindings: net: Add binding for ti,icssg-prueth
+Subject: [PATCH 084/108] dt-bindings: net: Add binding for ti,icssg-prueth
  device
 
 This is the DT binding document for the ICSSG Dual-EMAC Ethernet
@@ -149,5 +149,5 @@ index 000000000000..67609e26afa5
 +		};
 +	};
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0085-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0085-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
@@ -1,7 +1,7 @@
-From c3be05c640f3ac35f0349ab0f861d3c552f0bd57 Mon Sep 17 00:00:00 2001
+From f8c1f99e3f97ff4ea2eb9b50ceb81df9e1bca8a0 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:23 +0300
-Subject: [PATCH 085/104] net: ti: icssg-prueth: Add ICSSG ethernet driver
+Subject: [PATCH 085/108] net: ti: icssg-prueth: Add ICSSG ethernet driver
 
 This is the Ethernet driver for TI SoCs with the
 ICSSG PRU Sub-system running dual-EMAC firmware.
@@ -4497,5 +4497,5 @@ index 5fdd6f03446d..2a034c08b4c2 100644
  /*
   * enum pruss_gp_mux_sel - PRUSS GPI/O Mux modes for the
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0086-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0086-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
@@ -1,7 +1,7 @@
-From eaf14682c7e545e897968d32b9552e4162774a50 Mon Sep 17 00:00:00 2001
+From cb46d473ac77fd784533d250439b3031443d880d Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:24 +0300
-Subject: [PATCH 086/104] net: ethernet: ti: icssg_prueth: add 10M full duplex
+Subject: [PATCH 086/108] net: ethernet: ti: icssg_prueth: add 10M full duplex
  support
 
 For 10M support RGMII need to be configured in inband mode and FW has to be
@@ -250,5 +250,5 @@ index bf52d350bdd0..644a22b53424 100644
  #define TAS_GATE_MASK_LIST0                                0x0100
  /*TAS gate mask for windows list1*/
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
@@ -1,7 +1,7 @@
-From 98dd46caaa1f2df7a6389dc584d60c94b14f3fc6 Mon Sep 17 00:00:00 2001
+From c44e8f2008b5322be5029b2612ab34908a3d3b4a Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:25 +0300
-Subject: [PATCH 087/104] net: ethernet: ti: icssg_prueth: Use DMA device for
+Subject: [PATCH 087/108] net: ethernet: ti: icssg_prueth: Use DMA device for
  DMA API
 
 For DMA API the DMA device should be used as cpsw does not accesses to
@@ -342,5 +342,5 @@ index 69c558eb004d..2e8d45c8c25d 100644
  	struct k3_udma_glue_rx_channel *rx_chn;
  	u32 descs_num;
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
@@ -1,7 +1,7 @@
-From 12d4d1a80249c134f663c5c2dbaf22b09cb000e0 Mon Sep 17 00:00:00 2001
+From ed1ed64acbc39e9596cd25405e716911588eebbb Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:26 +0300
-Subject: [PATCH 088/104] net: ethernet: ti: icss_iep: add icss_iep_get_idx()
+Subject: [PATCH 088/108] net: ethernet: ti: icss_iep: add icss_iep_get_idx()
  api
 
 Add icss_iep_get_idx() API to allow retrieve IEP from phandle list in DT.
@@ -59,5 +59,5 @@ index a41e18df666e..eefc8c8bd8cc 100644
  int icss_iep_init(struct icss_iep *iep, const struct icss_iep_clockops *clkops,
  		  void *clockops_data, u32 cycle_time_ns);
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
@@ -1,7 +1,7 @@
-From ce1a000c10b8e7e5d8131881e0710f25b99f8918 Mon Sep 17 00:00:00 2001
+From d5146fd40535c28e075c933c42e68484e38aee3a Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:27 +0300
-Subject: [PATCH 089/104] net: ethernet: ti: icss_iep: use readl() in
+Subject: [PATCH 089/108] net: ethernet: ti: icss_iep: use readl() in
  icss_iep_get_count_low/hi()
 
 Use readl() in icss_iep_get_count_low/hi() to speed up hot path.
@@ -35,5 +35,5 @@ index 51f8717fc446..23e72e0ffe46 100644
  	return val;
  }
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
@@ -1,7 +1,7 @@
-From 2fdcd242488e6110efe413e7e8bf26a527b3ffe8 Mon Sep 17 00:00:00 2001
+From 046a4bba2c24cf757d3845ab1123d3441b9e1c95 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:28 +0300
-Subject: [PATCH 090/104] net: ethernet: ti: icss_iep: fix init for sr2.0
+Subject: [PATCH 090/108] net: ethernet: ti: icss_iep: fix init for sr2.0
 
 There are two issues with IEP initialization for ICSSG SR2.0 where only one
 IEP0 is used in shadow mode:
@@ -147,5 +147,5 @@ index 23e72e0ffe46..eec7e9fb1f61 100644
  	dev_set_drvdata(dev, iep);
  	icss_iep_disable(iep);
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
@@ -1,7 +1,7 @@
-From dc61819613feab4d9619c224c738d707bd7d3687 Mon Sep 17 00:00:00 2001
+From c6ae141f0a17489d92b6317ebe2c432321fd627e Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:29 +0300
-Subject: [PATCH 091/104] net: ethernet: ti: icss_iep: sr2.0 fix NULL pointer
+Subject: [PATCH 091/108] net: ethernet: ti: icss_iep: sr2.0 fix NULL pointer
  exception on pps stop
 
 The NULL pointer exception is observed on pps stop - fix it as timer is not
@@ -38,5 +38,5 @@ index eec7e9fb1f61..0ed54c8251e2 100644
  	}
  
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0092-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0092-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
@@ -1,7 +1,7 @@
-From 9801bc6f46a6ab949c84398578a0c100da290319 Mon Sep 17 00:00:00 2001
+From a07febdefcc4bef55cf2350a1d34df6ecab7024a Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:30 +0300
-Subject: [PATCH 092/104] net: ti: ethernet: icssg-prueth: add packet
+Subject: [PATCH 092/108] net: ti: ethernet: icssg-prueth: add packet
  timestamping and ptp support
 
 Add packet timestamping TS and PTP PHC clock support.
@@ -856,5 +856,5 @@ index 2e8d45c8c25d..156716bf0a76 100644
  
  struct emac_tx_ts_response_sr1 {
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0093-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0093-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
@@ -1,7 +1,7 @@
-From 596d1d83778020fd5a8df06c80c36729cc65e552 Mon Sep 17 00:00:00 2001
+From 304bcc5a69a4fe5cd54b482cde15a5b5b19a7d6f Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:33 +0300
-Subject: [PATCH 093/104] net: ethernet: ti: icssg_prueth: add am64x icssg
+Subject: [PATCH 093/108] net: ethernet: ti: icssg_prueth: add am64x icssg
  support
 
 Add AM64x ICSSG support which is similar to am65x SR2.0, but required:
@@ -120,5 +120,5 @@ index 156716bf0a76..b536ac5ec0bf 100644
  
  struct emac_tx_ts_response_sr1 {
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
@@ -1,7 +1,7 @@
-From d565a0a0b9d915281f95c3755fcfc36d78172e7c Mon Sep 17 00:00:00 2001
+From 1e036d3d7931ef6092a14ac9962570c60afc07de Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 19 May 2021 19:31:36 +0300
-Subject: [PATCH 094/104] net: ethernet: ti: icssg_prueth: am65x SR2.0 add 10M
+Subject: [PATCH 094/108] net: ethernet: ti: icssg_prueth: am65x SR2.0 add 10M
  full duplex support
 
 For for AM65x SR2.0 it's required to enable IEP1 in raw 64bit mode which is
@@ -158,5 +158,5 @@ index b536ac5ec0bf..7cc81c67bf72 100644
  
  /**
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0095-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0095-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
@@ -1,7 +1,7 @@
-From ccb6f8b8bcf23b254fae4d1f0b51265bf5d0ead0 Mon Sep 17 00:00:00 2001
+From 540c8c0dc7dad58e5d055ca2459c8714a127fa3f Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Mon, 21 Jun 2021 15:47:49 +0530
-Subject: [PATCH 095/104] net: ti: icssg_prueth: Free desc pool before DMA
+Subject: [PATCH 095/108] net: ti: icssg_prueth: Free desc pool before DMA
  channel release
 
 Release DMA desc pool associated with channel before releasing the
@@ -48,5 +48,5 @@ index ef7392a2b9da..38d151dca81c 100644
  		 * end after all channel resources are freed
  		 */
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0096-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0096-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
@@ -1,7 +1,7 @@
-From e1f7c7672096f10f474f504b0ef29685831169d1 Mon Sep 17 00:00:00 2001
+From 63e98d1c6947b6df572029635d97b63282424860 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:47 +0300
-Subject: [PATCH 096/104] net: ethernet: icssg-prueth: fix rgmii tx delay
+Subject: [PATCH 096/108] net: ethernet: icssg-prueth: fix rgmii tx delay
  configuration
 
 The driver enables RGMII TX delay without checking specified
@@ -125,5 +125,5 @@ index 38d151dca81c..d19a05fd8b06 100644
  		if (ret)
  			goto put_cores;
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
@@ -1,7 +1,7 @@
-From fce321b6376c541a5562e7a0518d037f0f090717 Mon Sep 17 00:00:00 2001
+From 82df348f6574b1bf31755c5d47bd517e30e32616 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:48 +0300
-Subject: [PATCH 097/104] net: ethernet: icssg-prueth: enable "fixed-link"
+Subject: [PATCH 097/108] net: ethernet: icssg-prueth: enable "fixed-link"
  connection
 
 The ICSSG has incomplete and incorrect "fixed-link" connection type
@@ -71,5 +71,5 @@ index d19a05fd8b06..3b1769a5e2b3 100644
  		ret = -EPROBE_DEFER;
  		goto free;
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
@@ -1,7 +1,7 @@
-From 9fe8f18af949b19c59a226f7f1d2b2597672081d Mon Sep 17 00:00:00 2001
+From 632a2965405aeeef80f9329674d3da1e42ef0dce Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:12 +0300
-Subject: [PATCH 098/104] net: ethernet: icssg-prueth: fix bug 'scheduling
+Subject: [PATCH 098/108] net: ethernet: icssg-prueth: fix bug 'scheduling
  while atomic' from emac_ndo_set_rx_mode()
 
 The .ndo_set_rx_mode() is called with BH disabled and should be atomic, but
@@ -133,5 +133,5 @@ index 7cc81c67bf72..59dec45a3c86 100644
  	struct pruss_mem_region dram;
  };
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
@@ -1,7 +1,7 @@
-From 1b1140f6088a19746908a6f59cde4e49c6e3ede2 Mon Sep 17 00:00:00 2001
+From 1f1fd94179bf92f94cd33d95d010d540274afe2f Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:13 +0300
-Subject: [PATCH 099/104] net: ethernet: icssg-prueth: fix enabling/disabling
+Subject: [PATCH 099/108] net: ethernet: icssg-prueth: fix enabling/disabling
  port in emac_adjust_link()
 
 The port state is set to FORWARD in emac_ndo_open() and never changed, but
@@ -59,5 +59,5 @@ index f212e5904afc..abd062bedebb 100644
  
  reset_tx_chan:
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0100-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0100-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
@@ -1,7 +1,7 @@
-From 4a1be7fe9afc4b4d869ef637c2c41dc99266356f Mon Sep 17 00:00:00 2001
+From fc6c08ff8e9fb393f701e75e6f1dc9df5205ff89 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 27 Jun 2020 10:53:13 +0200
-Subject: [PATCH 100/104] arm64: dts: ti: iot2050: Add icssg-prueth nodes for
+Subject: [PATCH 100/108] arm64: dts: ti: iot2050: Add icssg-prueth nodes for
  PG1 and PG2 devices
 
 Add the required nodes to enable ICSSG SR1.0 and SR2.0 based prueth
@@ -206,5 +206,5 @@ index 65da226847f4..2faefccca7a9 100644
  
  &icssg1_mdio {
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0101-HACK-setting-the-RJ45-port-led-behavior.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0101-HACK-setting-the-RJ45-port-led-behavior.patch
@@ -1,7 +1,7 @@
-From 95c9dd53a0065a3535457e0819c3c0dbbc843f42 Mon Sep 17 00:00:00 2001
+From e825c604a126b7e21a0f4adcebb617405165d685 Mon Sep 17 00:00:00 2001
 From: zengchao <chao.zeng@siemens.com>
 Date: Wed, 6 Nov 2019 11:21:49 +0800
-Subject: [PATCH 101/104] HACK: setting the RJ45 port led behavior
+Subject: [PATCH 101/108] HACK: setting the RJ45 port led behavior
 
 Temporary needed until we have a proper, likely LED-class based
 solution upstream.
@@ -37,5 +37,5 @@ index c716074fdef0..9ee2375782b3 100644
  }
  
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0102-WIP-feat-extend-led-panic-indicator-on-and-off.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0102-WIP-feat-extend-led-panic-indicator-on-and-off.patch
@@ -1,7 +1,7 @@
-From 63a024c97bb2c85fb0decb1bdbfa369b5ab0a0a3 Mon Sep 17 00:00:00 2001
+From ee5c75290c1c70b08aaeff97be7d145b2d9407ae Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Tue, 22 Dec 2020 15:05:56 +0800
-Subject: [PATCH 102/104] WIP: feat:extend led panic-indicator on and off
+Subject: [PATCH 102/108] WIP: feat:extend led panic-indicator on and off
 
 WIP because upstream strategy is still under discussion.
 
@@ -124,5 +124,5 @@ index 6a8d6409c993..d84423d42f89 100644
  	int 		num_leds;
  	const struct gpio_led *leds;
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0103-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0103-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
@@ -1,7 +1,7 @@
-From d8c55854d446024c9cd1227884c8be0f35b3c36b Mon Sep 17 00:00:00 2001
+From ebbcf7cbf62b98b79b395b9cccee5a341e68a32e Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Mar 2021 15:28:21 +0100
-Subject: [PATCH 103/104] WIP: arm64: dts: ti: iot2050: Add node for generic
+Subject: [PATCH 103/108] WIP: arm64: dts: ti: iot2050: Add node for generic
  spidev
 
 This allows to use mcu_spi0 via userspace spidev.
@@ -33,5 +33,5 @@ index 2faefccca7a9..3510948e9d41 100644
  
  &tscadc0 {
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0104-watchdog-rti-wdt-Provide-set_timeout-handler-to-make.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0104-watchdog-rti-wdt-Provide-set_timeout-handler-to-make.patch
@@ -1,7 +1,7 @@
-From 5527baa53e1abd5f649441bd142642383794435f Mon Sep 17 00:00:00 2001
+From cda1d3e1224b3f12c20737e5054d53d72b844cc8 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 13 Sep 2021 12:27:17 +0200
-Subject: [PATCH 104/104] watchdog: rti-wdt: Provide set_timeout handler to
+Subject: [PATCH 104/108] watchdog: rti-wdt: Provide set_timeout handler to
  make existing userspace happy
 
 Prominent userspace - systemd - cannot handle watchdogs without
@@ -57,5 +57,5 @@ index 359302f71f7e..365255b15a0d 100644
  };
  
 -- 
-2.31.1
+2.32.0
 

--- a/recipes-kernel/linux/files/patches-5.10/0105-dt-bindings-net-ti-icssg-prueth-Add-documentation-fo.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0105-dt-bindings-net-ti-icssg-prueth-Add-documentation-fo.patch
@@ -1,0 +1,41 @@
+From 8d0a6581d8f1b9bed1636228155497eba2526be4 Mon Sep 17 00:00:00 2001
+From: Murali Karicheri <m-karicheri2@ti.com>
+Date: Tue, 12 Oct 2021 13:54:41 +0300
+Subject: [PATCH 105/108] dt-bindings: net: ti, icssg-prueth: Add documentation
+ for half duplex
+
+In order to support half-duplex operation at 10M and 100M link speeds, the
+PHY collision detection signal (GPIO output pin) should be routed to ICSSG,
+GPIO pin so that firmware can detect collision signal and apply the csma/cd
+algorithm applicable for half duplex operation. A DT property, half-duplex
+is introduced for this purpose. If board has the required modification
+done, this DT property can be added to eth node of ICSSG, MII port to
+support half duplex operation at that port.
+
+On AM654x-IDK only ICSSG0 MII port 1 can be used.
+
+Signed-off-by: Murali Karicheri <m-karicheri2@ti.com>
+Signed-off-by: Grygorii Strashko <grygorii.strashko@ti.com>
+Signed-off-by: Vignesh Raghavendra <vigneshr@ti.com>
+---
+ Documentation/devicetree/bindings/net/ti,icssg-prueth.txt | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/Documentation/devicetree/bindings/net/ti,icssg-prueth.txt b/Documentation/devicetree/bindings/net/ti,icssg-prueth.txt
+index 125a204ef2d2..41cba6907fc9 100644
+--- a/Documentation/devicetree/bindings/net/ti,icssg-prueth.txt
++++ b/Documentation/devicetree/bindings/net/ti,icssg-prueth.txt
+@@ -39,6 +39,10 @@ Required properties for children:
+ 
+ Optional properties for children:
+ - local-mac-address	: mac address for the port.
++- ti,half-duplex-capable : Enable half duplex operation on ICSSG MII port.
++			  This requires board modification to route PHY
++			  output pin (COL) to ICSSG GPIO pin
++			  (PRG0_PRU1_GPIO10) as input.
+ 
+ Example (k3-am654 base board SR2.0, dual-emac):
+ ==============================================
+-- 
+2.32.0
+

--- a/recipes-kernel/linux/files/patches-5.10/0106-net-ethernet-icssg-prueth-sr1.0-add-support-for-half.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0106-net-ethernet-icssg-prueth-sr1.0-add-support-for-half.patch
@@ -1,0 +1,107 @@
+From fa676b2e76b11b891e7221ce9c305848f47f944e Mon Sep 17 00:00:00 2001
+From: Grygorii Strashko <grygorii.strashko@ti.com>
+Date: Tue, 12 Oct 2021 13:54:42 +0300
+Subject: [PATCH 106/108] net: ethernet: icssg-prueth: sr1.0: add support for
+ half duplex operation
+
+This patch adds support for half duplex operation at 10M and 100M link
+speeds. Driver needs to configure rand_seed, a random number, in the config
+struct passed to firmware. This is used as a seed value at firmware for
+random number generation logic required to implement csma/cd logic timer.
+Also don't clear the half duplex bits in the supported modes of phydev for
+10M and 100M as they now become supported.
+
+Signed-off-by: Grygorii Strashko <grygorii.strashko@ti.com>
+Signed-off-by: Vignesh Raghavendra <vigneshr@ti.com>
+---
+ drivers/net/ethernet/ti/icssg_config.c |  1 +
+ drivers/net/ethernet/ti/icssg_config.h |  2 ++
+ drivers/net/ethernet/ti/icssg_prueth.c | 19 +++++++++++++++++--
+ drivers/net/ethernet/ti/icssg_prueth.h |  1 +
+ 4 files changed, 21 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ethernet/ti/icssg_config.c b/drivers/net/ethernet/ti/icssg_config.c
+index b5cef264cdf9..905c743e8e11 100644
+--- a/drivers/net/ethernet/ti/icssg_config.c
++++ b/drivers/net/ethernet/ti/icssg_config.c
+@@ -239,6 +239,7 @@ void icssg_config_sr1(struct prueth *prueth, struct prueth_emac *emac,
+ 	config->num_tx_threads = 0;
+ 	config->rx_flow_id = emac->rx_flow_id_base; /* flow id for host port */
+ 	config->rx_mgr_flow_id = emac->rx_mgm_flow_id_base; /* for mgm ch */
++	config->rand_seed = get_random_int();
+ 
+ 	for (i = PRUETH_EMAC_BUF_POOL_START_SR1; i < PRUETH_NUM_BUF_POOLS_SR1;
+ 	     i++) {
+diff --git a/drivers/net/ethernet/ti/icssg_config.h b/drivers/net/ethernet/ti/icssg_config.h
+index 82930383204b..b9fe3f3cc940 100644
+--- a/drivers/net/ethernet/ti/icssg_config.h
++++ b/drivers/net/ethernet/ti/icssg_config.h
+@@ -60,6 +60,8 @@ struct icssg_config_sr1 {
+ 	__le32 n_burst;		/* for debug */
+ 	__le32 rtu_status;	/* RTU status */
+ 	__le32 info;		/* reserved */
++	__le32 reserve;
++	__le32 rand_seed;	/* Used for the random number generation at fw */
+ } __packed;
+ 
+ /* Shutdown command to stop processing at firmware.
+diff --git a/drivers/net/ethernet/ti/icssg_prueth.c b/drivers/net/ethernet/ti/icssg_prueth.c
+index abd062bedebb..635eec1fd6ee 100644
+--- a/drivers/net/ethernet/ti/icssg_prueth.c
++++ b/drivers/net/ethernet/ti/icssg_prueth.c
+@@ -1232,6 +1232,15 @@ static void prueth_emac_stop(struct prueth_emac *emac)
+ 	rproc_shutdown(prueth->pru[slice]);
+ }
+ 
++static void icssg_config_half_duplex(struct prueth *prueth, int slice)
++{
++	void __iomem *va = prueth->shram.va + slice * ICSSG_CONFIG_OFFSET_SLICE1;
++	struct icssg_config_sr1 *config = (struct icssg_config_sr1 *)va;
++	u32 val = get_random_int();
++
++	writel(val, &config->rand_seed);
++}
++
+ /* called back by PHY layer if there is change in link state of hw port*/
+ static void emac_adjust_link(struct net_device *ndev)
+ {
+@@ -1275,6 +1284,8 @@ static void emac_adjust_link(struct net_device *ndev)
+ 		 * values
+ 		 */
+ 		if (emac->link) {
++			if (emac->duplex == DUPLEX_HALF)
++				icssg_config_half_duplex(prueth, prueth_emac_slice(emac));
+ 			/* Set the RGMII cfg for gig en and full duplex */
+ 			icssg_update_rgmii_cfg(prueth->miig_rt, emac->speed,
+ 					       emac->duplex, slice);
+@@ -2176,9 +2187,13 @@ static int prueth_netdev_init(struct prueth *prueth,
+ 		goto free;
+ 	}
+ 
++	emac->half_duplex = of_property_read_bool(eth_node, "ti,half-duplex-capable");
++
+ 	/* remove unsupported modes */
+-	phy_remove_link_mode(emac->phydev, ETHTOOL_LINK_MODE_10baseT_Half_BIT);
+-	phy_remove_link_mode(emac->phydev, ETHTOOL_LINK_MODE_100baseT_Half_BIT);
++	if (!emac->half_duplex) {
++		phy_remove_link_mode(emac->phydev, ETHTOOL_LINK_MODE_10baseT_Half_BIT);
++		phy_remove_link_mode(emac->phydev, ETHTOOL_LINK_MODE_100baseT_Half_BIT);
++	}
+ 	phy_remove_link_mode(emac->phydev, ETHTOOL_LINK_MODE_1000baseT_Half_BIT);
+ 	phy_remove_link_mode(emac->phydev, ETHTOOL_LINK_MODE_Pause_BIT);
+ 	phy_remove_link_mode(emac->phydev, ETHTOOL_LINK_MODE_Asym_Pause_BIT);
+diff --git a/drivers/net/ethernet/ti/icssg_prueth.h b/drivers/net/ethernet/ti/icssg_prueth.h
+index 59dec45a3c86..917c6f9a2514 100644
+--- a/drivers/net/ethernet/ti/icssg_prueth.h
++++ b/drivers/net/ethernet/ti/icssg_prueth.h
+@@ -139,6 +139,7 @@ struct prueth_emac {
+ 	struct icss_iep *iep;
+ 	unsigned int rx_ts_enabled : 1;
+ 	unsigned int tx_ts_enabled : 1;
++	unsigned int half_duplex : 1;
+ 
+ 	/* DMA related */
+ 	struct prueth_tx_chn tx_chns[PRUETH_MAX_TX_QUEUES];
+-- 
+2.32.0
+

--- a/recipes-kernel/linux/files/patches-5.10/0107-net-ethernet-icssg-prueth-sr2.0-add-support-for-half.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0107-net-ethernet-icssg-prueth-sr2.0-add-support-for-half.patch
@@ -1,0 +1,139 @@
+From 6d107ffc9d8951048d716f9d5b2d4d5eb482100e Mon Sep 17 00:00:00 2001
+From: Grygorii Strashko <grygorii.strashko@ti.com>
+Date: Tue, 12 Oct 2021 13:54:43 +0300
+Subject: [PATCH 107/108] net: ethernet: icssg-prueth: sr2.0: add support for
+ half duplex operation
+
+This patch adds support for half duplex operation at 10M and 100M link
+speeds for AM654x ICSS-G SR2.0 devices.
+- Driver configures rand_seed, a random number, in DMEM HD_RAND_SEED_OFFSET
+field, which will be used by firmware for Back off time calculation.
+- Driver informs FW about half duplex link operation in DMEM
+PORT_LINK_SPEED_OFFSET field by setting bit 7 for 10/100M HD.
+
+Hence, the half duplex operation depends on board design the
+"ti,half-duplex-capable" property has to be enabled for ICSS-G ports if HW
+is capable to perform half duplex.
+
+Signed-off-by: Grygorii Strashko <grygorii.strashko@ti.com>
+Signed-off-by: Vignesh Raghavendra <vigneshr@ti.com>
+---
+ drivers/net/ethernet/ti/icssg_config.c     | 30 ++++++++++++++++++++++
+ drivers/net/ethernet/ti/icssg_prueth.c     | 11 +-------
+ drivers/net/ethernet/ti/icssg_prueth.h     |  2 ++
+ drivers/net/ethernet/ti/icssg_switch_map.h |  3 +++
+ 4 files changed, 36 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/net/ethernet/ti/icssg_config.c b/drivers/net/ethernet/ti/icssg_config.c
+index 905c743e8e11..50acf4e31008 100644
+--- a/drivers/net/ethernet/ti/icssg_config.c
++++ b/drivers/net/ethernet/ti/icssg_config.c
+@@ -420,6 +420,9 @@ void icssg_config_set_speed(struct prueth_emac *emac)
+ {
+ 	u8 fw_speed;
+ 
++	if (emac->is_sr1)
++		return;
++
+ 	switch (emac->speed) {
+ 	case SPEED_1000:
+ 		fw_speed = FW_LINK_SPEED_1G;
+@@ -436,5 +439,32 @@ void icssg_config_set_speed(struct prueth_emac *emac)
+ 		return;
+ 	}
+ 
++	if (emac->duplex == DUPLEX_HALF)
++		fw_speed |= FW_LINK_SPEED_HD;
++
+ 	writeb(fw_speed, emac->dram.va + PORT_LINK_SPEED_OFFSET);
+ }
++
++static void icssg_config_half_duplex_sr1(struct prueth_emac *emac)
++{
++	int slice = prueth_emac_slice(emac);
++	struct icssg_config_sr1 *config;
++	u32 val = get_random_int();
++	void __iomem *va;
++
++	va = emac->prueth->shram.va + slice * ICSSG_CONFIG_OFFSET_SLICE1;
++	config = (struct icssg_config_sr1 *)va;
++
++	writel(val, &config->rand_seed);
++}
++
++void icssg_config_half_duplex(struct prueth_emac *emac)
++{
++	u32 val;
++
++	if (emac->is_sr1)
++		icssg_config_half_duplex_sr1(emac);
++
++	val = get_random_int();
++	writel(val, emac->dram.va + HD_RAND_SEED_OFFSET);
++}
+diff --git a/drivers/net/ethernet/ti/icssg_prueth.c b/drivers/net/ethernet/ti/icssg_prueth.c
+index 635eec1fd6ee..e33aafc9e029 100644
+--- a/drivers/net/ethernet/ti/icssg_prueth.c
++++ b/drivers/net/ethernet/ti/icssg_prueth.c
+@@ -1232,15 +1232,6 @@ static void prueth_emac_stop(struct prueth_emac *emac)
+ 	rproc_shutdown(prueth->pru[slice]);
+ }
+ 
+-static void icssg_config_half_duplex(struct prueth *prueth, int slice)
+-{
+-	void __iomem *va = prueth->shram.va + slice * ICSSG_CONFIG_OFFSET_SLICE1;
+-	struct icssg_config_sr1 *config = (struct icssg_config_sr1 *)va;
+-	u32 val = get_random_int();
+-
+-	writel(val, &config->rand_seed);
+-}
+-
+ /* called back by PHY layer if there is change in link state of hw port*/
+ static void emac_adjust_link(struct net_device *ndev)
+ {
+@@ -1285,7 +1276,7 @@ static void emac_adjust_link(struct net_device *ndev)
+ 		 */
+ 		if (emac->link) {
+ 			if (emac->duplex == DUPLEX_HALF)
+-				icssg_config_half_duplex(prueth, prueth_emac_slice(emac));
++				icssg_config_half_duplex(emac);
+ 			/* Set the RGMII cfg for gig en and full duplex */
+ 			icssg_update_rgmii_cfg(prueth->miig_rt, emac->speed,
+ 					       emac->duplex, slice);
+diff --git a/drivers/net/ethernet/ti/icssg_prueth.h b/drivers/net/ethernet/ti/icssg_prueth.h
+index 917c6f9a2514..0ff9e9680b57 100644
+--- a/drivers/net/ethernet/ti/icssg_prueth.h
++++ b/drivers/net/ethernet/ti/icssg_prueth.h
+@@ -282,6 +282,8 @@ int icssg_config_sr2(struct prueth *prueth, struct prueth_emac *emac,
+ int emac_set_port_state(struct prueth_emac *emac,
+ 			enum icssg_port_state_cmd state);
+ void icssg_config_set_speed(struct prueth_emac *emac);
++void icssg_config_half_duplex(struct prueth_emac *emac);
++
+ #define prueth_napi_to_tx_chn(pnapi) \
+ 	container_of(pnapi, struct prueth_tx_chn, napi_tx)
+ 
+diff --git a/drivers/net/ethernet/ti/icssg_switch_map.h b/drivers/net/ethernet/ti/icssg_switch_map.h
+index 644a22b53424..99225d0f1582 100644
+--- a/drivers/net/ethernet/ti/icssg_switch_map.h
++++ b/drivers/net/ethernet/ti/icssg_switch_map.h
+@@ -16,6 +16,7 @@
+ #define FW_LINK_SPEED_1G                           (0x00)
+ #define FW_LINK_SPEED_100M                         (0x01)
+ #define FW_LINK_SPEED_10M                          (0x02)
++#define FW_LINK_SPEED_HD                           (0x80)
+ 
+ /*Time after which FDB entries are checked for aged out values. Value in nanoseconds*/
+ #define FDB_AGEING_TIMEOUT_OFFSET                          0x0014
+@@ -154,6 +155,8 @@
+ #define HOST_RX_Q_PRE_CONTEXT_OFFSET                       0x0684
+ /*Buffer for 8 FDB entries to be added by 'Add Multiple FDB entries IOCTL*/
+ #define FDB_CMD_BUFFER                                     0x0894
++/*Used by FW to generate random number with the SEED value*/
++#define HD_RAND_SEED_OFFSET                                0x0934
+ 
+ /* Memory Usage of : DMEM1
+  *
+-- 
+2.32.0
+

--- a/recipes-kernel/linux/files/patches-5.10/0108-arm64-dts-ti-add-the-support-for-the-half-duplex.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0108-arm64-dts-ti-add-the-support-for-the-half-duplex.patch
@@ -1,0 +1,35 @@
+From fbd9b2830a7d7c69bf8c4d4a67c7c63a40d72b3a Mon Sep 17 00:00:00 2001
+From: chao zeng <chao.zeng@siemens.com>
+Date: Fri, 22 Oct 2021 13:37:22 +0800
+Subject: [PATCH 108/108] arm64: dts: ti: add the support for the half-duplex
+
+origin from TI and add the dts property to support the half-duplex for ethernet port
+
+Signed-off-by: chao zeng <chao.zeng@siemens.com>
+---
+ arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi
+index 3510948e9d41..34a4bcec204a 100644
+--- a/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi
++++ b/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi
+@@ -159,6 +159,7 @@ icssg0_emac0: ethernet-mii0 {
+ 			phy-handle = <&icssg0_eth0_phy>;
+ 			phy-mode = "rgmii-rxid";
+ 			syscon-rgmii-delay = <&scm_conf 0x4100>;
++			ti,half-duplex-capable;
+ 			/* Filled in by bootloader */
+ 			local-mac-address = [00 00 00 00 00 00];
+ 		};
+@@ -167,6 +168,7 @@ icssg0_emac1: ethernet-mii1 {
+ 			phy-handle = <&icssg0_eth1_phy>;
+ 			phy-mode = "rgmii-rxid";
+ 			syscon-rgmii-delay = <&scm_conf 0x4104>;
++			ti,half-duplex-capable;
+ 			/* Filled in by bootloader */
+ 			local-mac-address = [00 00 00 00 00 00];
+ 		};
+-- 
+2.32.0
+


### PR DESCRIPTION
There patches are origin from https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/?h=ti-linux-5.10.y
pick releated patches.

Signed-off-by: chao zeng <chao.zeng@siemens.com>