### PR TITLE
linux: usb : serial: pick up some missing patches to fix software flo…

### DIFF
--- a/recipes-kernel/linux/files/patches-5.10/0001-dmaengine-ti-k3-udma-glue-Add-function-to-get-device.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0001-dmaengine-ti-k3-udma-glue-Add-function-to-get-device.patch
@@ -1,7 +1,7 @@
-From f91d9ec0fd20c299ec830a552a251df5ee795068 Mon Sep 17 00:00:00 2001
+From 83202d53880f68384482db221d5b30327057459c Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Tue, 8 Dec 2020 11:04:24 +0200
-Subject: [PATCH 001/108] dmaengine: ti: k3-udma-glue: Add function to get
+Subject: [PATCH 001/116] dmaengine: ti: k3-udma-glue: Add function to get
  device pointer for DMA API
 
 Glue layer users should use the device of the DMA for DMA mapping and
@@ -99,5 +99,5 @@ index 5eb34ad973a7..d7c12f31377c 100644
  
  #endif /* K3_UDMA_GLUE_H_ */
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0002-arm64-dts-ti-k3-am65-ringacc-drop-ti-dma-ring-reset-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0002-arm64-dts-ti-k3-am65-ringacc-drop-ti-dma-ring-reset-.patch
@@ -1,7 +1,7 @@
-From 4fe95bfad8dc7007894b05210cc19839d409c6e0 Mon Sep 17 00:00:00 2001
+From 16fbb95307c6a968eeb93eb519cbf9eb88eff876 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Sat, 29 Aug 2020 21:41:39 +0300
-Subject: [PATCH 002/108] arm64: dts: ti: k3-am65: ringacc: drop ti,
+Subject: [PATCH 002/116] arm64: dts: ti: k3-am65: ringacc: drop ti,
  dma-ring-reset-quirk
 
 Remove obsolete "ti,dma-ring-reset-quirk" Ringacc DT property.
@@ -39,5 +39,5 @@ index 29aaf8dca6f6..044042b166d9 100644
  			ti,sci-dev-id = <195>;
  			msi-parent = <&inta_main_udmass>;
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0003-arm64-dts-ti-k3-am65-mcu-Add-MCU-domain-R5F-cluster-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0003-arm64-dts-ti-k3-am65-mcu-Add-MCU-domain-R5F-cluster-.patch
@@ -1,7 +1,7 @@
-From 387183b2de2b174767328fab6934794e6be4f97a Mon Sep 17 00:00:00 2001
+From 160084a924e514651f22f3829f2450782c06dbc3 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 28 Oct 2020 22:37:55 -0500
-Subject: [PATCH 003/108] arm64: dts: ti: k3-am65-mcu: Add MCU domain R5F
+Subject: [PATCH 003/116] arm64: dts: ti: k3-am65-mcu: Add MCU domain R5F
  cluster node
 
 The AM65x SoCs have a single dual-core Arm Cortex-R5F processor (R5FSS)
@@ -95,5 +95,5 @@ index 044042b166d9..7454c8cec0cc 100644
 +	};
  };
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0004-arm64-dts-ti-k3-am65-Cleanup-disabled-nodes-at-SoC-d.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0004-arm64-dts-ti-k3-am65-Cleanup-disabled-nodes-at-SoC-d.patch
@@ -1,7 +1,7 @@
-From 1156fabd02fa65e7372d82b00fbae07360267909 Mon Sep 17 00:00:00 2001
+From a894a3372c3c8ee5af53ff05a08f64699227542d Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Fri, 13 Nov 2020 15:18:22 -0600
-Subject: [PATCH 004/108] arm64: dts: ti: k3-am65*: Cleanup disabled nodes at
+Subject: [PATCH 004/116] arm64: dts: ti: k3-am65*: Cleanup disabled nodes at
  SoC dtsi level
 
 The device tree standard states that when the status property is
@@ -121,5 +121,5 @@ index 937dd7280c7a..8c082af489f5 100644
 +	status = "disabled";
 +};
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0005-arm64-dts-ti-am65-j721e-Fix-up-un-necessary-status-s.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0005-arm64-dts-ti-am65-j721e-Fix-up-un-necessary-status-s.patch
@@ -1,7 +1,7 @@
-From 86d7dc66a1fc2dc696b03b3803ea5f12c721fb5c Mon Sep 17 00:00:00 2001
+From b29aa4d5a00e412d8fe79c2caa7db42c1ab4dcfa Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Fri, 13 Nov 2020 15:18:24 -0600
-Subject: [PATCH 005/108] arm64: dts: ti: am65/j721e: Fix up un-necessary
+Subject: [PATCH 005/116] arm64: dts: ti: am65/j721e: Fix up un-necessary
  status set to "okay" for crypto
 
 The default state of a device tree node is "okay". There is no specific
@@ -44,5 +44,5 @@ index 6ffdebd60122..d386b38b5b0b 100644
  				<&main_udmap 0x4001>;
  		dma-names = "tx", "rx1", "rx2";
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0006-arm64-dts-ti-k3-mmc-fix-dtbs_check-warnings.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0006-arm64-dts-ti-k3-mmc-fix-dtbs_check-warnings.patch
@@ -1,7 +1,7 @@
-From 789d88914fb0a5cbe3840de41faf399c03e1812b Mon Sep 17 00:00:00 2001
+From 1b151cfd61f581bb844e9265f9d9a5d4da050fa7 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 15 Jan 2021 21:30:16 +0200
-Subject: [PATCH 006/108] arm64: dts: ti: k3: mmc: fix dtbs_check warnings
+Subject: [PATCH 006/116] arm64: dts: ti: k3: mmc: fix dtbs_check warnings
 
 Now the dtbs_check produces below warnings
  sdhci@4f80000: clock-names:0: 'clk_ahb' was expected
@@ -129,5 +129,5 @@ index d386b38b5b0b..4f8bbad8731c 100644
  		assigned-clock-parents = <&k3_clks 93 1>;
  		ti,otap-del-sel = <0x2>;
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0007-arm64-dts-ti-k3-am65-main-Add-device_type-to-pcie-_r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0007-arm64-dts-ti-k3-am65-main-Add-device_type-to-pcie-_r.patch
@@ -1,7 +1,7 @@
-From 4a1e53464d690b7d92768b3264da54eb4f01ea52 Mon Sep 17 00:00:00 2001
+From 997140e1e68654b14dbabfc41c7b69c9faea3b9b Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Feb 2021 20:32:56 +0100
-Subject: [PATCH 007/108] arm64: dts: ti: k3-am65-main: Add device_type to
+Subject: [PATCH 007/116] arm64: dts: ti: k3-am65-main: Add device_type to
  pcie*_rc nodes
 
 This is demanded by the parent binding of ti,am654-pcie-rc, see
@@ -36,5 +36,5 @@ index 29c647f35464..00cd06ff98ee 100644
  
  	pcie1_ep: pcie-ep@5600000 {
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0008-arm64-dts-ti-k3-am65-main-Add-ICSSG-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0008-arm64-dts-ti-k3-am65-main-Add-ICSSG-nodes.patch
@@ -1,7 +1,7 @@
-From 8e58c3ddc89a6d755abc406e6f6bbbbcd8899058 Mon Sep 17 00:00:00 2001
+From 558dd13ea7c23057fd262c88dc19d181d68b8dd3 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Thu, 4 Mar 2021 10:07:11 -0600
-Subject: [PATCH 008/108] arm64: dts: ti: k3-am65-main: Add ICSSG nodes
+Subject: [PATCH 008/116] arm64: dts: ti: k3-am65-main: Add ICSSG nodes
 
 Add the DT nodes for the ICSSG0, ICSSG1 and ICSSG2 processor subsystems
 that are present on the K3 AM65x SoCs. The three ICSSGs are identical
@@ -475,5 +475,5 @@ index 00cd06ff98ee..67047f108130 100644
 +	};
  };
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0009-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0009-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
@@ -1,7 +1,7 @@
-From 01ae9ae1848ad9e4ec2ee63e1414c890d7c5f866 Mon Sep 17 00:00:00 2001
+From 2429ba79c7d88326f195db1d03a5b3b7ccb323fc Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 20 Feb 2021 13:49:51 +0100
-Subject: [PATCH 009/108] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
+Subject: [PATCH 009/116] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
 
 Add the DT entry for a watchdog based on RTI1.
 
@@ -37,5 +37,5 @@ index 7454c8cec0cc..0388c02c2203 100644
 +	};
  };
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0010-arm64-dts-ti-Add-support-for-Siemens-IOT2050-boards.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0010-arm64-dts-ti-Add-support-for-Siemens-IOT2050-boards.patch
@@ -1,7 +1,7 @@
-From 07de3abce9def7a8a54b6f362d8aea72f761cc45 Mon Sep 17 00:00:00 2001
+From f222526be26acb66e41dc947a62feca32cef45b8 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Mar 2021 15:33:43 +0100
-Subject: [PATCH 010/108] arm64: dts: ti: Add support for Siemens IOT2050
+Subject: [PATCH 010/116] arm64: dts: ti: Add support for Siemens IOT2050
  boards
 
 Add support for two Siemens SIMATIC IOT2050 variants, Basic and
@@ -836,5 +836,5 @@ index 000000000000..ec9617c13cdb
 +	status = "disabled";
 +};
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0011-arm64-dts-ti-k3-am65-j721e-am64-Map-the-dma-navigato.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0011-arm64-dts-ti-k3-am65-j721e-am64-Map-the-dma-navigato.patch
@@ -1,7 +1,7 @@
-From b1eddaf33322c8121a6887f4d2cc8e599216c0a6 Mon Sep 17 00:00:00 2001
+From e042909d3f91dfbaa52db7fd9acb2e457c5ce37b Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Mon, 10 May 2021 09:54:29 -0500
-Subject: [PATCH 011/108] arm64: dts: ti: k3-am65|j721e|am64: Map the dma /
+Subject: [PATCH 011/116] arm64: dts: ti: k3-am65|j721e|am64: Map the dma /
  navigator subsystem via explicit ranges
 
 Instead of using empty ranges property, lets map explicitly the address
@@ -102,5 +102,5 @@ index e581cb1d87ee..d766c7fe02af 100644
  		dma-ranges;
  
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0012-arm64-dts-ti-k3-Introduce-reg-definition-for-interru.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0012-arm64-dts-ti-k3-Introduce-reg-definition-for-interru.patch
@@ -1,7 +1,7 @@
-From a09dc72824e58c25c03aaa4137684c2d6f35a443 Mon Sep 17 00:00:00 2001
+From 33efb510838ad45e53631b85eba71d636633d88f Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Tue, 11 May 2021 14:48:21 -0500
-Subject: [PATCH 012/108] arm64: dts: ti: k3*: Introduce reg definition for
+Subject: [PATCH 012/116] arm64: dts: ti: k3*: Introduce reg definition for
  interrupt routers
 
 Interrupt routers are memory mapped peripherals, that are organized
@@ -162,5 +162,5 @@ index d766c7fe02af..282bbdc359ac 100644
  		interrupt-controller;
  		interrupt-parent = <&gic500>;
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0013-mmc-sdhci_am654-Use-pm_runtime_resume_and_get-to-rep.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0013-mmc-sdhci_am654-Use-pm_runtime_resume_and_get-to-rep.patch
@@ -1,7 +1,7 @@
-From 02727ec6c09897692372b752f06d370254732ccb Mon Sep 17 00:00:00 2001
+From 891b86f183969b6a38fbd6763249b29ccd26250f Mon Sep 17 00:00:00 2001
 From: Tian Tao <tiantao6@hisilicon.com>
 Date: Fri, 21 May 2021 08:59:35 +0800
-Subject: [PATCH 013/108] mmc: sdhci_am654: Use pm_runtime_resume_and_get() to
+Subject: [PATCH 013/116] mmc: sdhci_am654: Use pm_runtime_resume_and_get() to
  replace open coding
 
 use pm_runtime_resume_and_get() to replace pm_runtime_get_sync and
@@ -34,5 +34,5 @@ index a64ea143d185..c4799a16a61f 100644
  	base = devm_platform_ioremap_resource(pdev, 1);
  	if (IS_ERR(base)) {
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0014-arm64-dts-ti-k3-am65-iot2050-common-Disable-mailbox-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0014-arm64-dts-ti-k3-am65-iot2050-common-Disable-mailbox-.patch
@@ -1,7 +1,7 @@
-From b081a3d2405a815b206d1901b24c959a55bd8903 Mon Sep 17 00:00:00 2001
+From 42d38a24e818034fc232ff1b1ffe0bb4eca71444 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 14 May 2021 16:20:16 -0500
-Subject: [PATCH 014/108] arm64: dts: ti: k3-am65-iot2050-common: Disable
+Subject: [PATCH 014/116] arm64: dts: ti: k3-am65-iot2050-common: Disable
  mailbox nodes
 
 There are no sub-mailbox devices defined currently for both the
@@ -80,5 +80,5 @@ index de763ca9251c..f4ec9ed52939 100644
 +	status = "disabled";
 +};
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0015-arm64-dts-ti-k3-am65-Add-support-for-UHS-I-modes-in-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0015-arm64-dts-ti-k3-am65-Add-support-for-UHS-I-modes-in-.patch
@@ -1,7 +1,7 @@
-From 777e79db9b48318f77bc50392ccf53a6c0338219 Mon Sep 17 00:00:00 2001
+From 5d0f351d889b0628f35184a085c0114a352cf024 Mon Sep 17 00:00:00 2001
 From: Aswath Govindraju <a-govindraju@ti.com>
 Date: Sat, 29 May 2021 09:07:49 +0530
-Subject: [PATCH 015/108] arm64: dts: ti: k3-am65: Add support for UHS-I modes
+Subject: [PATCH 015/116] arm64: dts: ti: k3-am65: Add support for UHS-I modes
  in MMCSD1 subsystem
 
 UHS-I speed modes are supported in AM65 S.R. 2.0 SoC[1].
@@ -108,5 +108,5 @@ index 8c082af489f5..fea6a8243d75 100644
  	pinctrl-0 = <&main_mmc1_pins_default>;
  	ti,driver-strength-ohm = <50>;
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0016-arm64-dts-ti-k3-am65-main-Add-ICSSG-MDIO-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0016-arm64-dts-ti-k3-am65-main-Add-ICSSG-MDIO-nodes.patch
@@ -1,7 +1,7 @@
-From 12471d335137a5783a5ae3b5ba71a1e9cdc570e5 Mon Sep 17 00:00:00 2001
+From e75253d1123b86ca97ff2f893ff310ec6e225e79 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 1 Jun 2021 10:00:31 -0500
-Subject: [PATCH 016/108] arm64: dts: ti: k3-am65-main: Add ICSSG MDIO nodes
+Subject: [PATCH 016/116] arm64: dts: ti: k3-am65-main: Add ICSSG MDIO nodes
 
 The ICSSGs on K3 AM65x SoCs contain an MDIO controller that can
 be used to control external PHYs associated with the Industrial
@@ -125,5 +125,5 @@ index fea6a8243d75..b47fc2a1e59d 100644
 +	status = "disabled";
 +};
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0017-arm64-dts-ti-iot2050-Configure-r5f-cluster-on-basic-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0017-arm64-dts-ti-iot2050-Configure-r5f-cluster-on-basic-.patch
@@ -1,7 +1,7 @@
-From e6cdbb2f52f00dba2ef65ae1f4bc730cc3596708 Mon Sep 17 00:00:00 2001
+From c52d516f095d40fbcbff996ba62be0e808fe71e5 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 2 Jun 2021 08:56:15 +0200
-Subject: [PATCH 017/108] arm64: dts: ti: iot2050: Configure r5f cluster on
+Subject: [PATCH 017/116] arm64: dts: ti: iot2050: Configure r5f cluster on
  basic variant in split mode
 
 Lockstep mode is not supported here. So turn it off to avoid warnings
@@ -28,5 +28,5 @@ index 4f7e3f2a6265..94bb5dd39122 100644
 +	ti,cluster-mode = <0>;
 +};
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0018-arm64-dts-ti-am65-align-ti-pindir-d0-out-d1-in-prope.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0018-arm64-dts-ti-am65-align-ti-pindir-d0-out-d1-in-prope.patch
@@ -1,7 +1,7 @@
-From abf58c4f6abe3e40b8609d7c15a74e389bbc4279 Mon Sep 17 00:00:00 2001
+From e58ee2ede15eae19a01e65911cbe051ced3aa7a8 Mon Sep 17 00:00:00 2001
 From: Aswath Govindraju <a-govindraju@ti.com>
 Date: Tue, 8 Jun 2021 10:44:13 +0530
-Subject: [PATCH 018/108] arm64: dts: ti: am65: align ti,pindir-d0-out-d1-in
+Subject: [PATCH 018/116] arm64: dts: ti: am65: align ti,pindir-d0-out-d1-in
  property with dt-shema
 
 ti,pindir-d0-out-d1-in property is expected to be of type boolean.
