### PR TITLE
u-boot-iot2050: Add patch that prevents spurious red LED signal

### DIFF
--- a/recipes-bsp/u-boot/files/0001-arm-mach-k3-am6_init-Prioritize-MSMC-traffic-over-DD.patch
+++ b/recipes-bsp/u-boot/files/0001-arm-mach-k3-am6_init-Prioritize-MSMC-traffic-over-DD.patch
@@ -1,7 +1,7 @@
 From 1438d1bfbdd163f29db3c1d1c0e0c1a075896b1c Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Wed, 8 Sep 2021 22:28:59 +0200
-Subject: [PATCH 1/8] arm: mach-k3: am6_init: Prioritize MSMC traffic over DDR
+Subject: [PATCH 1/9] arm: mach-k3: am6_init: Prioritize MSMC traffic over DDR
  in NAVSS Northbridge
 
 NB0 is bridge to SRAM and NB1 is bridge to DDR.

--- a/recipes-bsp/u-boot/files/0002-arm-dts-Add-IOT2050-device-tree-files.patch
+++ b/recipes-bsp/u-boot/files/0002-arm-dts-Add-IOT2050-device-tree-files.patch
@@ -1,7 +1,7 @@
 From e5fcae48800cc368eb26b917e9349b9ea53ebaa1 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 30 Nov 2020 10:13:04 +0100
-Subject: [PATCH 2/8] arm: dts: Add IOT2050 device tree files
+Subject: [PATCH 2/9] arm: dts: Add IOT2050 device tree files
 
 Prepares for the addition of the IOT2050 board which is based on the TI
 AM65x. The board comes in four variants, Basic and Advanced, each as

--- a/recipes-bsp/u-boot/files/0003-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
+++ b/recipes-bsp/u-boot/files/0003-board-siemens-Add-support-for-SIMATIC-IOT2050-device.patch
@@ -1,7 +1,7 @@
 From 1530b2afcf32dfcd37fa450e8fa21634e2b5a486 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 11 May 2020 20:10:16 +0200
-Subject: [PATCH 3/8] board: siemens: Add support for SIMATIC IOT2050 devices
+Subject: [PATCH 3/9] board: siemens: Add support for SIMATIC IOT2050 devices
 
 This adds support for the IOT2050 Basic and Advanced devices. The Basic
 used the dual-core AM6528 GP processor, the Advanced one the AM6548 HS

--- a/recipes-bsp/u-boot/files/0004-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
+++ b/recipes-bsp/u-boot/files/0004-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
@@ -1,7 +1,7 @@
 From 43c99feaafbacb11fb26acefb03f31f7937fe573 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 27 Jun 2020 07:58:01 +0200
-Subject: [PATCH 4/8] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
+Subject: [PATCH 4/9] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
 
 Add the DT entry for a watchdog based on RTI1. It requires additional
 firmware on the MCU R5F cores to handle the expiry, e.g.

--- a/recipes-bsp/u-boot/files/0005-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
+++ b/recipes-bsp/u-boot/files/0005-watchdog-rti_wdt-Add-support-for-loading-firmware.patch
@@ -1,7 +1,7 @@
 From 548fd0795fea097bdffedfb50f7d6915673dee39 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 21 Jun 2020 09:04:30 +0200
-Subject: [PATCH 5/8] watchdog: rti_wdt: Add support for loading firmware
+Subject: [PATCH 5/9] watchdog: rti_wdt: Add support for loading firmware
 
 To avoid the need of extra boot scripting on AM65x for loading a
 watchdog firmware, add the required rproc init and loading logic for the

--- a/recipes-bsp/u-boot/files/0006-watchdog-Allow-to-use-CONFIG_WDT-without-starting-wa.patch
+++ b/recipes-bsp/u-boot/files/0006-watchdog-Allow-to-use-CONFIG_WDT-without-starting-wa.patch
@@ -1,7 +1,7 @@
 From ccb260bbd296a4d872e7731ca56cac66eaa94b5d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
 Date: Tue, 9 Mar 2021 14:26:56 +0100
