### PR TITLE
node-red-gpio: Add configurable GPIO mode for DIN

### DIFF
--- a/recipes-app/node-red-gpio/files/0005-Add-configurable-GPIO-mode-for-DIN.patch
+++ b/recipes-app/node-red-gpio/files/0005-Add-configurable-GPIO-mode-for-DIN.patch
@@ -1,0 +1,68 @@
+From 1cffd0ca33728aee6b20ae178b7c1171e15fce97 Mon Sep 17 00:00:00 2001
+From: Ivan Mikhaylov <ivan.mikhaylov@siemens.com>
+Date: Thu, 28 Oct 2021 16:41:51 +0000
+Subject: [PATCH] Add configurable GPIO mode for DIN
+
+GPIO mode wasn't set correctly, it was set from Pinmuxes modes instead
+of GPIO. Add way to control GPIO modes on DINs from Node-RED with
+possible values from mraa : Strong, Hiz, Pull-down, Pull-up.
+
+to close #135
+
+Signed-off-by: Ivan Mikhaylov <ivan.mikhaylov@siemens.com>
+---
+ hardware/intel/mraa-gpio-din.html | 13 ++++++++++++-
+ hardware/intel/mraa-gpio-din.js   |  3 ++-
+ 2 files changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/hardware/intel/mraa-gpio-din.html b/hardware/intel/mraa-gpio-din.html
+index d2ac00e..58a1363 100644
+--- a/hardware/intel/mraa-gpio-din.html
++++ b/hardware/intel/mraa-gpio-din.html
+@@ -7,7 +7,8 @@
+         defaults: {
+             name: {value:""},
+             pin:  {value:"", required: true},
+-            interrupt: {value:"", required: true}
++            interrupt: {value:"", required: true},
++            mode: {value:"", required: true}
+         },
+         inputs:0,
+         outputs:1,
+@@ -69,6 +70,16 @@
+             <option value="20">USER button</option>
+         </select>
+     </div>
++    <div class="form-row">
++        <label for="node-input-name"><i class="fa-level-up"></i> Mode</label>
++        <select type="text" id="node-input-mode" style="width: 250px;">
++            <option value='' disabled selected style='display:none;'>select mode</option>
++            <option value="0">Strong </option>
++            <option value="1">Pull-up </option>
++            <option value="2">Pull-down </option>
++            <option value="3">Hiz </option>
++        </select>
++    </div>
+     <div class="form-row">
+         <label for="node-input-name"><i class="fa-level-up"></i> Interrupt</label>
+         <select type="text" id="node-input-interrupt" style="width: 250px;">
+diff --git a/hardware/intel/mraa-gpio-din.js b/hardware/intel/mraa-gpio-din.js
+index 7eca35a..9fc3a12 100644
+--- a/hardware/intel/mraa-gpio-din.js
++++ b/hardware/intel/mraa-gpio-din.js
+@@ -7,10 +7,11 @@ module.exports = function(RED) {
+         RED.nodes.createNode(this,n);
+         this.pin = n.pin;
+         this.interrupt = n.interrupt;
++        this.mode = n.mode;
+         this.x = new m.Gpio(parseInt(this.pin));
+         this.board = m.getPlatformName();
+         var node = this;
+-        node.x.mode(m.PIN_GPIO);
++        node.x.mode(parseInt(this.mode));
+         node.x.dir(m.DIR_IN);
+         node.x.isr(m.EDGE_BOTH, function() {
+             var g = node.x.read();
+-- 
+2.33.1
+

--- a/recipes-app/node-red-gpio/node-red-gpio_0.0.6-IOT2050.bb
+++ b/recipes-app/node-red-gpio/node-red-gpio_0.0.6-IOT2050.bb
@@ -19,7 +19,8 @@ SRC_URI = " \
     file://0001-add-the-board-info-add-the-led-control-node.patch \
     file://0002-extend-gpio-to-D19.patch \
     file://0003-Clean-up-mraa-objects-on-node-closing.patch \
-    file://0004-Add-USER-button.patch"
+    file://0004-Add-USER-button.patch \
+    file://0005-Add-configurable-GPIO-mode-for-DIN.patch"
 SRCREV="3087e8e2a1ea189f394bca0a2af159ad859d7722"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
GPIO mode wasn't set correctly. Add the possibility to set mode via
node red DIN with 4 possible values from mraa: Strong, Pull-up,
Pull-down, Hiz.

Fixes #135

Signed-off-by: Ivan Mikhaylov <ivan.mikhaylov@siemens.com>