@@ -46,5 +46,5 @@ index b47fc2a1e59d..56dc855a5f13 100644
  	flash@0{
  		compatible = "jedec,spi-nor";
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0019-firmware-ti_sci-rm-Add-support-for-tx_tdtype-paramet.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0019-firmware-ti_sci-rm-Add-support-for-tx_tdtype-paramet.patch
@@ -1,7 +1,7 @@
-From 0f5310a6f8bc4c28f2f2a6ea6e27663150cb0259 Mon Sep 17 00:00:00 2001
+From 22d2dbcc367a794afdcc6ab7b486d8f3a27061a3 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:02 -0700
-Subject: [PATCH 019/108] firmware: ti_sci: rm: Add support for tx_tdtype
+Subject: [PATCH 019/116] firmware: ti_sci: rm: Add support for tx_tdtype
  parameter for tx channel
 
 The system controller's resource manager have support for configuring the
@@ -86,5 +86,5 @@ index cf27b080e148..d254d99fd45b 100644
  
  /**
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0020-firmware-ti_sci-Use-struct-ti_sci_resource_desc-in-g.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0020-firmware-ti_sci-Use-struct-ti_sci_resource_desc-in-g.patch
@@ -1,7 +1,7 @@
-From e1b42d7a877e39afe84a9423efdce3fe355dc17f Mon Sep 17 00:00:00 2001
+From b651e23a3f40e43ef55e0590efa28d3936f45c64 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:03 -0700
-Subject: [PATCH 020/108] firmware: ti_sci: Use struct ti_sci_resource_desc in
+Subject: [PATCH 020/116] firmware: ti_sci: Use struct ti_sci_resource_desc in
  get_range ops
 
 Use the ti_sci_resource_desc directly and update it's start and num members
@@ -177,5 +177,5 @@ index d254d99fd45b..6cd537db4d33 100644
   * struct ti_sci_resource - Structure representing a resource assigned
   *			    to a device.
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0021-firmware-ti_sci-rm-Add-support-for-second-resource-r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0021-firmware-ti_sci-rm-Add-support-for-second-resource-r.patch
@@ -1,7 +1,7 @@
-From 9bd667d113e13db0fcaa07ccddef74859923cd74 Mon Sep 17 00:00:00 2001
+From 1a34fd3a6e48f42d23259775fc97c8b7307dfc19 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:03 -0700
-Subject: [PATCH 021/108] firmware: ti_sci: rm: Add support for second resource
+Subject: [PATCH 021/116] firmware: ti_sci: rm: Add support for second resource
  range
 
 Sysfw added support for a second range in the resource range API to be able
@@ -174,5 +174,5 @@ index 6cd537db4d33..9699b260de59 100644
  };
  
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0022-soc-ti-ti_sci_inta_msi-Add-support-for-second-range-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0022-soc-ti-ti_sci_inta_msi-Add-support-for-second-range-.patch
@@ -1,7 +1,7 @@
-From 0c1081ff2727912a7c1801c330267a26de14e016 Mon Sep 17 00:00:00 2001
+From 76e16364c745f87dab9fb13787fd41acd14bb49c Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:04 -0700
-Subject: [PATCH 022/108] soc: ti: ti_sci_inta_msi: Add support for second
+Subject: [PATCH 022/116] soc: ti: ti_sci_inta_msi: Add support for second
  range in resource ranges
 
 Allocate MSI entries for both first and second range if they are valid
@@ -36,5 +36,5 @@ index 0eb9462f609e..a1d9c027022a 100644
  
  	return count;
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0023-firmware-ti_sci-rm-Add-support-for-extended_ch_type-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0023-firmware-ti_sci-rm-Add-support-for-extended_ch_type-.patch
@@ -1,7 +1,7 @@
-From d0fb670643ee2d8e1bb14e9e582c7e7340e258b7 Mon Sep 17 00:00:00 2001
+From 3de69b809366689a28017e38fe962b5f26ccaab1 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:05 -0700
-Subject: [PATCH 023/108] firmware: ti_sci: rm: Add support for
+Subject: [PATCH 023/116] firmware: ti_sci: rm: Add support for
  extended_ch_type for tx channel
 
 Sysfw added 'extended_ch_type' to the tx_ch_cfg_req message which should be
@@ -91,5 +91,5 @@ index 9699b260de59..6978afc00823 100644
  
  /**
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0024-firmware-ti_sci-rm-Remove-ring_get_config-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0024-firmware-ti_sci-rm-Remove-ring_get_config-support.patch
@@ -1,7 +1,7 @@
-From 6968dd022b8bd7b9351d2d82bf8619f7eb1586f9 Mon Sep 17 00:00:00 2001
+From 498416ef41bbac631881fece40b48895081a9a1b Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:05 -0700
-Subject: [PATCH 024/108] firmware: ti_sci: rm: Remove ring_get_config support
+Subject: [PATCH 024/116] firmware: ti_sci: rm: Remove ring_get_config support
 
 The ring_get_cfg (0x1111 message) is not used and it is not supported by
 sysfw for a long time.
@@ -200,5 +200,5 @@ index 6978afc00823..6710d7ac7a72 100644
  
  /**
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0025-firmware-ti_sci-rm-Add-new-ops-for-ring-configuratio.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0025-firmware-ti_sci-rm-Add-new-ops-for-ring-configuratio.patch
@@ -1,7 +1,7 @@
-From 37580ba6588e7973af52118373f1f4326d3f76c1 Mon Sep 17 00:00:00 2001
+From f939190c60e15d46b2bb95bcdf01782876091a61 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:06 -0700
-Subject: [PATCH 025/108] firmware: ti_sci: rm: Add new ops for ring
+Subject: [PATCH 025/116] firmware: ti_sci: rm: Add new ops for ring
  configuration
 
 The sysfw ring configuration message has been extended to include virtid
@@ -198,5 +198,5 @@ index 6710d7ac7a72..d1711050cd9d 100644
  
  /**
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0026-soc-ti-k3-ringacc-Use-the-ti_sci-set_cfg-callback-fo.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0026-soc-ti-k3-ringacc-Use-the-ti_sci-set_cfg-callback-fo.patch
@@ -1,7 +1,7 @@
-From 5b3ad66e982f2548a47e68326ef42a3396499bba Mon Sep 17 00:00:00 2001
+From 57c1a5940bf76b099c718ae10ec952e84a0016f4 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:07 -0700
-Subject: [PATCH 026/108] soc: ti: k3-ringacc: Use the ti_sci set_cfg callback
+Subject: [PATCH 026/116] soc: ti: k3-ringacc: Use the ti_sci set_cfg callback
  for ring configuration
 
 Switch to the new set_cfg to configure the ring.
@@ -142,5 +142,5 @@ index 1147dc4c1d59..9ddd77113c5a 100644
  	return ret;
  }
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0027-firmware-ti_sci-rm-Remove-unused-config-from-ti_sci_.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0027-firmware-ti_sci-rm-Remove-unused-config-from-ti_sci_.patch
@@ -1,7 +1,7 @@
-From bbb650f291fcf762038fdb3d80885e5685a63044 Mon Sep 17 00:00:00 2001
+From ff498916e5e2c7b218daee828b227dbc4107bae0 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:07 -0700
-Subject: [PATCH 027/108] firmware: ti_sci: rm: Remove unused config() from
+Subject: [PATCH 027/116] firmware: ti_sci: rm: Remove unused config() from
  ti_sci_rm_ringacc_ops
 
 The ringacc driver has been converted to use the new set_cfg function to
@@ -127,5 +127,5 @@ index d1711050cd9d..0aad7009b50e 100644
  		       const struct ti_sci_msg_rm_ring_cfg *params);
  };
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0028-soc-ti-k3-ringacc-Use-correct-device-for-allocation-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0028-soc-ti-k3-ringacc-Use-correct-device-for-allocation-.patch
@@ -1,7 +1,7 @@
-From f00021165844ad4cbeaec641f1da2df739217936 Mon Sep 17 00:00:00 2001
+From f116332f65eaaa2f0e04bd534b91e837f3fda5eb Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:22 -0700
-Subject: [PATCH 028/108] soc: ti: k3-ringacc: Use correct device for
+Subject: [PATCH 028/116] soc: ti: k3-ringacc: Use correct device for
  allocation in RING mode
 
 In RING mode the ringacc does not access the ring memory. In this access
@@ -126,5 +126,5 @@ index 5a472eca5ee4..658dc71d2901 100644
  
  #define K3_RINGACC_RING_ID_ANY (-1)
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0029-soc-ti-pruss-Remove-wrong-check-against-get_match_da.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0029-soc-ti-pruss-Remove-wrong-check-against-get_match_da.patch
@@ -1,7 +1,7 @@
-From 353ed0d85a74bca6994ee7f842500c41886df9a9 Mon Sep 17 00:00:00 2001
+From 586bdb5596127f7d69773146228c2dd7d036e7a5 Mon Sep 17 00:00:00 2001
 From: Grzegorz Jaszczyk <grzegorz.jaszczyk@linaro.org>
 Date: Sat, 21 Nov 2020 19:22:25 -0800
-Subject: [PATCH 029/108] soc: ti: pruss: Remove wrong check against
+Subject: [PATCH 029/116] soc: ti: pruss: Remove wrong check against
  *get_match_data return value
 
 Since the of_device_get_match_data() doesn't return error code, remove
@@ -43,5 +43,5 @@ index cc0b4ad7a3d3..5d6e7132a5c4 100644
  	ret = dma_set_coherent_mask(dev, DMA_BIT_MASK(32));
  	if (ret) {
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0030-soc-ti-pruss-Correct-the-pruss_clk_init-error-trace-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0030-soc-ti-pruss-Correct-the-pruss_clk_init-error-trace-.patch
@@ -1,7 +1,7 @@
-From 85c6db483ab50e33ec673a9e4198be65b6f45f1b Mon Sep 17 00:00:00 2001
+From 2503ea0ec1bdf6e00048536382dbd619cb4b97ed Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 24 Jan 2021 20:51:37 -0800
-Subject: [PATCH 030/108] soc: ti: pruss: Correct the pruss_clk_init error
+Subject: [PATCH 030/116] soc: ti: pruss: Correct the pruss_clk_init error
  trace text
 
 The pruss_clk_init() function can register more than one clock.
@@ -28,5 +28,5 @@ index 5d6e7132a5c4..1d6890134312 100644
  	}
  
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0031-soc-ti-pruss-Refactor-the-CFG-sub-module-init.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0031-soc-ti-pruss-Refactor-the-CFG-sub-module-init.patch
@@ -1,7 +1,7 @@
-From e786e6f52e259a46250512d2beb725d0b2a9dac2 Mon Sep 17 00:00:00 2001
+From 03f60028b3f7d16264ae193fb5a6b794a4ca82aa Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 31 Jan 2021 20:53:43 -0800
-Subject: [PATCH 031/108] soc: ti: pruss: Refactor the CFG sub-module init
+Subject: [PATCH 031/116] soc: ti: pruss: Refactor the CFG sub-module init
 
 The CFG sub-module is not present on some earlier SoCs like the
 DA850/OMAPL-138 in the TI Davinci family. Refactor out the CFG
@@ -134,5 +134,5 @@ index 1d6890134312..f22ac1edbdd0 100644
  	pm_runtime_put_sync(dev);
  rpm_disable:
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0032-soc-ti-k3-ringacc-Use-of_device_get_match_data.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0032-soc-ti-k3-ringacc-Use-of_device_get_match_data.patch
@@ -1,7 +1,7 @@
-From 306c28cc4c76edf8f4fb036d242be280bfb4b5e0 Mon Sep 17 00:00:00 2001
+From c6806cb3b46939546487b8b072cd94350caa2fcb Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 31 Jan 2021 20:58:49 -0800
-Subject: [PATCH 032/108] soc: ti: k3-ringacc: Use of_device_get_match_data()
+Subject: [PATCH 032/116] soc: ti: k3-ringacc: Use of_device_get_match_data()
 
 Simplify the retrieval of getting the match data in the probe
 function by directly using of_device_get_match_data() instead
@@ -44,5 +44,5 @@ index 7fdb688452f7..db3f705da7a0 100644
  	ringacc = devm_kzalloc(dev, sizeof(*ringacc), GFP_KERNEL);
  	if (!ringacc)
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0033-remoteproc-ti_k3-fix-Wcast-function-type-warning.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0033-remoteproc-ti_k3-fix-Wcast-function-type-warning.patch
@@ -1,7 +1,7 @@
-From e6da21a6df8c569c60ec68a2410936f4d13efb3f Mon Sep 17 00:00:00 2001
+From 289f91185dee8d36abfc941f6186a7e3e77ee618 Mon Sep 17 00:00:00 2001
 From: Arnd Bergmann <arnd@arndb.de>
 Date: Mon, 26 Oct 2020 17:05:23 +0100
-Subject: [PATCH 033/108] remoteproc: ti_k3: fix -Wcast-function-type warning
+Subject: [PATCH 033/116] remoteproc: ti_k3: fix -Wcast-function-type warning
 
 The function cast causes a warning with "make W=1"
 
@@ -79,5 +79,5 @@ index afeb9d6e4313..b68384455726 100644
  		return ret;
  
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0034-remoteproc-Add-a-rproc_set_firmware-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0034-remoteproc-Add-a-rproc_set_firmware-API.patch
@@ -1,7 +1,7 @@
-From fa744e6fbc2fb61eb8bc0e911f612b8e8a0a51e0 Mon Sep 17 00:00:00 2001
+From 8a2da00f94e19564afa2f74027f1465a3df7c4db Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 20 Nov 2020 21:20:42 -0600
-Subject: [PATCH 034/108] remoteproc: Add a rproc_set_firmware() API
+Subject: [PATCH 034/116] remoteproc: Add a rproc_set_firmware() API
 
 A new API, rproc_set_firmware() is added to allow the remoteproc platform
 drivers and remoteproc client drivers to be able to configure a custom
@@ -159,5 +159,5 @@ index 3fa3ba6498e8..e8ac041c64d9 100644
  int rproc_coredump_add_segment(struct rproc *rproc, dma_addr_t da, size_t size);
  int rproc_coredump_add_custom_segment(struct rproc *rproc,
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0035-remoteproc-pru-Add-a-PRU-remoteproc-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0035-remoteproc-pru-Add-a-PRU-remoteproc-driver.patch
@@ -1,7 +1,7 @@
-From ae292983f7e1e50eecb9319f986490ef66615bc0 Mon Sep 17 00:00:00 2001
+From 7e918c0d3821dbad7c29041f277afef0141143b8 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:09:58 +0100
-Subject: [PATCH 035/108] remoteproc: pru: Add a PRU remoteproc driver
+Subject: [PATCH 035/116] remoteproc: pru: Add a PRU remoteproc driver
 
 The Programmable Real-Time Unit Subsystem (PRUSS) consists of
 dual 32-bit RISC cores (Programmable Real-Time Units, or PRUs)
@@ -524,5 +524,5 @@ index 000000000000..d33392bbd8af
 +MODULE_DESCRIPTION("PRU-ICSS Remote Processor Driver");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0036-remoteproc-pru-Add-support-for-PRU-specific-interrup.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0036-remoteproc-pru-Add-support-for-PRU-specific-interrup.patch
@@ -1,7 +1,7 @@
-From 774ac7b71a7c8d999044d64aea010d1fbfb77a60 Mon Sep 17 00:00:00 2001
+From cb464e63b6aefdcd0dda0c4662cb6a9ff6d10cf2 Mon Sep 17 00:00:00 2001
 From: Grzegorz Jaszczyk <grzegorz.jaszczyk@linaro.org>
 Date: Tue, 8 Dec 2020 15:09:59 +0100
-Subject: [PATCH 036/108] remoteproc: pru: Add support for PRU specific
+Subject: [PATCH 036/116] remoteproc: pru: Add support for PRU specific
  interrupt configuration
 
 The firmware blob can contain optional ELF sections: .resource_table
@@ -352,5 +352,5 @@ index 000000000000..8ee9c3171610
 +
 +#endif	/* _PRU_RPROC_H_ */
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0037-remoteproc-pru-Add-pru-specific-debugfs-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0037-remoteproc-pru-Add-pru-specific-debugfs-support.patch
@@ -1,7 +1,7 @@
-From 1dd226fed64077e490141df98bb2f078088dd702 Mon Sep 17 00:00:00 2001
+From f945aba4b4661d7c24dcdc99c9fdb5dbbe8b3a7d Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:10:00 +0100
-Subject: [PATCH 037/108] remoteproc: pru: Add pru-specific debugfs support
+Subject: [PATCH 037/116] remoteproc: pru: Add pru-specific debugfs support
 
 The remoteproc core creates certain standard debugfs entries,
 that does not give a whole lot of useful information for the
@@ -223,5 +223,5 @@ index 72e64d15f0dc..59240fd82f56 100644
  
  	return 0;
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0038-remoteproc-pru-Add-support-for-various-PRU-cores-on-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0038-remoteproc-pru-Add-support-for-various-PRU-cores-on-.patch
@@ -1,7 +1,7 @@
-From da251bc46f842c184491c890fd963bfafa4477fd Mon Sep 17 00:00:00 2001
+From ace82bd1ec7626b7b157e41ec4bbd567c14647b0 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:10:01 +0100
-Subject: [PATCH 038/108] remoteproc: pru: Add support for various PRU cores on
+Subject: [PATCH 038/116] remoteproc: pru: Add support for various PRU cores on
  K3 AM65x SoCs
 
 The K3 AM65x family of SoCs have the next generation of the PRU-ICSS
@@ -294,5 +294,5 @@ index 59240fd82f56..421ebbc1c02d 100644
  };
  MODULE_DEVICE_TABLE(of, pru_rproc_match);
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0039-remoteproc-pru-Fix-loading-of-GNU-Binutils-ELF.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0039-remoteproc-pru-Fix-loading-of-GNU-Binutils-ELF.patch
@@ -1,7 +1,7 @@
-From 5262ec84ba2fbc50aca52f104e453cb4d5a7c15c Mon Sep 17 00:00:00 2001
+From 86634921448600fdb5f2140fbbeb293f229defc2 Mon Sep 17 00:00:00 2001
 From: Dimitar Dimitrov <dimitar@dinux.eu>
 Date: Wed, 30 Dec 2020 12:50:05 +0200