-Subject: [PATCH 6/8] watchdog: Allow to use CONFIG_WDT without starting
+Subject: [PATCH 6/9] watchdog: Allow to use CONFIG_WDT without starting
  watchdog
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/recipes-bsp/u-boot/files/0007-iot2050-Enable-watchdog-support-but-do-not-auto-star.patch
+++ b/recipes-bsp/u-boot/files/0007-iot2050-Enable-watchdog-support-but-do-not-auto-star.patch
@@ -1,7 +1,7 @@
 From 84972e5e3478435524d95cc06668067ead43751c Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 19 Jun 2020 08:56:35 +0200
-Subject: [PATCH 7/8] iot2050: Enable watchdog support, but do not auto-start
+Subject: [PATCH 7/9] iot2050: Enable watchdog support, but do not auto-start
  it
 
 This allows to use the watchdog in custom scripts but does not enforce

--- a/recipes-bsp/u-boot/files/0008-sf-Querying-write-protect-status-before-operating-th.patch
+++ b/recipes-bsp/u-boot/files/0008-sf-Querying-write-protect-status-before-operating-th.patch
@@ -1,7 +1,7 @@
 From 05b0710049c12c114b73e7850a81e3fcf75eed68 Mon Sep 17 00:00:00 2001
 From: Chao Zeng <chao.zeng@siemens.com>
 Date: Tue, 22 Jun 2021 13:21:26 +0800
-Subject: [PATCH 8/8] sf: Querying write-protect status before operating the
+Subject: [PATCH 8/9] sf: Querying write-protect status before operating the
  flash
 
 When operating the write-protection flash,spi_flash_std_write() and

--- a/recipes-bsp/u-boot/files/0009-boards-siemens-iot2050-Ignore-network-errors-during-.patch
+++ b/recipes-bsp/u-boot/files/0009-boards-siemens-iot2050-Ignore-network-errors-during-.patch
@@ -1,0 +1,32 @@
+From e6738c3fb4735300a6f394e0c0d89c7763583fa5 Mon Sep 17 00:00:00 2001
+From: Jan Kiszka <jan.kiszka@siemens.com>
+Date: Wed, 3 Nov 2021 14:09:15 +0100
+Subject: [PATCH 9/9] boards: siemens: iot2050: Ignore network errors during
+ bootstage tracking
+
+We need to filter out NET_ETH_START errors because we have to enable
+networking in order to propagate the MAC addresses to the DT while there
+is no network driver for the prueth in U-Boot yet.
+
+Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
+---
+ board/siemens/iot2050/board.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/board/siemens/iot2050/board.c b/board/siemens/iot2050/board.c
+index b2110978ae..817fbf4ecb 100644
+--- a/board/siemens/iot2050/board.c
++++ b/board/siemens/iot2050/board.c
+@@ -259,7 +259,8 @@ void show_boot_progress(int progress)
+ 	struct udevice *dev;
+ 	int ret;
+ 
+-	if (progress < 0 || progress == BOOTSTAGE_ID_ENTER_CLI_LOOP) {
++	if ((progress < 0 && progress != -BOOTSTAGE_ID_NET_ETH_START) ||
++	    progress == BOOTSTAGE_ID_ENTER_CLI_LOOP) {
+ 		ret = led_get_by_label("status-led-green", &dev);
+ 		if (ret == 0)
+ 			led_set_state(dev, LEDST_OFF);
+-- 
+2.31.1
+

--- a/recipes-bsp/u-boot/u-boot-iot2050_2021.04.bb
+++ b/recipes-bsp/u-boot/u-boot-iot2050_2021.04.bb
@@ -20,6 +20,7 @@ SRC_URI += " \
     file://0006-watchdog-Allow-to-use-CONFIG_WDT-without-starting-wa.patch \
     file://0007-iot2050-Enable-watchdog-support-but-do-not-auto-star.patch \
     file://0008-sf-Querying-write-protect-status-before-operating-th.patch \
+    file://0009-boards-siemens-iot2050-Ignore-network-errors-during-.patch \
     "
 
 SRC_URI[sha256sum] = "0d438b1bb5cceb57a18ea2de4a0d51f7be5b05b98717df05938636e0aadfe11a"


### PR DESCRIPTION
Needed to prevent that the red error LED is turned on even during
successful boots.