-Subject: [PATCH 039/108] remoteproc: pru: Fix loading of GNU Binutils ELF
+Subject: [PATCH 039/116] remoteproc: pru: Fix loading of GNU Binutils ELF
 
 PRU port of GNU Binutils lacks support for separate address spaces.
 PRU IRAM addresses are marked with artificial offset to differentiate
@@ -48,5 +48,5 @@ index 421ebbc1c02d..a113e150d5d5 100644
  	    da + len <= PRU_IRAM_DA + pru->mem_regions[PRU_IOMEM_IRAM].size) {
  		offset = da - PRU_IRAM_DA;
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0040-remoteproc-pru-Fix-firmware-loading-crashes-on-K3-So.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0040-remoteproc-pru-Fix-firmware-loading-crashes-on-K3-So.patch
@@ -1,7 +1,7 @@
-From 3202417c0d11ca4eb8822ca94e321802cba40733 Mon Sep 17 00:00:00 2001
+From 0bbf1d354818732d76d60ea8ac53d2403e4563af Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Mon, 15 Mar 2021 15:58:59 -0500
-Subject: [PATCH 040/108] remoteproc: pru: Fix firmware loading crashes on K3
+Subject: [PATCH 040/116] remoteproc: pru: Fix firmware loading crashes on K3
  SoCs
 
 The K3 PRUs are 32-bit processors and in general have some limitations
@@ -36,5 +36,5 @@ index a113e150d5d5..21105592a83d 100644
  					       filesz);
  			if (ret) {
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0041-remoteproc-pru-Fixup-interrupt-parent-logic-for-fw-e.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0041-remoteproc-pru-Fixup-interrupt-parent-logic-for-fw-e.patch
@@ -1,7 +1,7 @@
-From ae838770678e6f24e2b83377180953be9aebf9fb Mon Sep 17 00:00:00 2001
+From f5b0d71543124d9a71373799f8cfdad56962c14b Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:39 -0500
-Subject: [PATCH 041/108] remoteproc: pru: Fixup interrupt-parent logic for fw
+Subject: [PATCH 041/116] remoteproc: pru: Fixup interrupt-parent logic for fw
  events
 
 The PRU firmware interrupt mapping logic in pru_handle_intrmap() uses
@@ -74,5 +74,5 @@ index 21105592a83d..773c09d01958 100644
  	return ret;
  }
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0042-remoteproc-pru-Fix-wrong-success-return-value-for-fw.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0042-remoteproc-pru-Fix-wrong-success-return-value-for-fw.patch
@@ -1,7 +1,7 @@
-From 673d998e57440bd53322bb6381f9d27154c97c12 Mon Sep 17 00:00:00 2001
+From 3a09d1469019f15c51a6f243d529ca929ec5b1dd Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:40 -0500
-Subject: [PATCH 042/108] remoteproc: pru: Fix wrong success return value for
+Subject: [PATCH 042/116] remoteproc: pru: Fix wrong success return value for
  fw events
 
 The irq_create_fwspec_mapping() returns a proper virq value on success
@@ -41,5 +41,5 @@ index 773c09d01958..e0c5fce8bccd 100644
  		}
  	}
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0043-remoteproc-pru-Fix-and-cleanup-firmware-interrupt-ma.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0043-remoteproc-pru-Fix-and-cleanup-firmware-interrupt-ma.patch
@@ -1,7 +1,7 @@
-From daa1cebc311e672adbc670e8358220b37b6e92c4 Mon Sep 17 00:00:00 2001
+From 04318f4750655bbcc8d5743cff08fa3699ecfc50 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:41 -0500
-Subject: [PATCH 043/108] remoteproc: pru: Fix and cleanup firmware interrupt
+Subject: [PATCH 043/116] remoteproc: pru: Fix and cleanup firmware interrupt
  mapping logic
 
 The PRU firmware interrupt mappings are configured and unconfigured in
@@ -95,5 +95,5 @@ index e0c5fce8bccd..d8597027a93e 100644
  	return 0;
  }
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0044-watchdog-Start-watchdog-in-watchdog_set_last_hw_keep.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0044-watchdog-Start-watchdog-in-watchdog_set_last_hw_keep.patch
@@ -1,7 +1,7 @@
-From e018a676923c133b92ee6680c6d9c34240fa8299 Mon Sep 17 00:00:00 2001
+From 8aedfe807760f940e17e248e21e18e309cc5e39f Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 30 Jul 2021 21:19:38 +0200
-Subject: [PATCH 044/108] watchdog: Start watchdog in
+Subject: [PATCH 044/116] watchdog: Start watchdog in
  watchdog_set_last_hw_keepalive only if appropriate
 
 We must not pet a running watchdog when handle_boot_enabled is off
@@ -33,5 +33,5 @@ index 2946f3a63110..2ee017442dfc 100644
  EXPORT_SYMBOL_GPL(watchdog_set_last_hw_keepalive);
  
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0045-arm64-dts-ti-iot2050-Flip-mmc-device-ordering-on-Adv.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0045-arm64-dts-ti-iot2050-Flip-mmc-device-ordering-on-Adv.patch
@@ -1,7 +1,7 @@
-From d451afb66f37f553afd6cc2e9d0a396e0c146da9 Mon Sep 17 00:00:00 2001
+From 8115a5cf79a7042530fda8505245f05f77a0c0f9 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 1 Sep 2021 21:52:11 +0200
-Subject: [PATCH 045/108] arm64: dts: ti: iot2050: Flip mmc device ordering on
+Subject: [PATCH 045/116] arm64: dts: ti: iot2050: Flip mmc device ordering on
  Advanced devices
 
 This ensures that the SD card will remain mmc0 across Basic and Advanced
@@ -27,5 +27,5 @@ index 1008e9162ba2..6261ca8ee2d8 100644
  
  	chosen {
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0046-arm64-dts-ti-iot2050-Disable-SR2.0-only-PRUs.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0046-arm64-dts-ti-iot2050-Disable-SR2.0-only-PRUs.patch
@@ -1,7 +1,7 @@
-From 598fddf8c0e906c56fd8fb7ad061200ffedf683c Mon Sep 17 00:00:00 2001
+From c407d7b9a95a95883a0dbbfd3b3393a4b5fd3468 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 1 Sep 2021 19:58:30 +0200
-Subject: [PATCH 046/108] arm64: dts: ti: iot2050: Disable SR2.0-only PRUs
+Subject: [PATCH 046/116] arm64: dts: ti: iot2050: Disable SR2.0-only PRUs
 
 The IOT2050 devices described so far are using SR1.0 silicon, thus do
 not have the additional PRUs of the ICSSG of the SR2.0. Disable them.
@@ -44,5 +44,5 @@ index 6261ca8ee2d8..58c8e64d5885 100644
 +	status = "disabled";
 +};
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0047-arm64-dts-ti-iot2050-Add-enabled-mailboxes-and-carve.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0047-arm64-dts-ti-iot2050-Add-enabled-mailboxes-and-carve.patch
@@ -1,7 +1,7 @@
-From 10b99593f25c0c844423467d5e5a945019f3da12 Mon Sep 17 00:00:00 2001
+From f0ee3b0b14e6cfb646612c000a01debd15d36139 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 9 Sep 2021 08:01:16 +0200
-Subject: [PATCH 047/108] arm64: dts: ti: iot2050: Add/enabled mailboxes and
+Subject: [PATCH 047/116] arm64: dts: ti: iot2050: Add/enabled mailboxes and
  carve-outs for R5F cores
 
 Analogously to the am654-base-board, configure the mailboxes for the the
@@ -62,5 +62,5 @@ index 58c8e64d5885..b29537088289 100644
  	status = "disabled";
  };
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0048-arm64-dts-ti-iot2050-Prepare-for-adding-2nd-generati.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0048-arm64-dts-ti-iot2050-Prepare-for-adding-2nd-generati.patch
@@ -1,7 +1,7 @@
-From a0fc6ab1d2e2b4749ddca15de843a2d5ec9ebd52 Mon Sep 17 00:00:00 2001
+From 262a03dff963109aec6ebfb3fcfa5dc38f0d989c Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 7 Sep 2021 17:49:55 +0200
-Subject: [PATCH 048/108] arm64: dts: ti: iot2050: Prepare for adding
+Subject: [PATCH 048/116] arm64: dts: ti: iot2050: Prepare for adding
  2nd-generation boards
 
 The current IOT2050 devices are Product Generation 1 (PG1), using SR1.0
@@ -417,5 +417,5 @@ index ec9617c13cdb..077f165bdc68 100644
 -	status = "disabled";
  };
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
@@ -1,7 +1,7 @@
-From ba2599d68371557c505dd4a46368290cb2217c7d Mon Sep 17 00:00:00 2001
+From 471fd8fdb3007155117fd8a2a3896192a2fd24c8 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 21 Jun 2021 11:04:56 +0200
-Subject: [PATCH 049/108] arm64: dts: ti: iot2050: Add support for product
+Subject: [PATCH 049/116] arm64: dts: ti: iot2050: Add support for product
  generation 2 boards
 
 This adds the devices trees for IOT2050 Product Generation 2 (PG2)
@@ -158,5 +158,5 @@ index 000000000000..f00dc86d01b9
 +	ti,cluster-mode = <0>;
 +};
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
@@ -1,7 +1,7 @@
-From 4405fd659b8d61c7a54b0bf6863848c6a895b41b Mon Sep 17 00:00:00 2001
+From 3a83e68fc9295ebae2d31f2770185d5432414765 Mon Sep 17 00:00:00 2001
 From: Tomi Valkeinen <tomi.valkeinen@ti.com>
 Date: Mon, 31 May 2021 16:31:35 +0530
-Subject: [PATCH 050/108] arm64: dts: ti: k3-am65-main: fix DSS irq trigger
+Subject: [PATCH 050/116] arm64: dts: ti: k3-am65-main: fix DSS irq trigger
  type
 
 DSS irq trigger type is set to IRQ_TYPE_EDGE_RISING. For some reason this
@@ -35,5 +35,5 @@ index 9338f1042232..9b1a016162b2 100644
  		dma-coherent;
  
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0051-irqdomain-Export-of_phandle_args_to_fwspec.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0051-irqdomain-Export-of_phandle_args_to_fwspec.patch
@@ -1,7 +1,7 @@
-From e3146d74676a36b7905e30498f87554127520241 Mon Sep 17 00:00:00 2001
+From 453e4c873269d9cecc35a7785bd31625887f99dc Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:46 +0530
-Subject: [PATCH 051/108] irqdomain: Export of_phandle_args_to_fwspec()
+Subject: [PATCH 051/116] irqdomain: Export of_phandle_args_to_fwspec()
 
 Export of_phandle_args_to_fwspec() to be used by drivers.
 of_phandle_args_to_fwspec() can be used by drivers to get irq specifier
@@ -55,5 +55,5 @@ index c6b419db68ef..a17e4ce3811d 100644
  unsigned int irq_create_fwspec_mapping(struct irq_fwspec *fwspec)
  {
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0052-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0052-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
@@ -1,7 +1,7 @@
-From aaabb423d0c8bf6ad042a24b4876b0bfa1c7c8d1 Mon Sep 17 00:00:00 2001
+From f60fd72ebfb3529450fd927fe708c78afec219c8 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:47 +0530
-Subject: [PATCH 052/108] PCI: keystone: Convert to using hierarchy domain for
+Subject: [PATCH 052/116] PCI: keystone: Convert to using hierarchy domain for
  legacy interrupts
 
 K2G provides separate IRQ lines for each of the four legacy interrupts.
@@ -318,5 +318,5 @@ index 90482d5246ff..0493e43ba416 100644
  err:
  	of_node_put(intc_np);
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
@@ -1,7 +1,7 @@
-From 32021af50c37c33b8c82a58e5dbe41783adc35fb Mon Sep 17 00:00:00 2001
+From 9d724394f54485a61a10990532371670479d0c8d Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:48 +0530
-Subject: [PATCH 053/108] PCI: keystone: Add PCI legacy interrupt support for
+Subject: [PATCH 053/116] PCI: keystone: Add PCI legacy interrupt support for
  AM654
 
 Add PCI legacy interrupt support for AM654. AM654 has a single HW
@@ -135,5 +135,5 @@ index 0493e43ba416..0460ed2a277a 100644
  		return ret;
  
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
@@ -1,7 +1,7 @@
-From ed017c1f44c12b073ef5e419aaefc36b3f247e3f Mon Sep 17 00:00:00 2001
+From bb4cb3d49447d32d9ad144b27883a4a48ecec5ff Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:49 +0530
-Subject: [PATCH 054/108] PCI: keystone: Add workaround for Errata #i2037
+Subject: [PATCH 054/116] PCI: keystone: Add workaround for Errata #i2037
  (AM65x SR 1.0)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -110,5 +110,5 @@ index 0460ed2a277a..bb7190400ba8 100644
  DECLARE_PCI_FIXUP_ENABLE(PCI_ANY_ID, PCI_ANY_ID, ks_pcie_quirk);
  
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0055-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0055-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
@@ -1,7 +1,7 @@
-From 5427d3ff876054957fe10e6ea74abb6db9680621 Mon Sep 17 00:00:00 2001
+From c40be9099b52f979e53c75920c5f8461cf4e23f2 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:38:07 +0530
-Subject: [PATCH 055/108] arm64: dts: ti: k3-am65-main: Add properties to
+Subject: [PATCH 055/116] arm64: dts: ti: k3-am65-main: Add properties to
  support legacy interrupts
 
 Add DT properties in PCIe DT node to support legacy interrupts.
@@ -82,5 +82,5 @@ index 9b1a016162b2..b786daed9639 100644
  
  	pcie1_ep: pcie-ep@5600000 {
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0056-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0056-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
@@ -1,7 +1,7 @@
-From 59c3f633840a17727576f271ced5c1259b1fba4f Mon Sep 17 00:00:00 2001
+From 42a18ea79d6f6652d7ea968bc3a3d4dda603d84c Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 20 Nov 2020 21:01:54 -0600
-Subject: [PATCH 056/108] remoteproc: Fix unbalanced boot with sysfs for no
+Subject: [PATCH 056/116] remoteproc: Fix unbalanced boot with sysfs for no
  auto-boot rprocs
 
 The remoteproc core performs automatic boot and shutdown of a remote
@@ -73,5 +73,5 @@ index 1dbef895e65e..3b05230641c8 100644
  		dev_err(&rproc->dev, "Unrecognised option: %s\n", buf);
  		ret = -EINVAL;
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Introduce-deny_sysfs_ops-flag.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Introduce-deny_sysfs_ops-flag.patch
@@ -1,7 +1,7 @@
-From f791815baf4cddf112aa069295aa9e6b8dc96b22 Mon Sep 17 00:00:00 2001
+From 4589f836c8967133227bee8a36b3b1a667aaac0f Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 13:05:28 -0500
-Subject: [PATCH 057/108] remoteproc: Introduce deny_sysfs_ops flag
+Subject: [PATCH 057/116] remoteproc: Introduce deny_sysfs_ops flag
 
 The remoteproc framework provides sysfs interfaces for changing the
 firmware name and for starting/stopping a remote processor through
@@ -95,5 +95,5 @@ index e8ac041c64d9..02425aac6100 100644
  	int nb_vdev;
  	u8 elf_class;
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
@@ -1,7 +1,7 @@
-From 305c7fb191a731e2afa3e1645c439b55ad4db105 Mon Sep 17 00:00:00 2001
+From 61deb22e4f5754eee60be0d224cc518a6f18312d Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:32:29 -0500
-Subject: [PATCH 058/108] remoteproc: pru: Add APIs to get and put the PRU
+Subject: [PATCH 058/116] remoteproc: pru: Add APIs to get and put the PRU
  cores
 
 Add two new APIs, pru_rproc_get() and pru_rproc_put(), to the PRU
@@ -279,5 +279,5 @@ index 000000000000..1a97856b463a
 +
 +#endif /* __LINUX_PRUSS_H */
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
@@ -1,7 +1,7 @@
-From e76d8ba1ddf69d490f2dc623a35f869950ae3fc6 Mon Sep 17 00:00:00 2001
+From c0449b202016b2feca39f2a5516df8d9663a5fc6 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 16 Dec 2020 17:52:37 +0100
-Subject: [PATCH 059/108] remoteproc: pru: Deny rproc sysfs ops for PRU client
+Subject: [PATCH 059/116] remoteproc: pru: Deny rproc sysfs ops for PRU client
  driven boots
 
 The PRU remoteproc driver is not configured for 'auto-boot' by default,
@@ -41,5 +41,5 @@ index 0b57b3f7747f..8fac021adc52 100644
  
  	put_device(&rproc->dev);
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
@@ -1,7 +1,7 @@
-From e2832bdfd25405fae98f80c70693cba08cc4bd36 Mon Sep 17 00:00:00 2001
+From b9809c0e54d05cf24d3ad3331d2ffa278b05365a Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Fri, 26 Mar 2021 15:43:53 -0500
-Subject: [PATCH 060/108] remoteproc: pru: Add pru_rproc_set_ctable() function
+Subject: [PATCH 060/116] remoteproc: pru: Add pru_rproc_set_ctable() function
 
 Some firmwares expect the OS drivers to configure the CTABLE
 entries publishing dynamically allocated memory regions. For
@@ -182,5 +182,5 @@ index 1a97856b463a..e1740ff06962 100644
  
  static inline bool is_pru_rproc(struct device *dev)
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Configure-firmware-based-on-client-se.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Configure-firmware-based-on-client-se.patch
@@ -1,7 +1,7 @@
-From 4859cf17ad3147075cc680656e9a0f7e0a7f96b0 Mon Sep 17 00:00:00 2001
+From a34bcaf922a727ba7486163eae17b137188f3a12 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:50:14 -0500
-Subject: [PATCH 061/108] remoteproc: pru: Configure firmware based on client
+Subject: [PATCH 061/116] remoteproc: pru: Configure firmware based on client
  setup
 
 Client device node property firmware-name is now used to configure
@@ -104,5 +104,5 @@ index 90c097ebc27e..c346899d5e3b 100644
  	pru->client_np = NULL;
  	rproc->deny_sysfs_ops = false;
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0062-soc-ti-pruss-Add-pruss_get-put-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0062-soc-ti-pruss-Add-pruss_get-put-API.patch
@@ -1,7 +1,7 @@
-From 0b0b108db79e3906bd50836c9fd88d35697a0745 Mon Sep 17 00:00:00 2001
+From 00affafb5370efe9d80a4474666ef344087250b1 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:58:00 -0500
-Subject: [PATCH 062/108] soc: ti: pruss: Add pruss_get()/put() API
+Subject: [PATCH 062/116] soc: ti: pruss: Add pruss_get()/put() API
 
 Add two new get and put API, pruss_get() and pruss_put() to the
 PRUSS platform driver to allow client drivers to request a handle
@@ -176,5 +176,5 @@ index ecfded30ed05..4d1321f0d326 100644
  
  /*
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
@@ -1,7 +1,7 @@
-From 2b79fb945194cc2aa277a1e86a3aa26865d3e32a Mon Sep 17 00:00:00 2001
+From 24b1c2058fdd89498647586ba46af251adaa08ae Mon Sep 17 00:00:00 2001
 From: "Andrew F. Davis" <afd@ti.com>
 Date: Fri, 26 Mar 2021 16:11:42 -0500
-Subject: [PATCH 063/108] soc: ti: pruss: Add
+Subject: [PATCH 063/116] soc: ti: pruss: Add
  pruss_{request,release}_mem_region() API
 
 Add two new API - pruss_request_mem_region() & pruss_release_mem_region(),
@@ -236,5 +236,5 @@ index 4d1321f0d326..f1d1197fd91a 100644
  	struct clk *iep_clk_mux;
  };
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
@@ -1,7 +1,7 @@
-From ec2e7d171ad311a9c00b5da7e6866162d30c275b Mon Sep 17 00:00:00 2001
+From e7f7e24b315b6d7da585efc8724a733860920036 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:27:34 -0500
-Subject: [PATCH 064/108] soc: ti: pruss: Add pruss_cfg_read()/update() API
+Subject: [PATCH 064/116] soc: ti: pruss: Add pruss_cfg_read()/update() API
 
 Add two new generic API pruss_cfg_read() and pruss_cfg_update() to
 the PRUSS platform driver to allow other drivers to read and program
@@ -209,5 +209,5 @@ index 40de553d4446..a4f59a46c331 100644
  
  #if IS_ENABLED(CONFIG_PRU_REMOTEPROC)
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
@@ -1,7 +1,7 @@
-From 7b014fd3936f9a9e5cd0685c83136e58fe339a23 Mon Sep 17 00:00:00 2001
+From f3abbc9d186151a63fb5f416eddff5013e0e8e64 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 11 Dec 2020 19:48:09 +0100
-Subject: [PATCH 065/108] soc: ti: pruss: Add helper functions to set GPI mode,
+Subject: [PATCH 065/116] soc: ti: pruss: Add helper functions to set GPI mode,
  MII_RT_event and XFR
 
 The PRUSS CFG module is represented as a syscon node and is currently
@@ -82,5 +82,5 @@ index a4f59a46c331..ba5b728d5015 100644
 +
  #endif /* __LINUX_PRUSS_H */
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
@@ -1,7 +1,7 @@
-From 1a8d17300e51fc4257f2e339abfe7e00601f88a9 Mon Sep 17 00:00:00 2001
+From 3207317180889a69b60c30b96186f78c1e16684b Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:38:11 -0500
-Subject: [PATCH 066/108] soc: ti: pruss: Add helper function to enable OCP
+Subject: [PATCH 066/116] soc: ti: pruss: Add helper function to enable OCP
  master ports
 
 The PRU-ICSS subsystem on OMAP-architecture based SoCS (AM33xx, AM437x
@@ -178,5 +178,5 @@ index ba5b728d5015..5fdd6f03446d 100644
  
  #if IS_ENABLED(CONFIG_PRU_REMOTEPROC)
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
@@ -1,7 +1,7 @@
-From 535726e0ef46a478c6943421db999a28111cad94 Mon Sep 17 00:00:00 2001
+From aca173a16a5d4f412172fb4c7e6422b34de4fd45 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 09:24:51 -0500
-Subject: [PATCH 067/108] soc: ti: pruss: Add helper functions to get/set
+Subject: [PATCH 067/116] soc: ti: pruss: Add helper functions to get/set
  PRUSS_CFG_GPMUX
 
 Add two new helper functions pruss_cfg_get_gpmux() & pruss_cfg_set_gpmux()
@@ -71,5 +71,5 @@ index f1d1197fd91a..d6abfdd17631 100644
 +
  #endif	/* _PRUSS_DRIVER_H_ */
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0068-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0068-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
@@ -1,7 +1,7 @@
-From b22cac48856b2f40702b5967edceb1e6cee97c5e Mon Sep 17 00:00:00 2001
+From 2cccf8035953dd9a274edd977d44491c56904a3d Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 10:11:42 -0500
-Subject: [PATCH 068/108] remoteproc/pru: add support for configuring GPMUX
+Subject: [PATCH 068/116] remoteproc/pru: add support for configuring GPMUX
  based on client setup
 
 Client device node property ti,pruss-gp-mux-sel can now be used to
@@ -75,5 +75,5 @@ index c346899d5e3b..7ef176170b18 100644
  
  	mutex_lock(&pru->lock);
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0069-net-ethernet-ti-prueth-Add-IEP-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0069-net-ethernet-ti-prueth-Add-IEP-driver.patch
@@ -1,7 +1,7 @@
-From ca03a84ccd41e5bb9a5c69e9778de14032337e33 Mon Sep 17 00:00:00 2001
+From 027d132920acaceaf99026b9e5d04ed2a29b5860 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 20 Apr 2021 13:17:30 +0530
-Subject: [PATCH 069/108] net: ethernet: ti: prueth: Add IEP driver
+Subject: [PATCH 069/116] net: ethernet: ti: prueth: Add IEP driver
 
 Add a driver for Industrial Ethernet Peripheral (IEP) block of PRUSS to
 support timestamping of ethernet packets and thus support PTP and PPS
@@ -1146,5 +1146,5 @@ index 000000000000..a41e18df666e
 +
 +#endif /* __NET_TI_ICSS_IEP_H */
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0070-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0070-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
@@ -1,7 +1,7 @@
-From e374ff679350048e9fc70f13b9a5dec8ca304235 Mon Sep 17 00:00:00 2001
+From ebf8d21995d8624a247a30dfc71079d64f9cdf55 Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Tue, 20 Apr 2021 13:17:31 +0530
-Subject: [PATCH 070/108] HACK: net: ethernet: ti: icss-iep: Fix sync0
+Subject: [PATCH 070/116] HACK: net: ethernet: ti: icss-iep: Fix sync0
  generation on a compare event
 
 commit 41e5c46849b5 ("net: ethernet: ti: icss-iep: Add support for generating
@@ -119,5 +119,5 @@ index 234972a034a9..22034d41c988 100644
  EXPORT_SYMBOL_GPL(icss_iep_put);
  
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0071-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0071-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
@@ -1,7 +1,7 @@
-From b87ceb6899df6870f25607ff68ff5fc928838257 Mon Sep 17 00:00:00 2001
+From f8b5ae2cef8898d3ed37a72540e95304748475a6 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:28 +0300
-Subject: [PATCH 071/108] net: ethernet: ti: icss_iep: drop
+Subject: [PATCH 071/116] net: ethernet: ti: icss_iep: drop
  ICSS_IEP_CAPx_FALL_REGy
 
 ICSS_IEP_CAPx_FALL_REGy are not used, but cause indexation issues in
@@ -80,5 +80,5 @@ index 22034d41c988..60a284c6c0c9 100644
  		[ICSS_IEP_CMP_CFG_REG] = 0x40,
  		[ICSS_IEP_CMP_STAT_REG] = 0x44,
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
@@ -1,7 +1,7 @@
-From 00d849170ad24c60fb94c6b70d940010b70718e6 Mon Sep 17 00:00:00 2001
+From 79660be71868c8d305e0a1039b127981250ae412 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:29 +0300
-Subject: [PATCH 072/108] net: ethernet: ti: icss_iep: fix access to x_REG1 in
+Subject: [PATCH 072/116] net: ethernet: ti: icss_iep: fix access to x_REG1 in
  non 64bit mode
 
 Do not access x_REG1 registers in non 64bit mode.
@@ -93,5 +93,5 @@ index 60a284c6c0c9..73c0a31e8245 100644
  			pevent.type = PTP_CLOCK_EXTTS;
  			pevent.index = i;
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
@@ -1,7 +1,7 @@
-From ae7a361f97a9384f19779849309b858276836d9c Mon Sep 17 00:00:00 2001
+From 0339118a256447b1d9df60449eb2ade78e9780dc Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:30 +0300
-Subject: [PATCH 073/108] net: ethernet: ti: icss_iep: disable extts and pps if
+Subject: [PATCH 073/116] net: ethernet: ti: icss_iep: disable extts and pps if
  no slow compensation or non 64bit mode
 
 Disable extts and pps if no slow compensation support or non 64bit mode.
@@ -37,5 +37,5 @@ index 73c0a31e8245..c0bcb1d1180a 100644
  
  put_iep_device:
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
@@ -1,7 +1,7 @@
-From 662dfc831dad1b6baff4dfb8d2cfdf69d8002bdd Mon Sep 17 00:00:00 2001
+From 30a085109e66db87a7a7057d00eacff72a1f41b5 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:31 +0300
-Subject: [PATCH 074/108] net: ethernet: ti: icss_iep: fix pps irq race vs pps
+Subject: [PATCH 074/116] net: ethernet: ti: icss_iep: fix pps irq race vs pps
  disable
 
 When PPS is disabled the PPS IRQ can be running and PPS timer started which
@@ -123,5 +123,5 @@ index c0bcb1d1180a..ead1e7c94021 100644
  	mutex_unlock(&iep->ptp_clk_mutex);
  
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
@@ -1,7 +1,7 @@
-From ce3c90ad7779bcdacae445bd940b8cb76824abfc Mon Sep 17 00:00:00 2001
+From 18eb60af0c76883188edcaaf957a81d7060ca45d Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:32 +0300
-Subject: [PATCH 075/108] net: ethernet: ti: icss_iep: improve icss_iep_gettime
+Subject: [PATCH 075/116] net: ethernet: ti: icss_iep: improve icss_iep_gettime
 
 There are few issues with icss_iep_gettime():
 - it has to be very fast, but it's not protected from interruption
@@ -69,5 +69,5 @@ index ead1e7c94021..cbec01328a71 100644
  
  static void icss_iep_enable(struct icss_iep *iep)
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
@@ -1,7 +1,7 @@
-From 2dfc6701cafaba0f15002c7e6fbb0352643a3d22 Mon Sep 17 00:00:00 2001
+From d56570c4be5b7d97edd9785eafce86cdcd3575ec Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:33 +0300
-Subject: [PATCH 076/108] net: ethernet: ti: icss_iep: simplify peroutput
+Subject: [PATCH 076/116] net: ethernet: ti: icss_iep: simplify peroutput
  processing
 
 simplify peroutput processing
@@ -114,5 +114,5 @@ index cbec01328a71..b39d4c08c6c9 100644
  		hrtimer_start(&iep->sync_timer, ms_to_ktime(110), /* 100ms + buffer */
  			      HRTIMER_MODE_REL);
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
@@ -1,7 +1,7 @@
-From a035157ee5f05051479e8e2f81053c6436e2ed1e Mon Sep 17 00:00:00 2001
+From f77d3d4fc159a60f1d8615f6c7ed6be3e6fec9d7 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:34 +0300
-Subject: [PATCH 077/108] net: ethernet: ti: icss_iep: use readl/writel in
+Subject: [PATCH 077/116] net: ethernet: ti: icss_iep: use readl/writel in
  cap_cmp_handler
 
 Use readl/writel in cap_cmp_handler and timer handler instead of regmap
@@ -102,5 +102,5 @@ index b39d4c08c6c9..e2663dd5cf38 100644
  	return HRTIMER_NORESTART;
  }
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
@@ -1,7 +1,7 @@
-From dcbf67b080f2add568e74731dadef382df5d1623 Mon Sep 17 00:00:00 2001
+From 668a7d614c71db72aa4a0d6bab7175772ce74e0f Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:35 +0300
-Subject: [PATCH 078/108] net: ethernet: ti: icss_iep: switch to .gettimex64()
+Subject: [PATCH 078/116] net: ethernet: ti: icss_iep: switch to .gettimex64()
 
 The .gettime64() is deprecated by commit 916444df305e ("ptp: deprecate
 gettime64() in favor of gettimex64()").
@@ -95,5 +95,5 @@ index e2663dd5cf38..c0497b448d68 100644
  	.enable		= icss_iep_ptp_enable,
  };
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
@@ -1,7 +1,7 @@
-From f1b206a2404908c872fec8c4c793e00f3c421a4c Mon Sep 17 00:00:00 2001
+From c06ad7ba1e9e45df9868a98e13eaab04acce242b Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Thu, 29 Apr 2021 18:13:36 +0300
-Subject: [PATCH 079/108] net: ethernet: ti: icss_iep: Update compare registers
+Subject: [PATCH 079/116] net: ethernet: ti: icss_iep: Update compare registers
  after changing ptp clock time
 
 Consider the scenario where PPS is enabled, then iep set_time or adjust_time is
@@ -60,5 +60,5 @@ index c0497b448d68..8bad9c86775a 100644
  
  static u64 icss_iep_gettime(struct icss_iep *iep,
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
@@ -1,7 +1,7 @@
-From 504d65cb7c251fbd2146e4172a8aca3d8cdbde6e Mon Sep 17 00:00:00 2001
+From 8218d69c400d6ff9d3504f13487f693ebe6075f2 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:37 +0300
-Subject: [PATCH 080/108] net: ethernet: ti: icss_iep: request cmp_cap irq from
+Subject: [PATCH 080/116] net: ethernet: ti: icss_iep: request cmp_cap irq from
  probe
 
 The current INTC design allows to define IEP cmp_cap IRQ explicitly for IEP
@@ -106,5 +106,5 @@ index 8bad9c86775a..df74b5fd17e9 100644
  	if (IS_ERR(iep_clk))
  		return PTR_ERR(iep_clk);
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
@@ -1,7 +1,7 @@
-From 9384987c10db9053a36932c9827d7fb7c9414b72 Mon Sep 17 00:00:00 2001
+From 74f63476a6c8f513e97fe57ed70f3f1ea85e25e2 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:38 +0300
-Subject: [PATCH 081/108] net: ethernet: ti: icss_iep: set phc time to system
+Subject: [PATCH 081/116] net: ethernet: ti: icss_iep: set phc time to system
  time on init
 
 Following customer feedback IEP PHC time has to be set to system time on
@@ -28,5 +28,5 @@ index df74b5fd17e9..08b456f0bc12 100644
  	iep->clk_tick_time = def_inc;
  
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
@@ -1,7 +1,7 @@
-From 9a199a422d0f6eea6bd95aea420cb44d348b7aca Mon Sep 17 00:00:00 2001
+From 1b5b9f3bd2747b3786d1571ab46e8303ae0f3ae0 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:39 +0300
-Subject: [PATCH 082/108] net: ethernet: ti: icss_iep: use
+Subject: [PATCH 082/116] net: ethernet: ti: icss_iep: use
  devm_platform_ioremap_resource
 
 Use devm_platform_ioremap_resource() in probe to simplify code.
@@ -35,5 +35,5 @@ index 08b456f0bc12..640f483854d0 100644
  		return -ENODEV;
  
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0083-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0083-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
@@ -1,7 +1,7 @@
-From 8e1eed2b2e52bb8ab738b9abe1d7699a86bb0a8b Mon Sep 17 00:00:00 2001
+From 48d33938e66ef28217dbcfb422fc8b7a0a53f63a Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 16 Mar 2021 18:00:25 -0500
-Subject: [PATCH 083/108] arm64: dts: ti: k3-am65-main: Add ICSSG IEP nodes
+Subject: [PATCH 083/116] arm64: dts: ti: k3-am65-main: Add ICSSG IEP nodes
 
 The ICSSG IP on AM65x SoCs have two Industrial Ethernet Peripherals (IEPs)
 to manage/generate Industrial Ethernet functions such as time stamping.
@@ -77,5 +77,5 @@ index b786daed9639..d0e565fb5e12 100644
  			compatible = "ti,pruss-mii", "syscon";
  			reg = <0x32000 0x100>;
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0084-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0084-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
@@ -1,7 +1,7 @@
-From 18b980c152c5d58e3fe0f0a595788d4990c2115f Mon Sep 17 00:00:00 2001
+From 1e389c8a9d3e0d0d45371d5803ae9321a036af32 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:22 +0300
-Subject: [PATCH 084/108] dt-bindings: net: Add binding for ti,icssg-prueth
+Subject: [PATCH 084/116] dt-bindings: net: Add binding for ti,icssg-prueth
  device
 
 This is the DT binding document for the ICSSG Dual-EMAC Ethernet
@@ -149,5 +149,5 @@ index 000000000000..67609e26afa5
 +		};
 +	};
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0085-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0085-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
@@ -1,7 +1,7 @@
-From f8c1f99e3f97ff4ea2eb9b50ceb81df9e1bca8a0 Mon Sep 17 00:00:00 2001
+From 25dc558d045bd6956a4617bcd5f48e1642f8c93a Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:23 +0300
-Subject: [PATCH 085/108] net: ti: icssg-prueth: Add ICSSG ethernet driver
+Subject: [PATCH 085/116] net: ti: icssg-prueth: Add ICSSG ethernet driver
 
 This is the Ethernet driver for TI SoCs with the
 ICSSG PRU Sub-system running dual-EMAC firmware.
@@ -4497,5 +4497,5 @@ index 5fdd6f03446d..2a034c08b4c2 100644
  /*
   * enum pruss_gp_mux_sel - PRUSS GPI/O Mux modes for the
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0086-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0086-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
@@ -1,7 +1,7 @@
-From cb46d473ac77fd784533d250439b3031443d880d Mon Sep 17 00:00:00 2001
+From 233ec86faf1c7191897cd1334af1d939656c1892 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:24 +0300
-Subject: [PATCH 086/108] net: ethernet: ti: icssg_prueth: add 10M full duplex
+Subject: [PATCH 086/116] net: ethernet: ti: icssg_prueth: add 10M full duplex
  support
 
 For 10M support RGMII need to be configured in inband mode and FW has to be
@@ -250,5 +250,5 @@ index bf52d350bdd0..644a22b53424 100644
  #define TAS_GATE_MASK_LIST0                                0x0100
  /*TAS gate mask for windows list1*/
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
@@ -1,7 +1,7 @@
-From c44e8f2008b5322be5029b2612ab34908a3d3b4a Mon Sep 17 00:00:00 2001
+From b8578a2a208ddb70f159a59ece6fb0c8c9e674e1 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:25 +0300
-Subject: [PATCH 087/108] net: ethernet: ti: icssg_prueth: Use DMA device for
+Subject: [PATCH 087/116] net: ethernet: ti: icssg_prueth: Use DMA device for
  DMA API
 
 For DMA API the DMA device should be used as cpsw does not accesses to
@@ -342,5 +342,5 @@ index 69c558eb004d..2e8d45c8c25d 100644
  	struct k3_udma_glue_rx_channel *rx_chn;
  	u32 descs_num;
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
@@ -1,7 +1,7 @@
-From ed1ed64acbc39e9596cd25405e716911588eebbb Mon Sep 17 00:00:00 2001
+From caa778642db76df295ee110120b510cdefadc7f5 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:26 +0300
-Subject: [PATCH 088/108] net: ethernet: ti: icss_iep: add icss_iep_get_idx()
+Subject: [PATCH 088/116] net: ethernet: ti: icss_iep: add icss_iep_get_idx()
  api
 
 Add icss_iep_get_idx() API to allow retrieve IEP from phandle list in DT.
@@ -59,5 +59,5 @@ index a41e18df666e..eefc8c8bd8cc 100644
  int icss_iep_init(struct icss_iep *iep, const struct icss_iep_clockops *clkops,
  		  void *clockops_data, u32 cycle_time_ns);
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
@@ -1,7 +1,7 @@
-From d5146fd40535c28e075c933c42e68484e38aee3a Mon Sep 17 00:00:00 2001
+From 184b7ebaca759e9dcf3f3d062c1ea25e5625dbf2 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:27 +0300
-Subject: [PATCH 089/108] net: ethernet: ti: icss_iep: use readl() in
+Subject: [PATCH 089/116] net: ethernet: ti: icss_iep: use readl() in
  icss_iep_get_count_low/hi()
 
 Use readl() in icss_iep_get_count_low/hi() to speed up hot path.
@@ -35,5 +35,5 @@ index 51f8717fc446..23e72e0ffe46 100644
  	return val;
  }
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
@@ -1,7 +1,7 @@
-From 046a4bba2c24cf757d3845ab1123d3441b9e1c95 Mon Sep 17 00:00:00 2001
+From 196ccfc7a0cc6e7c29e3f21ec6adbc3897ac49ff Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:28 +0300
-Subject: [PATCH 090/108] net: ethernet: ti: icss_iep: fix init for sr2.0
+Subject: [PATCH 090/116] net: ethernet: ti: icss_iep: fix init for sr2.0
 
 There are two issues with IEP initialization for ICSSG SR2.0 where only one
 IEP0 is used in shadow mode:
@@ -147,5 +147,5 @@ index 23e72e0ffe46..eec7e9fb1f61 100644
  	dev_set_drvdata(dev, iep);
  	icss_iep_disable(iep);
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
@@ -1,7 +1,7 @@
-From c6ae141f0a17489d92b6317ebe2c432321fd627e Mon Sep 17 00:00:00 2001
+From f94d3159e92321db554d35aa27da77b8779673ff Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:29 +0300
-Subject: [PATCH 091/108] net: ethernet: ti: icss_iep: sr2.0 fix NULL pointer
+Subject: [PATCH 091/116] net: ethernet: ti: icss_iep: sr2.0 fix NULL pointer
  exception on pps stop
 
 The NULL pointer exception is observed on pps stop - fix it as timer is not
@@ -38,5 +38,5 @@ index eec7e9fb1f61..0ed54c8251e2 100644
  	}
  
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0092-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0092-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
@@ -1,7 +1,7 @@
-From a07febdefcc4bef55cf2350a1d34df6ecab7024a Mon Sep 17 00:00:00 2001
+From a142c398d05803280f37ed78fabef57cf4b52673 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:30 +0300
-Subject: [PATCH 092/108] net: ti: ethernet: icssg-prueth: add packet
+Subject: [PATCH 092/116] net: ti: ethernet: icssg-prueth: add packet
  timestamping and ptp support
 
 Add packet timestamping TS and PTP PHC clock support.
@@ -856,5 +856,5 @@ index 2e8d45c8c25d..156716bf0a76 100644
  
  struct emac_tx_ts_response_sr1 {
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0093-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0093-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
@@ -1,7 +1,7 @@
-From 304bcc5a69a4fe5cd54b482cde15a5b5b19a7d6f Mon Sep 17 00:00:00 2001
+From 7fe19921deaedc3c69190b10d759371d186d2262 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:33 +0300
-Subject: [PATCH 093/108] net: ethernet: ti: icssg_prueth: add am64x icssg
+Subject: [PATCH 093/116] net: ethernet: ti: icssg_prueth: add am64x icssg
  support
 
 Add AM64x ICSSG support which is similar to am65x SR2.0, but required:
@@ -120,5 +120,5 @@ index 156716bf0a76..b536ac5ec0bf 100644
  
  struct emac_tx_ts_response_sr1 {
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
@@ -1,7 +1,7 @@
-From 1e036d3d7931ef6092a14ac9962570c60afc07de Mon Sep 17 00:00:00 2001
+From 8c9d57c440a9f84e0487d65e203a01c67191e2ca Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 19 May 2021 19:31:36 +0300
-Subject: [PATCH 094/108] net: ethernet: ti: icssg_prueth: am65x SR2.0 add 10M
+Subject: [PATCH 094/116] net: ethernet: ti: icssg_prueth: am65x SR2.0 add 10M
  full duplex support
 
 For for AM65x SR2.0 it's required to enable IEP1 in raw 64bit mode which is
@@ -158,5 +158,5 @@ index b536ac5ec0bf..7cc81c67bf72 100644
  
  /**
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0095-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0095-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
@@ -1,7 +1,7 @@
-From 540c8c0dc7dad58e5d055ca2459c8714a127fa3f Mon Sep 17 00:00:00 2001
+From 18ea22e5f2a76dcfc855d90a6df97360abf697aa Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Mon, 21 Jun 2021 15:47:49 +0530
-Subject: [PATCH 095/108] net: ti: icssg_prueth: Free desc pool before DMA
+Subject: [PATCH 095/116] net: ti: icssg_prueth: Free desc pool before DMA
  channel release
 
 Release DMA desc pool associated with channel before releasing the
@@ -48,5 +48,5 @@ index ef7392a2b9da..38d151dca81c 100644
  		 * end after all channel resources are freed
  		 */
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0096-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0096-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
@@ -1,7 +1,7 @@
-From 63e98d1c6947b6df572029635d97b63282424860 Mon Sep 17 00:00:00 2001
+From 44aa753795d955a085bd83d59c3595e963b3f9c8 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:47 +0300
-Subject: [PATCH 096/108] net: ethernet: icssg-prueth: fix rgmii tx delay
+Subject: [PATCH 096/116] net: ethernet: icssg-prueth: fix rgmii tx delay
  configuration
 
 The driver enables RGMII TX delay without checking specified
@@ -125,5 +125,5 @@ index 38d151dca81c..d19a05fd8b06 100644
  		if (ret)
  			goto put_cores;
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
@@ -1,7 +1,7 @@
-From 82df348f6574b1bf31755c5d47bd517e30e32616 Mon Sep 17 00:00:00 2001
+From 145877b43639748cd3a602da51bce2e1f035c406 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:48 +0300
-Subject: [PATCH 097/108] net: ethernet: icssg-prueth: enable "fixed-link"
+Subject: [PATCH 097/116] net: ethernet: icssg-prueth: enable "fixed-link"
  connection
 
 The ICSSG has incomplete and incorrect "fixed-link" connection type
@@ -71,5 +71,5 @@ index d19a05fd8b06..3b1769a5e2b3 100644
  		ret = -EPROBE_DEFER;
  		goto free;
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
@@ -1,7 +1,7 @@
-From 632a2965405aeeef80f9329674d3da1e42ef0dce Mon Sep 17 00:00:00 2001
+From 7ead1b6daf15fa16a618dff1d6e2b11003aa8843 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:12 +0300
-Subject: [PATCH 098/108] net: ethernet: icssg-prueth: fix bug 'scheduling
+Subject: [PATCH 098/116] net: ethernet: icssg-prueth: fix bug 'scheduling
  while atomic' from emac_ndo_set_rx_mode()
 
 The .ndo_set_rx_mode() is called with BH disabled and should be atomic, but
@@ -133,5 +133,5 @@ index 7cc81c67bf72..59dec45a3c86 100644
  	struct pruss_mem_region dram;
  };
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
@@ -1,7 +1,7 @@
-From 1f1fd94179bf92f94cd33d95d010d540274afe2f Mon Sep 17 00:00:00 2001
+From 36f246396aa2d44d4d96e7316bb8e5aac99d616f Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:13 +0300
-Subject: [PATCH 099/108] net: ethernet: icssg-prueth: fix enabling/disabling
+Subject: [PATCH 099/116] net: ethernet: icssg-prueth: fix enabling/disabling
  port in emac_adjust_link()
 
 The port state is set to FORWARD in emac_ndo_open() and never changed, but
@@ -59,5 +59,5 @@ index f212e5904afc..abd062bedebb 100644
  
  reset_tx_chan:
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0100-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0100-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
@@ -1,7 +1,7 @@
-From fc6c08ff8e9fb393f701e75e6f1dc9df5205ff89 Mon Sep 17 00:00:00 2001
+From 69a0c275b5a148d857f8748934aaf4f8b9c72ddd Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 27 Jun 2020 10:53:13 +0200
-Subject: [PATCH 100/108] arm64: dts: ti: iot2050: Add icssg-prueth nodes for
+Subject: [PATCH 100/116] arm64: dts: ti: iot2050: Add icssg-prueth nodes for
  PG1 and PG2 devices
 
 Add the required nodes to enable ICSSG SR1.0 and SR2.0 based prueth
@@ -206,5 +206,5 @@ index 65da226847f4..2faefccca7a9 100644
  
  &icssg1_mdio {
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0101-HACK-setting-the-RJ45-port-led-behavior.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0101-HACK-setting-the-RJ45-port-led-behavior.patch
@@ -1,7 +1,7 @@
-From e825c604a126b7e21a0f4adcebb617405165d685 Mon Sep 17 00:00:00 2001
+From 7803d41538b257887078d392fec539eeda638ead Mon Sep 17 00:00:00 2001
 From: zengchao <chao.zeng@siemens.com>
 Date: Wed, 6 Nov 2019 11:21:49 +0800
-Subject: [PATCH 101/108] HACK: setting the RJ45 port led behavior
+Subject: [PATCH 101/116] HACK: setting the RJ45 port led behavior
 
 Temporary needed until we have a proper, likely LED-class based
 solution upstream.
@@ -37,5 +37,5 @@ index c716074fdef0..9ee2375782b3 100644
  }
  
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0102-WIP-feat-extend-led-panic-indicator-on-and-off.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0102-WIP-feat-extend-led-panic-indicator-on-and-off.patch
@@ -1,7 +1,7 @@
-From ee5c75290c1c70b08aaeff97be7d145b2d9407ae Mon Sep 17 00:00:00 2001
+From 07eb0c0db6e68355b7afb9d5bc743d77f8e667e4 Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Tue, 22 Dec 2020 15:05:56 +0800
-Subject: [PATCH 102/108] WIP: feat:extend led panic-indicator on and off
+Subject: [PATCH 102/116] WIP: feat:extend led panic-indicator on and off
 
 WIP because upstream strategy is still under discussion.
 
@@ -124,5 +124,5 @@ index 6a8d6409c993..d84423d42f89 100644
  	int 		num_leds;
  	const struct gpio_led *leds;
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0103-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0103-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
@@ -1,7 +1,7 @@
-From ebbcf7cbf62b98b79b395b9cccee5a341e68a32e Mon Sep 17 00:00:00 2001
+From 20606211f83ef718e31c8c671c3b332764f98147 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Mar 2021 15:28:21 +0100
-Subject: [PATCH 103/108] WIP: arm64: dts: ti: iot2050: Add node for generic
+Subject: [PATCH 103/116] WIP: arm64: dts: ti: iot2050: Add node for generic
  spidev
 
 This allows to use mcu_spi0 via userspace spidev.
@@ -33,5 +33,5 @@ index 2faefccca7a9..3510948e9d41 100644
  
  &tscadc0 {
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0104-watchdog-rti-wdt-Provide-set_timeout-handler-to-make.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0104-watchdog-rti-wdt-Provide-set_timeout-handler-to-make.patch
@@ -1,7 +1,7 @@
-From cda1d3e1224b3f12c20737e5054d53d72b844cc8 Mon Sep 17 00:00:00 2001
+From 4cdc7709ed27c977d6e20f806e155b522a240b4f Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 13 Sep 2021 12:27:17 +0200
-Subject: [PATCH 104/108] watchdog: rti-wdt: Provide set_timeout handler to
+Subject: [PATCH 104/116] watchdog: rti-wdt: Provide set_timeout handler to
  make existing userspace happy
 
 Prominent userspace - systemd - cannot handle watchdogs without
@@ -57,5 +57,5 @@ index 359302f71f7e..365255b15a0d 100644
  };
  
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0105-dt-bindings-net-ti-icssg-prueth-Add-documentation-fo.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0105-dt-bindings-net-ti-icssg-prueth-Add-documentation-fo.patch
@@ -1,7 +1,7 @@
-From 8d0a6581d8f1b9bed1636228155497eba2526be4 Mon Sep 17 00:00:00 2001
+From cfde63d4e0422f9771be393c0b3b3f5268c77f48 Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Tue, 12 Oct 2021 13:54:41 +0300
-Subject: [PATCH 105/108] dt-bindings: net: ti, icssg-prueth: Add documentation
+Subject: [PATCH 105/116] dt-bindings: net: ti, icssg-prueth: Add documentation
  for half duplex
 
 In order to support half-duplex operation at 10M and 100M link speeds, the
@@ -37,5 +37,5 @@ index 125a204ef2d2..41cba6907fc9 100644
  Example (k3-am654 base board SR2.0, dual-emac):
  ==============================================
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0106-net-ethernet-icssg-prueth-sr1.0-add-support-for-half.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0106-net-ethernet-icssg-prueth-sr1.0-add-support-for-half.patch
@@ -1,7 +1,7 @@
-From fa676b2e76b11b891e7221ce9c305848f47f944e Mon Sep 17 00:00:00 2001
+From e085a3bd27b1660e6952be40d617fe779fddb8f1 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 12 Oct 2021 13:54:42 +0300
-Subject: [PATCH 106/108] net: ethernet: icssg-prueth: sr1.0: add support for
+Subject: [PATCH 106/116] net: ethernet: icssg-prueth: sr1.0: add support for
  half duplex operation
 
 This patch adds support for half duplex operation at 10M and 100M link
@@ -103,5 +103,5 @@ index 59dec45a3c86..917c6f9a2514 100644
  	/* DMA related */
  	struct prueth_tx_chn tx_chns[PRUETH_MAX_TX_QUEUES];
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0107-net-ethernet-icssg-prueth-sr2.0-add-support-for-half.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0107-net-ethernet-icssg-prueth-sr2.0-add-support-for-half.patch
@@ -1,7 +1,7 @@
-From 6d107ffc9d8951048d716f9d5b2d4d5eb482100e Mon Sep 17 00:00:00 2001
+From 453f34a8c848f3060339bf1edb00c35680bd04df Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 12 Oct 2021 13:54:43 +0300
-Subject: [PATCH 107/108] net: ethernet: icssg-prueth: sr2.0: add support for
+Subject: [PATCH 107/116] net: ethernet: icssg-prueth: sr2.0: add support for
  half duplex operation
 
 This patch adds support for half duplex operation at 10M and 100M link
@@ -135,5 +135,5 @@ index 644a22b53424..99225d0f1582 100644
  /* Memory Usage of : DMEM1
   *
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0108-arm64-dts-ti-add-the-support-for-the-half-duplex.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0108-arm64-dts-ti-add-the-support-for-the-half-duplex.patch
@@ -1,7 +1,7 @@
-From fbd9b2830a7d7c69bf8c4d4a67c7c63a40d72b3a Mon Sep 17 00:00:00 2001
+From 7839f5faa70144f7f3ee3c72abed1f1a0c3ea796 Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Fri, 22 Oct 2021 13:37:22 +0800
-Subject: [PATCH 108/108] arm64: dts: ti: add the support for the half-duplex
+Subject: [PATCH 108/116] arm64: dts: ti: add the support for the half-duplex
 
 origin from TI and add the dts property to support the half-duplex for ethernet port
 
@@ -31,5 +31,5 @@ index 3510948e9d41..34a4bcec204a 100644
  			local-mac-address = [00 00 00 00 00 00];
  		};
 -- 
-2.32.0
+2.33.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0109-USB-serial-cp210x-return-early-on-unchanged-termios.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0109-USB-serial-cp210x-return-early-on-unchanged-termios.patch
@@ -1,0 +1,50 @@
+From a5d1fe3ede8bd9484c48855ee3a8f09343601011 Mon Sep 17 00:00:00 2001
+From: Johan Hovold <johan@kernel.org>
+Date: Mon, 16 Nov 2020 17:18:21 +0100
+Subject: [PATCH 109/116] USB: serial: cp210x: return early on unchanged
+ termios
+
+Return early from set_termios() in case no relevant terminal settings
+have changed.
+
+This avoids testing each parameter in turn and specifically allows the
+line-control handling to be cleaned up further.
+
+Signed-off-by: Johan Hovold <johan@kernel.org>
+---
+ drivers/usb/serial/cp210x.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/drivers/usb/serial/cp210x.c b/drivers/usb/serial/cp210x.c
+index 329fc25f78a4..a9f732c563c8 100644
+--- a/drivers/usb/serial/cp210x.c
++++ b/drivers/usb/serial/cp210x.c
+@@ -1364,6 +1364,15 @@ static void cp210x_disable_event_mode(struct usb_serial_port *port)
+ 	port_priv->event_mode = false;
+ }
+ 
++static bool cp210x_termios_change(const struct ktermios *a, const struct ktermios *b)
++{
++	bool iflag_change;
++
++	iflag_change = ((a->c_iflag ^ b->c_iflag) & INPCK);
++
++	return tty_termios_hw_change(a, b) || iflag_change;
++}
++
+ static void cp210x_set_termios(struct tty_struct *tty,
+ 		struct usb_serial_port *port, struct ktermios *old_termios)
+ {
+@@ -1371,6 +1380,9 @@ static void cp210x_set_termios(struct tty_struct *tty,
+ 	unsigned int cflag, old_cflag;
+ 	u16 bits;
+ 
++	if (!cp210x_termios_change(&tty->termios, old_termios))
++		return;
++
+ 	cflag = tty->termios.c_cflag;
+ 	old_cflag = old_termios->c_cflag;
+ 
+-- 
+2.33.1
+

--- a/recipes-kernel/linux/files/patches-5.10/0110-USB-serial-cp210x-clean-up-line-control-handling.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0110-USB-serial-cp210x-clean-up-line-control-handling.patch
@@ -1,0 +1,155 @@
+From b1bd79da6ea2aa3010cc2f5493d143959033f758 Mon Sep 17 00:00:00 2001
+From: Johan Hovold <johan@kernel.org>
+Date: Mon, 16 Nov 2020 17:18:22 +0100
+Subject: [PATCH 110/116] USB: serial: cp210x: clean up line-control handling
+
+Update the line-control settings in one request unconditionally instead
+of setting the word-length, parity and stop-bit settings separately.
+
+This avoids multiple requests when several settings are changed even if
+this scheme could potentially also be used to detect unsupported device
+settings. Since all device types but CP2101 appears to support all
+settings, let's handle that one specifically and also report back the
+unsupported settings properly through termios by clearing the
+corresponding bits.
+
+Also drop the related unnecessary debug printks.
+
+Signed-off-by: Johan Hovold <johan@kernel.org>
+---
+ drivers/usb/serial/cp210x.c | 101 +++++++++++++++---------------------
+ 1 file changed, 41 insertions(+), 60 deletions(-)
+
+diff --git a/drivers/usb/serial/cp210x.c b/drivers/usb/serial/cp210x.c
+index a9f732c563c8..7a7078de4b5c 100644
+--- a/drivers/usb/serial/cp210x.c
++++ b/drivers/usb/serial/cp210x.c
+@@ -1376,9 +1376,11 @@ static bool cp210x_termios_change(const struct ktermios *a, const struct ktermio
+ static void cp210x_set_termios(struct tty_struct *tty,
+ 		struct usb_serial_port *port, struct ktermios *old_termios)
+ {
++	struct cp210x_serial_private *priv = usb_get_serial_data(port->serial);
+ 	struct device *dev = &port->dev;
+ 	unsigned int cflag, old_cflag;
+ 	u16 bits;
++	int ret;
+ 
+ 	if (!cp210x_termios_change(&tty->termios, old_termios))
+ 		return;
+@@ -1389,74 +1391,53 @@ static void cp210x_set_termios(struct tty_struct *tty,
+ 	if (tty->termios.c_ospeed != old_termios->c_ospeed)
+ 		cp210x_change_speed(tty, port, old_termios);
+ 
+-	/* If the number of data bits is to be updated */
+-	if ((cflag & CSIZE) != (old_cflag & CSIZE)) {
+-		cp210x_get_line_ctl(port, &bits);
+-		bits &= ~BITS_DATA_MASK;
+-		switch (cflag & CSIZE) {
+-		case CS5:
+-			bits |= BITS_DATA_5;
+-			dev_dbg(dev, "%s - data bits = 5\n", __func__);
+-			break;
+-		case CS6:
+-			bits |= BITS_DATA_6;
+-			dev_dbg(dev, "%s - data bits = 6\n", __func__);
+-			break;
+-		case CS7:
+-			bits |= BITS_DATA_7;
+-			dev_dbg(dev, "%s - data bits = 7\n", __func__);
+-			break;
+-		case CS8:
+-		default:
+-			bits |= BITS_DATA_8;
+-			dev_dbg(dev, "%s - data bits = 8\n", __func__);
+-			break;
+-		}
+-		if (cp210x_write_u16_reg(port, CP210X_SET_LINE_CTL, bits))
+-			dev_dbg(dev, "Number of data bits requested not supported by device\n");
++	/* CP2101 only supports CS8, 1 stop bit and non-stick parity. */
++	if (priv->partnum == CP210X_PARTNUM_CP2101) {
++		tty->termios.c_cflag &= ~(CSIZE | CSTOPB | CMSPAR);
++		tty->termios.c_cflag |= CS8;
+ 	}
+ 
+-	if ((cflag     & (PARENB|PARODD|CMSPAR)) !=
+-	    (old_cflag & (PARENB|PARODD|CMSPAR))) {
+-		cp210x_get_line_ctl(port, &bits);
+-		bits &= ~BITS_PARITY_MASK;
+-		if (cflag & PARENB) {
+-			if (cflag & CMSPAR) {
+-				if (cflag & PARODD) {
+-					bits |= BITS_PARITY_MARK;
+-					dev_dbg(dev, "%s - parity = MARK\n", __func__);
+-				} else {
+-					bits |= BITS_PARITY_SPACE;
+-					dev_dbg(dev, "%s - parity = SPACE\n", __func__);
+-				}
+-			} else {
+-				if (cflag & PARODD) {
+-					bits |= BITS_PARITY_ODD;
+-					dev_dbg(dev, "%s - parity = ODD\n", __func__);
+-				} else {
+-					bits |= BITS_PARITY_EVEN;
+-					dev_dbg(dev, "%s - parity = EVEN\n", __func__);
+-				}
+-			}
+-		}
+-		if (cp210x_write_u16_reg(port, CP210X_SET_LINE_CTL, bits))
+-			dev_dbg(dev, "Parity mode not supported by device\n");
++	bits = 0;
++
++	switch (C_CSIZE(tty)) {
++	case CS5:
++		bits |= BITS_DATA_5;
++		break;
++	case CS6:
++		bits |= BITS_DATA_6;
++		break;
++	case CS7:
++		bits |= BITS_DATA_7;
++		break;
++	case CS8:
++	default:
++		bits |= BITS_DATA_8;
++		break;
+ 	}
+ 
+-	if ((cflag & CSTOPB) != (old_cflag & CSTOPB)) {
+-		cp210x_get_line_ctl(port, &bits);
+-		bits &= ~BITS_STOP_MASK;
+-		if (cflag & CSTOPB) {
+-			bits |= BITS_STOP_2;
+-			dev_dbg(dev, "%s - stop bits = 2\n", __func__);
++	if (C_PARENB(tty)) {
++		if (C_CMSPAR(tty)) {
++			if (C_PARODD(tty))
++				bits |= BITS_PARITY_MARK;
++			else
++				bits |= BITS_PARITY_SPACE;
+ 		} else {
+-			bits |= BITS_STOP_1;
+-			dev_dbg(dev, "%s - stop bits = 1\n", __func__);
++			if (C_PARODD(tty))
++				bits |= BITS_PARITY_ODD;
++			else
++				bits |= BITS_PARITY_EVEN;
+ 		}
+-		if (cp210x_write_u16_reg(port, CP210X_SET_LINE_CTL, bits))
+-			dev_dbg(dev, "Number of stop bits requested not supported by device\n");
+ 	}
+ 
++	if (C_CSTOPB(tty))
++		bits |= BITS_STOP_2;
++	else
++		bits |= BITS_STOP_1;
++
++	ret = cp210x_write_u16_reg(port, CP210X_SET_LINE_CTL, bits);
++	if (ret)
++		dev_err(&port->dev, "failed to set line control: %d\n", ret);
++
+ 	if ((cflag & CRTSCTS) != (old_cflag & CRTSCTS)) {
+ 		struct cp210x_flow_ctl flow_ctl;
+ 		u32 ctl_hs;
+-- 
+2.33.1
+

--- a/recipes-kernel/linux/files/patches-5.10/0111-USB-serial-cp210x-set-terminal-settings-on-open.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0111-USB-serial-cp210x-set-terminal-settings-on-open.patch
@@ -1,0 +1,402 @@
+From 8355d93cbeead07911012dde4c4fe7e6e0e1fd5c Mon Sep 17 00:00:00 2001
+From: Johan Hovold <johan@kernel.org>
+Date: Mon, 16 Nov 2020 17:18:23 +0100
+Subject: [PATCH 111/116] USB: serial: cp210x: set terminal settings on open
+
+Unlike other drivers cp210x have been retrieving the current terminal
+settings from the device on open and reflecting those in termios.
+
+Due to how set_termios() used to be implemented, this saved a few
+control requests on open but has instead caused problems like broken
+flow control and has required adding workarounds for swapped
+line-control in cp2108 and line-speed initialisation on cp2104.
+
+This unusual implementation also complicates adding new features for no
+good reason.
+
+Rip out the corresponding code and the above mentioned workarounds and
+instead initialise the terminal settings unconditionally on open.
+
+Signed-off-by: Johan Hovold <johan@kernel.org>
+---
+ drivers/usb/serial/cp210x.c | 289 +-----------------------------------
+ 1 file changed, 6 insertions(+), 283 deletions(-)
+
+diff --git a/drivers/usb/serial/cp210x.c b/drivers/usb/serial/cp210x.c
+index 7a7078de4b5c..b0543b2b7423 100644
+--- a/drivers/usb/serial/cp210x.c
++++ b/drivers/usb/serial/cp210x.c
+@@ -31,9 +31,6 @@
+  */
+ static int cp210x_open(struct tty_struct *tty, struct usb_serial_port *);
+ static void cp210x_close(struct usb_serial_port *);
+-static void cp210x_get_termios(struct tty_struct *, struct usb_serial_port *);
+-static void cp210x_get_termios_port(struct usb_serial_port *port,
+-	tcflag_t *cflagp, unsigned int *baudp);
+ static void cp210x_change_speed(struct tty_struct *, struct usb_serial_port *,
+ 							struct ktermios *);
+ static void cp210x_set_termios(struct tty_struct *, struct usb_serial_port *,
+@@ -273,7 +270,6 @@ enum cp210x_event_state {
+ 
+ struct cp210x_port_private {
+ 	u8			bInterfaceNumber;
+-	bool			has_swapped_line_ctl;
+ 	bool			event_mode;
+ 	enum cp210x_event_state event_state;
+ 	u8 lsr;
+@@ -605,46 +601,6 @@ static int cp210x_read_reg_block(struct usb_serial_port *port, u8 req,
+ 	return result;
+ }
+ 
+-/*
+- * Reads any 32-bit CP210X_ register identified by req.
+- */
+-static int cp210x_read_u32_reg(struct usb_serial_port *port, u8 req, u32 *val)
+-{
+-	__le32 le32_val;
+-	int err;
+-
+-	err = cp210x_read_reg_block(port, req, &le32_val, sizeof(le32_val));
+-	if (err) {
+-		/*
+-		 * FIXME Some callers don't bother to check for error,
+-		 * at least give them consistent junk until they are fixed
+-		 */
+-		*val = 0;
+-		return err;
+-	}
+-
+-	*val = le32_to_cpu(le32_val);
+-
+-	return 0;
+-}
+-
+-/*
+- * Reads any 16-bit CP210X_ register identified by req.
+- */
+-static int cp210x_read_u16_reg(struct usb_serial_port *port, u8 req, u16 *val)
+-{
+-	__le16 le16_val;
+-	int err;
+-
+-	err = cp210x_read_reg_block(port, req, &le16_val, sizeof(le16_val));
+-	if (err)
+-		return err;
+-
+-	*val = le16_to_cpu(le16_val);
+-
+-	return 0;
+-}
+-
+ /*
+  * Reads any 8-bit CP210X_ register identified by req.
+  */
+@@ -792,59 +748,6 @@ static int cp210x_write_vendor_block(struct usb_serial *serial, u8 type,
+ }
+ #endif
+ 
+-/*
+- * Detect CP2108 GET_LINE_CTL bug and activate workaround.
+- * Write a known good value 0x800, read it back.
+- * If it comes back swapped the bug is detected.
+- * Preserve the original register value.
+- */
+-static int cp210x_detect_swapped_line_ctl(struct usb_serial_port *port)
+-{
+-	struct cp210x_port_private *port_priv = usb_get_serial_port_data(port);
+-	u16 line_ctl_save;
+-	u16 line_ctl_test;
+-	int err;
+-
+-	err = cp210x_read_u16_reg(port, CP210X_GET_LINE_CTL, &line_ctl_save);
+-	if (err)
+-		return err;
+-
+-	err = cp210x_write_u16_reg(port, CP210X_SET_LINE_CTL, 0x800);
+-	if (err)
+-		return err;
+-
+-	err = cp210x_read_u16_reg(port, CP210X_GET_LINE_CTL, &line_ctl_test);
+-	if (err)
+-		return err;
+-
+-	if (line_ctl_test == 8) {
+-		port_priv->has_swapped_line_ctl = true;
+-		line_ctl_save = swab16(line_ctl_save);
+-	}
+-
+-	return cp210x_write_u16_reg(port, CP210X_SET_LINE_CTL, line_ctl_save);
+-}
+-
+-/*
+- * Must always be called instead of cp210x_read_u16_reg(CP210X_GET_LINE_CTL)
+- * to workaround cp2108 bug and get correct value.
+- */
+-static int cp210x_get_line_ctl(struct usb_serial_port *port, u16 *ctl)
+-{
+-	struct cp210x_port_private *port_priv = usb_get_serial_port_data(port);
+-	int err;
+-
+-	err = cp210x_read_u16_reg(port, CP210X_GET_LINE_CTL, ctl);
+-	if (err)
+-		return err;
+-
+-	/* Workaround swapped bytes in 16-bit value from CP210X_GET_LINE_CTL */
+-	if (port_priv->has_swapped_line_ctl)
+-		*ctl = swab16(*ctl);
+-
+-	return 0;
+-}
+-
+ static int cp210x_open(struct tty_struct *tty, struct usb_serial_port *port)
+ {
+ 	struct cp210x_port_private *port_priv = usb_get_serial_port_data(port);
+@@ -856,16 +759,8 @@ static int cp210x_open(struct tty_struct *tty, struct usb_serial_port *port)
+ 		return result;
+ 	}
+ 
+-	/* Configure the termios structure */
+-	cp210x_get_termios(tty, port);
+-
+-	if (tty) {
+-		/* The baud rate must be initialised on cp2104 */
+-		cp210x_change_speed(tty, port, NULL);
+-
+-		if (I_INPCK(tty))
+-			cp210x_enable_event_mode(port);
+-	}
++	if (tty)
++		cp210x_set_termios(tty, port, NULL);
+ 
+ 	result = usb_serial_generic_open(tty, port);
+ 	if (result)
+@@ -1044,167 +939,6 @@ static bool cp210x_tx_empty(struct usb_serial_port *port)
+ 	return !count;
+ }
+ 
+-/*
+- * cp210x_get_termios
+- * Reads the baud rate, data bits, parity, stop bits and flow control mode
+- * from the device, corrects any unsupported values, and configures the
+- * termios structure to reflect the state of the device
+- */
+-static void cp210x_get_termios(struct tty_struct *tty,
+-	struct usb_serial_port *port)
+-{
+-	unsigned int baud;
+-
+-	if (tty) {
+-		cp210x_get_termios_port(tty->driver_data,
+-			&tty->termios.c_cflag, &baud);
+-		tty_encode_baud_rate(tty, baud, baud);
+-	} else {
+-		tcflag_t cflag;
+-		cflag = 0;
+-		cp210x_get_termios_port(port, &cflag, &baud);
+-	}
+-}
+-
+-/*
+- * cp210x_get_termios_port
+- * This is the heart of cp210x_get_termios which always uses a &usb_serial_port.
+- */
+-static void cp210x_get_termios_port(struct usb_serial_port *port,
+-	tcflag_t *cflagp, unsigned int *baudp)
+-{
+-	struct device *dev = &port->dev;
+-	tcflag_t cflag;
+-	struct cp210x_flow_ctl flow_ctl;
+-	u32 baud;
+-	u16 bits;
+-	u32 ctl_hs;
+-	u32 flow_repl;
+-
+-	cp210x_read_u32_reg(port, CP210X_GET_BAUDRATE, &baud);
+-
+-	dev_dbg(dev, "%s - baud rate = %d\n", __func__, baud);
+-	*baudp = baud;
+-
+-	cflag = *cflagp;
+-
+-	cp210x_get_line_ctl(port, &bits);
+-	cflag &= ~CSIZE;
+-	switch (bits & BITS_DATA_MASK) {
+-	case BITS_DATA_5:
+-		dev_dbg(dev, "%s - data bits = 5\n", __func__);
+-		cflag |= CS5;
+-		break;
+-	case BITS_DATA_6:
+-		dev_dbg(dev, "%s - data bits = 6\n", __func__);
+-		cflag |= CS6;
+-		break;
+-	case BITS_DATA_7:
+-		dev_dbg(dev, "%s - data bits = 7\n", __func__);
+-		cflag |= CS7;
+-		break;
+-	case BITS_DATA_8:
+-		dev_dbg(dev, "%s - data bits = 8\n", __func__);
+-		cflag |= CS8;
+-		break;
+-	case BITS_DATA_9:
+-		dev_dbg(dev, "%s - data bits = 9 (not supported, using 8 data bits)\n", __func__);
+-		cflag |= CS8;
+-		bits &= ~BITS_DATA_MASK;
+-		bits |= BITS_DATA_8;
+-		cp210x_write_u16_reg(port, CP210X_SET_LINE_CTL, bits);
+-		break;
+-	default:
+-		dev_dbg(dev, "%s - Unknown number of data bits, using 8\n", __func__);
+-		cflag |= CS8;
+-		bits &= ~BITS_DATA_MASK;
+-		bits |= BITS_DATA_8;
+-		cp210x_write_u16_reg(port, CP210X_SET_LINE_CTL, bits);
+-		break;
+-	}
+-
+-	switch (bits & BITS_PARITY_MASK) {
+-	case BITS_PARITY_NONE:
+-		dev_dbg(dev, "%s - parity = NONE\n", __func__);
+-		cflag &= ~PARENB;
+-		break;
+-	case BITS_PARITY_ODD:
+-		dev_dbg(dev, "%s - parity = ODD\n", __func__);
+-		cflag |= (PARENB|PARODD);
+-		break;
+-	case BITS_PARITY_EVEN:
+-		dev_dbg(dev, "%s - parity = EVEN\n", __func__);
+-		cflag &= ~PARODD;
+-		cflag |= PARENB;
+-		break;
+-	case BITS_PARITY_MARK:
+-		dev_dbg(dev, "%s - parity = MARK\n", __func__);
+-		cflag |= (PARENB|PARODD|CMSPAR);
+-		break;
+-	case BITS_PARITY_SPACE:
+-		dev_dbg(dev, "%s - parity = SPACE\n", __func__);
+-		cflag &= ~PARODD;
+-		cflag |= (PARENB|CMSPAR);
+-		break;
+-	default:
+-		dev_dbg(dev, "%s - Unknown parity mode, disabling parity\n", __func__);
+-		cflag &= ~PARENB;
+-		bits &= ~BITS_PARITY_MASK;
+-		cp210x_write_u16_reg(port, CP210X_SET_LINE_CTL, bits);
+-		break;
+-	}
+-
+-	cflag &= ~CSTOPB;
+-	switch (bits & BITS_STOP_MASK) {
+-	case BITS_STOP_1:
+-		dev_dbg(dev, "%s - stop bits = 1\n", __func__);
+-		break;
+-	case BITS_STOP_1_5:
+-		dev_dbg(dev, "%s - stop bits = 1.5 (not supported, using 1 stop bit)\n", __func__);
+-		bits &= ~BITS_STOP_MASK;
+-		cp210x_write_u16_reg(port, CP210X_SET_LINE_CTL, bits);
+-		break;
+-	case BITS_STOP_2:
+-		dev_dbg(dev, "%s - stop bits = 2\n", __func__);
+-		cflag |= CSTOPB;
+-		break;
+-	default:
+-		dev_dbg(dev, "%s - Unknown number of stop bits, using 1 stop bit\n", __func__);
+-		bits &= ~BITS_STOP_MASK;
+-		cp210x_write_u16_reg(port, CP210X_SET_LINE_CTL, bits);
+-		break;
+-	}
+-
+-	cp210x_read_reg_block(port, CP210X_GET_FLOW, &flow_ctl,
+-			sizeof(flow_ctl));
+-	ctl_hs = le32_to_cpu(flow_ctl.ulControlHandshake);
+-	if (ctl_hs & CP210X_SERIAL_CTS_HANDSHAKE) {
+-		dev_dbg(dev, "%s - flow control = CRTSCTS\n", __func__);
+-		/*
+-		 * When the port is closed, the CP210x hardware disables
+-		 * auto-RTS and RTS is deasserted but it leaves auto-CTS when
+-		 * in hardware flow control mode. When re-opening the port, if
+-		 * auto-CTS is enabled on the cp210x, then auto-RTS must be
+-		 * re-enabled in the driver.
+-		 */
+-		flow_repl = le32_to_cpu(flow_ctl.ulFlowReplace);
+-		flow_repl &= ~CP210X_SERIAL_RTS_MASK;
+-		flow_repl |= CP210X_SERIAL_RTS_SHIFT(CP210X_SERIAL_RTS_FLOW_CTL);
+-		flow_ctl.ulFlowReplace = cpu_to_le32(flow_repl);
+-		cp210x_write_reg_block(port,
+-				CP210X_SET_FLOW,
+-				&flow_ctl,
+-				sizeof(flow_ctl));
+-
+-		cflag |= CRTSCTS;
+-	} else {
+-		dev_dbg(dev, "%s - flow control = NONE\n", __func__);
+-		cflag &= ~CRTSCTS;
+-	}
+-
+-	*cflagp = cflag;
+-}
+-
+ struct cp210x_rate {
+ 	speed_t rate;
+ 	speed_t high;
+@@ -1378,17 +1112,13 @@ static void cp210x_set_termios(struct tty_struct *tty,
+ {
+ 	struct cp210x_serial_private *priv = usb_get_serial_data(port->serial);
+ 	struct device *dev = &port->dev;
+-	unsigned int cflag, old_cflag;
+ 	u16 bits;
+ 	int ret;
+ 
+-	if (!cp210x_termios_change(&tty->termios, old_termios))
++	if (old_termios && !cp210x_termios_change(&tty->termios, old_termios))
+ 		return;
+ 
+-	cflag = tty->termios.c_cflag;
+-	old_cflag = old_termios->c_cflag;
+-
+-	if (tty->termios.c_ospeed != old_termios->c_ospeed)
++	if (!old_termios || tty->termios.c_ospeed != old_termios->c_ospeed)
+ 		cp210x_change_speed(tty, port, old_termios);
+ 
+ 	/* CP2101 only supports CS8, 1 stop bit and non-stick parity. */
+@@ -1438,7 +1168,7 @@ static void cp210x_set_termios(struct tty_struct *tty,
+ 	if (ret)
+ 		dev_err(&port->dev, "failed to set line control: %d\n", ret);
+ 
+-	if ((cflag & CRTSCTS) != (old_cflag & CRTSCTS)) {
++	if (!old_termios || C_CRTSCTS(tty) != (old_termios->c_cflag & CRTSCTS)) {
+ 		struct cp210x_flow_ctl flow_ctl;
+ 		u32 ctl_hs;
+ 		u32 flow_repl;
+@@ -1455,7 +1185,7 @@ static void cp210x_set_termios(struct tty_struct *tty,
+ 		ctl_hs &= ~CP210X_SERIAL_DSR_SENSITIVITY;
+ 		ctl_hs &= ~CP210X_SERIAL_DTR_MASK;
+ 		ctl_hs |= CP210X_SERIAL_DTR_SHIFT(CP210X_SERIAL_DTR_ACTIVE);
+-		if (cflag & CRTSCTS) {
++		if (C_CRTSCTS(tty)) {
+ 			ctl_hs |= CP210X_SERIAL_CTS_HANDSHAKE;
+ 
+ 			flow_repl &= ~CP210X_SERIAL_RTS_MASK;
+@@ -2003,7 +1733,6 @@ static int cp210x_port_probe(struct usb_serial_port *port)
+ {
+ 	struct usb_serial *serial = port->serial;
+ 	struct cp210x_port_private *port_priv;
+-	int ret;
+ 
+ 	port_priv = kzalloc(sizeof(*port_priv), GFP_KERNEL);
+ 	if (!port_priv)
+@@ -2013,12 +1742,6 @@ static int cp210x_port_probe(struct usb_serial_port *port)
+ 
+ 	usb_set_serial_port_data(port, port_priv);
+ 
+-	ret = cp210x_detect_swapped_line_ctl(port);
+-	if (ret) {
+-		kfree(port_priv);
+-		return ret;
+-	}
+-
+ 	return 0;
+ }
+ 
+-- 
+2.33.1
+

--- a/recipes-kernel/linux/files/patches-5.10/0112-USB-serial-cp210x-drop-flow-control-debugging.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0112-USB-serial-cp210x-drop-flow-control-debugging.patch
@@ -1,0 +1,47 @@
+From ff20783b325ba0f4d6201e2ffedf43fe47738b17 Mon Sep 17 00:00:00 2001
+From: Johan Hovold <johan@kernel.org>
+Date: Mon, 16 Nov 2020 17:18:24 +0100
+Subject: [PATCH 112/116] USB: serial: cp210x: drop flow-control debugging
+
+Drop some unnecessary flow-control debugging.
+
+Signed-off-by: Johan Hovold <johan@kernel.org>
+---
+ drivers/usb/serial/cp210x.c | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/drivers/usb/serial/cp210x.c b/drivers/usb/serial/cp210x.c
+index b0543b2b7423..899c854d65d5 100644
+--- a/drivers/usb/serial/cp210x.c
++++ b/drivers/usb/serial/cp210x.c
+@@ -1177,8 +1177,6 @@ static void cp210x_set_termios(struct tty_struct *tty,
+ 				sizeof(flow_ctl));
+ 		ctl_hs = le32_to_cpu(flow_ctl.ulControlHandshake);
+ 		flow_repl = le32_to_cpu(flow_ctl.ulFlowReplace);
+-		dev_dbg(dev, "%s - read ulControlHandshake=0x%08x, ulFlowReplace=0x%08x\n",
+-				__func__, ctl_hs, flow_repl);
+ 
+ 		ctl_hs &= ~CP210X_SERIAL_DSR_HANDSHAKE;
+ 		ctl_hs &= ~CP210X_SERIAL_DCD_HANDSHAKE;
+@@ -1191,17 +1189,15 @@ static void cp210x_set_termios(struct tty_struct *tty,
+ 			flow_repl &= ~CP210X_SERIAL_RTS_MASK;
+ 			flow_repl |= CP210X_SERIAL_RTS_SHIFT(
+ 					CP210X_SERIAL_RTS_FLOW_CTL);
+-			dev_dbg(dev, "%s - flow control = CRTSCTS\n", __func__);
+ 		} else {
+ 			ctl_hs &= ~CP210X_SERIAL_CTS_HANDSHAKE;
+ 
+ 			flow_repl &= ~CP210X_SERIAL_RTS_MASK;
+ 			flow_repl |= CP210X_SERIAL_RTS_SHIFT(
+ 					CP210X_SERIAL_RTS_ACTIVE);
+-			dev_dbg(dev, "%s - flow control = NONE\n", __func__);
+ 		}
+ 
+-		dev_dbg(dev, "%s - write ulControlHandshake=0x%08x, ulFlowReplace=0x%08x\n",
++		dev_dbg(dev, "%s - ulControlHandshake=0x%08x, ulFlowReplace=0x%08x\n",
+ 				__func__, ctl_hs, flow_repl);
+ 		flow_ctl.ulControlHandshake = cpu_to_le32(ctl_hs);
+ 		flow_ctl.ulFlowReplace = cpu_to_le32(flow_repl);
+-- 
+2.33.1
+

--- a/recipes-kernel/linux/files/patches-5.10/0113-USB-serial-cp210x-refactor-flow-control-handling.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0113-USB-serial-cp210x-refactor-flow-control-handling.patch
@@ -1,0 +1,156 @@
+From e48fbc039d4490a7b07ff27034ef261bb332e605 Mon Sep 17 00:00:00 2001
+From: Johan Hovold <johan@kernel.org>
+Date: Mon, 16 Nov 2020 17:18:25 +0100
+Subject: [PATCH 113/116] USB: serial: cp210x: refactor flow-control handling
+
+Add a helper function to be used to configure flow control.
+
+The flow-control code was the last caller that relied on the
+memset-on-failure behaviour of cp210x_read_reg_block(), which we can now
+drop in favour of bailing out on errors when retrieving the flow-control
+settings.
+
+This should also simplify adding support for software flow control.
+
+Signed-off-by: Johan Hovold <johan@kernel.org>
+---
+ drivers/usb/serial/cp210x.c | 97 ++++++++++++++++++-------------------
+ 1 file changed, 47 insertions(+), 50 deletions(-)
+
+diff --git a/drivers/usb/serial/cp210x.c b/drivers/usb/serial/cp210x.c
+index 899c854d65d5..19666329f386 100644
+--- a/drivers/usb/serial/cp210x.c
++++ b/drivers/usb/serial/cp210x.c
+@@ -567,14 +567,8 @@ static int cp210x_read_reg_block(struct usb_serial_port *port, u8 req,
+ 	int result;
+ 
+ 	dmabuf = kmalloc(bufsize, GFP_KERNEL);
+-	if (!dmabuf) {
+-		/*
+-		 * FIXME Some callers don't bother to check for error,
+-		 * at least give them consistent junk until they are fixed
+-		 */
+-		memset(buf, 0, bufsize);
++	if (!dmabuf)
+ 		return -ENOMEM;
+-	}
+ 
+ 	result = usb_control_msg(serial->dev, usb_rcvctrlpipe(serial->dev, 0),
+ 			req, REQTYPE_INTERFACE_TO_HOST, 0,
+@@ -588,12 +582,6 @@ static int cp210x_read_reg_block(struct usb_serial_port *port, u8 req,
+ 				req, bufsize, result);
+ 		if (result >= 0)
+ 			result = -EIO;
+-
+-		/*
+-		 * FIXME Some callers don't bother to check for error,
+-		 * at least give them consistent junk until they are fixed
+-		 */
+-		memset(buf, 0, bufsize);
+ 	}
+ 
+ 	kfree(dmabuf);
+@@ -1107,11 +1095,55 @@ static bool cp210x_termios_change(const struct ktermios *a, const struct ktermio
+ 	return tty_termios_hw_change(a, b) || iflag_change;
+ }
+ 
++static void cp210x_set_flow_control(struct tty_struct *tty,
++		struct usb_serial_port *port, struct ktermios *old_termios)
++{
++	struct cp210x_flow_ctl flow_ctl;
++	u32 flow_repl;
++	u32 ctl_hs;
++	int ret;
++
++	if (old_termios && C_CRTSCTS(tty) == (old_termios->c_cflag & CRTSCTS))
++		return;
++
++	ret = cp210x_read_reg_block(port, CP210X_GET_FLOW, &flow_ctl,
++			sizeof(flow_ctl));
++	if (ret)
++		return;
++
++	ctl_hs = le32_to_cpu(flow_ctl.ulControlHandshake);
++	flow_repl = le32_to_cpu(flow_ctl.ulFlowReplace);
++
++	ctl_hs &= ~CP210X_SERIAL_DSR_HANDSHAKE;
++	ctl_hs &= ~CP210X_SERIAL_DCD_HANDSHAKE;
++	ctl_hs &= ~CP210X_SERIAL_DSR_SENSITIVITY;
++	ctl_hs &= ~CP210X_SERIAL_DTR_MASK;
++	ctl_hs |= CP210X_SERIAL_DTR_SHIFT(CP210X_SERIAL_DTR_ACTIVE);
++
++	if (C_CRTSCTS(tty)) {
++		ctl_hs |= CP210X_SERIAL_CTS_HANDSHAKE;
++		flow_repl &= ~CP210X_SERIAL_RTS_MASK;
++		flow_repl |= CP210X_SERIAL_RTS_SHIFT(CP210X_SERIAL_RTS_FLOW_CTL);
++	} else {
++		ctl_hs &= ~CP210X_SERIAL_CTS_HANDSHAKE;
++		flow_repl &= ~CP210X_SERIAL_RTS_MASK;
++		flow_repl |= CP210X_SERIAL_RTS_SHIFT(CP210X_SERIAL_RTS_ACTIVE);
++	}
++
++	dev_dbg(&port->dev, "%s - ulControlHandshake=0x%08x, ulFlowReplace=0x%08x\n",
++			__func__, ctl_hs, flow_repl);
++
++	flow_ctl.ulControlHandshake = cpu_to_le32(ctl_hs);
++	flow_ctl.ulFlowReplace = cpu_to_le32(flow_repl);
++
++	cp210x_write_reg_block(port, CP210X_SET_FLOW, &flow_ctl,
++			sizeof(flow_ctl));
++}
++
+ static void cp210x_set_termios(struct tty_struct *tty,
+ 		struct usb_serial_port *port, struct ktermios *old_termios)
+ {
+ 	struct cp210x_serial_private *priv = usb_get_serial_data(port->serial);
+-	struct device *dev = &port->dev;
+ 	u16 bits;
+ 	int ret;
+ 
+@@ -1168,42 +1200,7 @@ static void cp210x_set_termios(struct tty_struct *tty,
+ 	if (ret)
+ 		dev_err(&port->dev, "failed to set line control: %d\n", ret);
+ 
+-	if (!old_termios || C_CRTSCTS(tty) != (old_termios->c_cflag & CRTSCTS)) {
+-		struct cp210x_flow_ctl flow_ctl;
+-		u32 ctl_hs;
+-		u32 flow_repl;
+-
+-		cp210x_read_reg_block(port, CP210X_GET_FLOW, &flow_ctl,
+-				sizeof(flow_ctl));
+-		ctl_hs = le32_to_cpu(flow_ctl.ulControlHandshake);
+-		flow_repl = le32_to_cpu(flow_ctl.ulFlowReplace);
+-
+-		ctl_hs &= ~CP210X_SERIAL_DSR_HANDSHAKE;
+-		ctl_hs &= ~CP210X_SERIAL_DCD_HANDSHAKE;
+-		ctl_hs &= ~CP210X_SERIAL_DSR_SENSITIVITY;
+-		ctl_hs &= ~CP210X_SERIAL_DTR_MASK;
+-		ctl_hs |= CP210X_SERIAL_DTR_SHIFT(CP210X_SERIAL_DTR_ACTIVE);
+-		if (C_CRTSCTS(tty)) {
+-			ctl_hs |= CP210X_SERIAL_CTS_HANDSHAKE;
+-
+-			flow_repl &= ~CP210X_SERIAL_RTS_MASK;
+-			flow_repl |= CP210X_SERIAL_RTS_SHIFT(
+-					CP210X_SERIAL_RTS_FLOW_CTL);
+-		} else {
+-			ctl_hs &= ~CP210X_SERIAL_CTS_HANDSHAKE;
+-
+-			flow_repl &= ~CP210X_SERIAL_RTS_MASK;
+-			flow_repl |= CP210X_SERIAL_RTS_SHIFT(
+-					CP210X_SERIAL_RTS_ACTIVE);
+-		}
+-
+-		dev_dbg(dev, "%s - ulControlHandshake=0x%08x, ulFlowReplace=0x%08x\n",
+-				__func__, ctl_hs, flow_repl);
+-		flow_ctl.ulControlHandshake = cpu_to_le32(ctl_hs);
+-		flow_ctl.ulFlowReplace = cpu_to_le32(flow_repl);
+-		cp210x_write_reg_block(port, CP210X_SET_FLOW, &flow_ctl,
+-				sizeof(flow_ctl));
+-	}
++	cp210x_set_flow_control(tty, port, old_termios);
+ 
+ 	/*
+ 	 * Enable event-insertion mode only if input parity checking is
+-- 
+2.33.1
+

--- a/recipes-kernel/linux/files/patches-5.10/0114-USB-serial-cp210x-clean-up-dtr_rts.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0114-USB-serial-cp210x-clean-up-dtr_rts.patch
@@ -1,0 +1,45 @@
+From 2efa8e0987353b6be26e8274086e19bc4aa4d41a Mon Sep 17 00:00:00 2001
+From: Johan Hovold <johan@kernel.org>
+Date: Mon, 16 Nov 2020 17:18:26 +0100
+Subject: [PATCH 114/116] USB: serial: cp210x: clean up dtr_rts()
+
+Clean up dtr_rts() by renaming the port parameter and adding missing
+whitespace.
+
+Signed-off-by: Johan Hovold <johan@kernel.org>
+---
+ drivers/usb/serial/cp210x.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/usb/serial/cp210x.c b/drivers/usb/serial/cp210x.c
+index 19666329f386..68b30960f441 100644
+--- a/drivers/usb/serial/cp210x.c
++++ b/drivers/usb/serial/cp210x.c
+@@ -46,7 +46,7 @@ static void cp210x_disconnect(struct usb_serial *);
+ static void cp210x_release(struct usb_serial *);
+ static int cp210x_port_probe(struct usb_serial_port *);
+ static int cp210x_port_remove(struct usb_serial_port *);
+-static void cp210x_dtr_rts(struct usb_serial_port *p, int on);
++static void cp210x_dtr_rts(struct usb_serial_port *port, int on);
+ static void cp210x_process_read_urb(struct urb *urb);
+ static void cp210x_enable_event_mode(struct usb_serial_port *port);
+ static void cp210x_disable_event_mode(struct usb_serial_port *port);
+@@ -1246,12 +1246,12 @@ static int cp210x_tiocmset_port(struct usb_serial_port *port,
+ 	return cp210x_write_u16_reg(port, CP210X_SET_MHS, control);
+ }
+ 
+-static void cp210x_dtr_rts(struct usb_serial_port *p, int on)
++static void cp210x_dtr_rts(struct usb_serial_port *port, int on)
+ {
+ 	if (on)
+-		cp210x_tiocmset_port(p, TIOCM_DTR|TIOCM_RTS, 0);
++		cp210x_tiocmset_port(port, TIOCM_DTR | TIOCM_RTS, 0);
+ 	else
+-		cp210x_tiocmset_port(p, 0, TIOCM_DTR|TIOCM_RTS);
++		cp210x_tiocmset_port(port, 0, TIOCM_DTR | TIOCM_RTS);
+ }
+ 
+ static int cp210x_tiocmget(struct tty_struct *tty)
+-- 
+2.33.1
+

--- a/recipes-kernel/linux/files/patches-5.10/0115-USB-serial-cp210x-add-support-for-software-flow-cont.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0115-USB-serial-cp210x-add-support-for-software-flow-cont.patch
@@ -1,0 +1,143 @@
+From 2727fb7a507e1b7479ad2bc6905c20fe96f8fde4 Mon Sep 17 00:00:00 2001
+From: Wang Sheng Long <shenglong.wang.ext@siemens.com>
+Date: Mon, 18 Jan 2021 12:13:26 +0100
+Subject: [PATCH 115/116] USB: serial: cp210x: add support for software flow
+ control
+
+When data is transmitted between two serial ports, the phenomenon of
+data loss often occurs. The two kinds of flow control commonly used in
+serial communication are hardware flow control and software flow
+control.
+
+In serial communication, If you only use RX/TX/GND Pins, you can't do
+hardware flow. So we often used software flow control and prevent data
+loss. The user sets the software flow control through the application
+program, and the application program sets the software flow control mode
+for the serial port chip through the driver.
+
+For the cp210 serial port chip, its driver lacks the software flow
+control setting code, so the user cannot set the software flow control
+function through the application program. This adds the missing software
+flow control.
+
+Signed-off-by: Wang Sheng Long <shenglong.wang.ext@siemens.com>
+Link: https://lore.kernel.org/r/20210104094502.3942-1-china_shenglong@163.com
+[ johan: rework properly on top of recent termios changes ]
+Reviewed-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Signed-off-by: Johan Hovold <johan@kernel.org>
+---
+ drivers/usb/serial/cp210x.c | 67 +++++++++++++++++++++++++++++++++++--
+ 1 file changed, 65 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/usb/serial/cp210x.c b/drivers/usb/serial/cp210x.c
+index 68b30960f441..a1c1a52b8680 100644
+--- a/drivers/usb/serial/cp210x.c
++++ b/drivers/usb/serial/cp210x.c
+@@ -383,6 +383,16 @@ static struct usb_serial_driver * const serial_drivers[] = {
+ #define CONTROL_WRITE_DTR	0x0100
+ #define CONTROL_WRITE_RTS	0x0200
+ 
++/* CP210X_(GET|SET)_CHARS */
++struct cp210x_special_chars {
++	u8	bEofChar;
++	u8	bErrorChar;
++	u8	bBreakChar;
++	u8	bEventChar;
++	u8	bXonChar;
++	u8	bXoffChar;
++};
++
+ /* CP210X_VENDOR_SPECIFIC values */
+ #define CP210X_READ_2NCONFIG	0x000E
+ #define CP210X_READ_LATCH	0x00C2
+@@ -1086,11 +1096,38 @@ static void cp210x_disable_event_mode(struct usb_serial_port *port)
+ 	port_priv->event_mode = false;
+ }
+ 
++static int cp210x_set_chars(struct usb_serial_port *port,
++		struct cp210x_special_chars *chars)
++{
++	struct cp210x_port_private *port_priv = usb_get_serial_port_data(port);
++	struct usb_serial *serial = port->serial;
++	void *dmabuf;
++	int result;
++
++	dmabuf = kmemdup(chars, sizeof(*chars), GFP_KERNEL);
++	if (!dmabuf)
++		return -ENOMEM;
++
++	result = usb_control_msg(serial->dev, usb_sndctrlpipe(serial->dev, 0),
++				CP210X_SET_CHARS, REQTYPE_HOST_TO_INTERFACE, 0,
++				port_priv->bInterfaceNumber,
++				dmabuf, sizeof(*chars), USB_CTRL_SET_TIMEOUT);
++
++	kfree(dmabuf);
++
++	if (result < 0) {
++		dev_err(&port->dev, "failed to set special chars: %d\n", result);
++		return result;
++	}
++
++	return 0;
++}
++
+ static bool cp210x_termios_change(const struct ktermios *a, const struct ktermios *b)
+ {
+ 	bool iflag_change;
+ 
+-	iflag_change = ((a->c_iflag ^ b->c_iflag) & INPCK);
++	iflag_change = ((a->c_iflag ^ b->c_iflag) & (INPCK | IXON | IXOFF));
+ 
+ 	return tty_termios_hw_change(a, b) || iflag_change;
+ }
+@@ -1098,13 +1135,29 @@ static bool cp210x_termios_change(const struct ktermios *a, const struct ktermio
+ static void cp210x_set_flow_control(struct tty_struct *tty,
+ 		struct usb_serial_port *port, struct ktermios *old_termios)
+ {
++	struct cp210x_special_chars chars;
+ 	struct cp210x_flow_ctl flow_ctl;
+ 	u32 flow_repl;
+ 	u32 ctl_hs;
+ 	int ret;
+ 
+-	if (old_termios && C_CRTSCTS(tty) == (old_termios->c_cflag & CRTSCTS))
++	if (old_termios &&
++			C_CRTSCTS(tty) == (old_termios->c_cflag & CRTSCTS) &&
++			I_IXON(tty) == (old_termios->c_iflag & IXON) &&
++			I_IXOFF(tty) == (old_termios->c_iflag & IXOFF)) {
+ 		return;
++	}
++
++	if (I_IXON(tty) || I_IXOFF(tty)) {
++		memset(&chars, 0, sizeof(chars));
++
++		chars.bXonChar = START_CHAR(tty);
++		chars.bXoffChar = STOP_CHAR(tty);
++
++		ret = cp210x_set_chars(port, &chars);
++		if (ret)
++			return;
++	}
+ 
+ 	ret = cp210x_read_reg_block(port, CP210X_GET_FLOW, &flow_ctl,
+ 			sizeof(flow_ctl));
+@@ -1130,6 +1183,16 @@ static void cp210x_set_flow_control(struct tty_struct *tty,
+ 		flow_repl |= CP210X_SERIAL_RTS_SHIFT(CP210X_SERIAL_RTS_ACTIVE);
+ 	}
+ 
++	if (I_IXOFF(tty))
++		flow_repl |= CP210X_SERIAL_AUTO_RECEIVE;
++	else
++		flow_repl &= ~CP210X_SERIAL_AUTO_RECEIVE;
++
++	if (I_IXON(tty))
++		flow_repl |= CP210X_SERIAL_AUTO_TRANSMIT;
++	else
++		flow_repl &= ~CP210X_SERIAL_AUTO_TRANSMIT;
++
+ 	dev_dbg(&port->dev, "%s - ulControlHandshake=0x%08x, ulFlowReplace=0x%08x\n",
+ 			__func__, ctl_hs, flow_repl);
+ 
+-- 
+2.33.1
+

--- a/recipes-kernel/linux/files/patches-5.10/0116-USB-serial-cp210x-fix-control-characters-error-handl.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0116-USB-serial-cp210x-fix-control-characters-error-handl.patch
@@ -1,0 +1,53 @@
+From e88bbb701628cd783bda08e707b1e82f792636f6 Mon Sep 17 00:00:00 2001
+From: Johan Hovold <johan@kernel.org>
+Date: Mon, 5 Jul 2021 10:20:10 +0200
+Subject: [PATCH 116/116] USB: serial: cp210x: fix control-characters error
+ handling
+
+In the unlikely event that setting the software flow-control characters
+fails the other flow-control settings should still be updated (just like
+all other terminal settings).
+
+Move out the error message printed by the set_chars() helper to make it
+more obvious that this is intentional.
+
+Fixes: 7748feffcd80 ("USB: serial: cp210x: add support for software flow control")
+Cc: stable@vger.kernel.org	# 5.11
+Reviewed-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Signed-off-by: Johan Hovold <johan@kernel.org>
+---
+ drivers/usb/serial/cp210x.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/usb/serial/cp210x.c b/drivers/usb/serial/cp210x.c
+index a1c1a52b8680..4308f37c61bc 100644
+--- a/drivers/usb/serial/cp210x.c
++++ b/drivers/usb/serial/cp210x.c
+@@ -1115,10 +1115,8 @@ static int cp210x_set_chars(struct usb_serial_port *port,
+ 
+ 	kfree(dmabuf);
+ 
+-	if (result < 0) {
+-		dev_err(&port->dev, "failed to set special chars: %d\n", result);
++	if (result < 0)
+ 		return result;
+-	}
+ 
+ 	return 0;
+ }
+@@ -1155,8 +1153,10 @@ static void cp210x_set_flow_control(struct tty_struct *tty,
+ 		chars.bXoffChar = STOP_CHAR(tty);
+ 
+ 		ret = cp210x_set_chars(port, &chars);
+-		if (ret)
+-			return;
++		if (ret) {
++			dev_err(&port->dev, "failed to set special chars: %d\n",
++					ret);
++		}
+ 	}
+ 
+ 	ret = cp210x_read_reg_block(port, CP210X_GET_FLOW, &flow_ctl,
+-- 
+2.33.1
+


### PR DESCRIPTION
…wcontrol

Since some patches are missing,resulting usb-to-serial software flowcontrol can not work

Pick up releated patches to fix the software flowcontrol

Signed-off-by: chao zeng <chao.zeng@siemens.com>