### PR TITLE
mraa: uart: allow change the uart attribute immediately

### DIFF
--- a/recipes-app/mraa/files/0001-aio.c-fix-mraa_aio_set_bit-for-result-scaling.patch
+++ b/recipes-app/mraa/files/0001-aio.c-fix-mraa_aio_set_bit-for-result-scaling.patch
@@ -1,7 +1,7 @@
-From 3b1222d0fc05107020e4f1e00e1d45b782c38c95 Mon Sep 17 00:00:00 2001
+From 95f32e87ca29fadeac35bc7f8925ba151d9eb770 Mon Sep 17 00:00:00 2001
 From: "le.jin" <le.jin@siemens.com>
 Date: Fri, 1 Nov 2019 18:02:54 +0800
-Subject: [PATCH 01/13] aio.c: fix mraa_aio_set_bit for result scaling
+Subject: [PATCH 01/14] aio.c: fix mraa_aio_set_bit for result scaling
 
 Signed-off-by: le.jin <le.jin@siemens.com>
 ---
@@ -28,5 +28,5 @@ index 0cc631f..7a94ac1 100644
  }
  
 -- 
-2.26.2
+2.32.0
 

--- a/recipes-app/mraa/files/0002-feat-iot2050-add-iot2050-platform-support.patch
+++ b/recipes-app/mraa/files/0002-feat-iot2050-add-iot2050-platform-support.patch
@@ -1,7 +1,7 @@
-From a1bee1d7bd044a7658e54d894b5ffbfb33f58360 Mon Sep 17 00:00:00 2001
+From 04d1329e410982dcf45bc71c12feaecac09b0472 Mon Sep 17 00:00:00 2001
 From: "le.jin" <le.jin@siemens.com>
 Date: Fri, 24 May 2019 14:33:42 +0800
-Subject: [PATCH 02/13] feat:iot2050:add iot2050 platform support
+Subject: [PATCH 02/14] feat:iot2050:add iot2050 platform support
 
 Add new iot2050 platform support with some modifications
 due to lack of support with register level pin mux hooks.
@@ -2191,5 +2191,5 @@ index f1a76d2..f1405f8 100644
          syslog(LOG_ERR, "uart%i: set_timeout: tcsetattr() failed: %s", dev->index, strerror(errno));
          return MRAA_ERROR_FEATURE_NOT_SUPPORTED;
 -- 
-2.26.2
+2.32.0
 

--- a/recipes-app/mraa/files/0003-feat-iot2050-add-some-example-code-for-testing.patch
+++ b/recipes-app/mraa/files/0003-feat-iot2050-add-some-example-code-for-testing.patch
@@ -1,7 +1,7 @@
-From 068659aab4ac171901aef3d8687d86f92029538d Mon Sep 17 00:00:00 2001
+From 960a3b65e5808dc1a9f3d0a6ecda4921e737e47f Mon Sep 17 00:00:00 2001
 From: "le.jin" <le.jin@siemens.com>
 Date: Tue, 18 Jun 2019 16:16:02 +0800
-Subject: [PATCH 03/13] feat:iot2050:add some example code for testing
+Subject: [PATCH 03/14] feat:iot2050:add some example code for testing
 
 Signed-off-by: le.jin <le.jin@siemens.com>
 ---
@@ -428,5 +428,5 @@ index 0000000..81d0171
 +}
 \ No newline at end of file
 -- 
-2.26.2
+2.32.0
 

--- a/recipes-app/mraa/files/0004-api-Add-explicit-close-methods-to-classes.patch
+++ b/recipes-app/mraa/files/0004-api-Add-explicit-close-methods-to-classes.patch
@@ -1,7 +1,7 @@
-From f0d40c4eba4790751ef54fe3fd014b45e09cb9cd Mon Sep 17 00:00:00 2001
+From 71232400a7920f91a99ce02203323818e250d4c2 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 27 Nov 2020 07:26:50 +0100
-Subject: [PATCH 04/13] api: Add explicit close methods to classes
+Subject: [PATCH 04/14] api: Add explicit close methods to classes
 
 This is needed for bindings to languages which perform implicit and lazy
 object cleanups. The explicit close methods allow to release resources
@@ -246,5 +246,5 @@ index db44e9d..e64a14a 100644
  
      /**
 -- 
-2.26.2
+2.32.0
 

--- a/recipes-app/mraa/files/0005-gpio-chardev-Add-helper-to-retrieve-gpiochip-and-lin.patch
+++ b/recipes-app/mraa/files/0005-gpio-chardev-Add-helper-to-retrieve-gpiochip-and-lin.patch
@@ -1,7 +1,7 @@
-From eb2790bb670d5c2ff5452f489c23abad5543501c Mon Sep 17 00:00:00 2001
+From eb72f16c48cce76ede53f5ed2c09bfd5bcc81287 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 18 Jan 2021 07:11:20 +0100
-Subject: [PATCH 05/13] gpio: chardev: Add helper to retrieve gpiochip and line
+Subject: [PATCH 05/14] gpio: chardev: Add helper to retrieve gpiochip and line
  offset by line name
 
 This makes the retrieval robust against chips being reordered during
@@ -80,5 +80,5 @@ index 7f1f6e0..9bea44b 100644
 +    return -1;
 +}
 -- 
-2.26.2
+2.32.0
 

--- a/recipes-app/mraa/files/0006-gpio-chardev-Add-function-to-retrieve-sysfs-base-for.patch
+++ b/recipes-app/mraa/files/0006-gpio-chardev-Add-function-to-retrieve-sysfs-base-for.patch
@@ -1,7 +1,7 @@
-From cfbcd5a9b19b925d33cc02aef4aae20e7cb2f5db Mon Sep 17 00:00:00 2001
+From 53444ab8b3c4ece6a807cdc0d34ba9dfb4ae6175 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 18 Jan 2021 07:05:19 +0100
-Subject: [PATCH 06/13] gpio: chardev: Add function to retrieve sysfs base for
+Subject: [PATCH 06/14] gpio: chardev: Add function to retrieve sysfs base for
  a gpiochip
 
 This allows to full mux structures which still need the sysfs GPIO
@@ -75,5 +75,5 @@ index 9bea44b..d83a40c 100644
  mraa_get_line_info_from_descriptor(int chip_fd, unsigned line_number)
  {
 -- 
-2.26.2
+2.32.0
 

--- a/recipes-app/mraa/files/0007-iot2050-Switch-to-runtime-detection-of-gpiochip-numb.patch
+++ b/recipes-app/mraa/files/0007-iot2050-Switch-to-runtime-detection-of-gpiochip-numb.patch
@@ -1,7 +1,7 @@
-From 2f227c0ac521866f991677be6a1324575237d04d Mon Sep 17 00:00:00 2001
+From 82fea7d51af3d4fbdeb58b8bfaf2767371c6f039 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 18 Jan 2021 09:13:17 +0100
-Subject: [PATCH 07/13] iot2050: Switch to runtime detection of gpiochip
+Subject: [PATCH 07/14] iot2050: Switch to runtime detection of gpiochip
  numbers and bases
 
 This makes the logic independent of the gpiochip probing order.
@@ -718,5 +718,5 @@ index 0035404..a042bf3 100644
      mux_info[4].value = MRAA_GPIO_IN;
      iot2050_pin_add_aio(b, pin_index, 5, mux_info, 5);
 -- 
-2.26.2
+2.32.0
 

--- a/recipes-app/mraa/files/0008-iot2050-Add-USER-button.patch
+++ b/recipes-app/mraa/files/0008-iot2050-Add-USER-button.patch
@@ -1,7 +1,7 @@
-From 51983e8cc21f6979be942078b1f8490bfdda1af0 Mon Sep 17 00:00:00 2001
+From 58b5206e491ae3c08d21a5cb4737b37ecb7453eb Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 18 Jan 2021 09:14:35 +0100
-Subject: [PATCH 08/13] iot2050: Add USER button
+Subject: [PATCH 08/14] iot2050: Add USER button
 
 A simple GPIO, no muxing needed, no pulling supported. Therefore, reject
 any mode changes that request pull up/down, ignore the others.
@@ -68,5 +68,5 @@ index a042bf3..52ab646 100644
      iot2050_setup_uart(b, "UART0", "/dev/ttyS1", "IO0", "IO1", "IO2", "IO3");
      b->def_uart_dev = 0;
 -- 
-2.26.2
+2.32.0
 

--- a/recipes-app/mraa/files/0009-led-Fix-and-cleanup-initialization.patch
+++ b/recipes-app/mraa/files/0009-led-Fix-and-cleanup-initialization.patch
@@ -1,7 +1,7 @@
-From 00df1594d0ec4021025449d7c41b2924ce1f7888 Mon Sep 17 00:00:00 2001
+From 5dceadbc770c038f77f10b16afa58c1223881900 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 4 Feb 2021 18:12:42 +0100
-Subject: [PATCH 09/13] led: Fix and cleanup initialization
+Subject: [PATCH 09/14] led: Fix and cleanup initialization
 
 The structure returned by readdir is may be statically allocated.
 Keeping a pointer to it is broken.
@@ -167,5 +167,5 @@ index 2c5fc94..1b04943 100644
  
      return MRAA_SUCCESS;
 -- 
-2.26.2
+2.32.0
 

--- a/recipes-app/mraa/files/0010-uart-Fix-software-flow-control-management.patch
+++ b/recipes-app/mraa/files/0010-uart-Fix-software-flow-control-management.patch
@@ -1,7 +1,7 @@
-From 9ec5a0a776b539deb44f34fc6973969c4b7dbda4 Mon Sep 17 00:00:00 2001
+From e6e0a58ffd17027e0daebc9133a0351d1a3d0d38 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 30 Apr 2021 07:57:59 +0200
-Subject: [PATCH 10/13] uart: Fix software flow control management
+Subject: [PATCH 10/14] uart: Fix software flow control management
 
 Rather than updating IXON/IXOFF in termios, mraa_uart_set_flowcontrol
 was incorrectly issuing a stop or start character on mode changes. This
@@ -49,5 +49,5 @@ index f1405f8..3e3aa32 100644
          termio.c_cflag |= CRTSCTS;
      } else {
 -- 
-2.26.2
+2.32.0
 

--- a/recipes-app/mraa/files/0011-gpio-Avoid-spurious-value-reset-without-output-mode-.patch
+++ b/recipes-app/mraa/files/0011-gpio-Avoid-spurious-value-reset-without-output-mode-.patch
@@ -1,7 +1,7 @@
-From b45b6518a48aa6a72960d7c79754400ac48fde7c Mon Sep 17 00:00:00 2001
+From a5b6072b1ba89423f4014a96a30ebb0a77415140 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 30 Apr 2021 18:57:44 +0200
-Subject: [PATCH 11/13] gpio: Avoid spurious value reset without output mode
+Subject: [PATCH 11/14] gpio: Avoid spurious value reset without output mode
  changes
 
 When a GPIO controlled via sysfs is set again to output mode, the kernel
@@ -149,5 +149,5 @@ index ff97b4b..baac7cd 100644
  
      return result;
 -- 
-2.26.2
+2.32.0
 

--- a/recipes-app/mraa/files/0012-version.h-Fix-multiple-definitions-of-gVERSION-_SHOR.patch
+++ b/recipes-app/mraa/files/0012-version.h-Fix-multiple-definitions-of-gVERSION-_SHOR.patch
@@ -1,7 +1,7 @@
-From 47c4020db5c2e3d415989183c8c2ba847ae48ea3 Mon Sep 17 00:00:00 2001
+From 767b2f996b69860948a4511828e4deb25217af20 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 26 Jun 2021 07:01:38 +0200
-Subject: [PATCH 12/13] version.h: Fix multiple definitions of gVERSION[_SHORT]
+Subject: [PATCH 12/14] version.h: Fix multiple definitions of gVERSION[_SHORT]
 
 Recent gcc versions / default settings reject this.
 
@@ -26,5 +26,5 @@ index 47366ef..3a567a1 100644
  #ifdef __cplusplus
  }
 -- 
-2.26.2
+2.32.0
 

--- a/recipes-app/mraa/files/0013-Support-for-swig-4.1.0.patch
+++ b/recipes-app/mraa/files/0013-Support-for-swig-4.1.0.patch
@@ -1,7 +1,7 @@
-From 299bb3b677c816f1b2b60415c18428e2d4962ccf Mon Sep 17 00:00:00 2001
+From 283df2573e5d9b7c4813074068b3dde8b6e7f797 Mon Sep 17 00:00:00 2001
 From: Hirokazu MORIKAWA <morikw2@gmail.com>
 Date: Mon, 3 May 2021 10:00:38 +0900
-Subject: [PATCH 13/13] Support for swig 4.1.0
+Subject: [PATCH 13/14] Support for swig 4.1.0
 
 In swig 4.1.0, the complicated handling of "SWIG_V8_VERSION" has been cleaned up a bit. I made the same changes as in this swig.
 
@@ -129,5 +129,5 @@ index 321cc22..4d9949c 100644
  }
  
 -- 
-2.26.2
+2.32.0
 

--- a/recipes-app/mraa/files/0014-uart-allow-change-the-uart-attribute-immediately.patch
+++ b/recipes-app/mraa/files/0014-uart-allow-change-the-uart-attribute-immediately.patch
@@ -1,0 +1,40 @@
+From 07c406fad4708b7f35acea1f2a1e405a0387d5e7 Mon Sep 17 00:00:00 2001
+From: chao zeng <chao.zeng@siemens.com>
+Date: Thu, 4 Nov 2021 14:10:14 +0800
+Subject: [PATCH 14/14] uart: allow change the uart attribute immediately
+
+When using the flow control, the rts asserts,
+There is also data in the buffer on the sender,
+So it can't change the termios attribute when
+re-instantiate the device.
+
+When the device is re-instantiated, discard
+the input and output buffers
+
+Signed-off-by: chao zeng <chao.zeng@siemens.com>
+---
+ src/uart/uart.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/uart/uart.c b/src/uart/uart.c
+index 3e3aa32..ccc0e57 100644
+--- a/src/uart/uart.c
++++ b/src/uart/uart.c
+@@ -296,11 +296,13 @@ mraa_uart_init_raw(const char* path)
+         goto init_raw_cleanup;
+     }
+ 
++    tcflush(dev->fd,TCIOFLUSH);
++
+     // setup for a 'raw' mode.  8N1, no echo or special character
+     // handling, such as flow control or line editing semantics.
+     // cfmakeraw is not POSIX!
+     cfmakeraw(&termio);
+-    if (tcsetattr(dev->fd, TCSAFLUSH, &termio) < 0) {
++    if (tcsetattr(dev->fd, TCSANOW, &termio) < 0) {
+         syslog(LOG_ERR, "uart: tcsetattr(%s) failed after cfmakeraw(): %s", path, strerror(errno));
+         status = MRAA_ERROR_INVALID_RESOURCE;
+         goto init_raw_cleanup;
+-- 
+2.32.0
+

--- a/recipes-app/mraa/mraa_2.2.0.bb
+++ b/recipes-app/mraa/mraa_2.2.0.bb
@@ -25,6 +25,7 @@ SRC_URI += "git://github.com/eclipse/mraa.git;protocol=https \
             file://0011-gpio-Avoid-spurious-value-reset-without-output-mode-.patch \
             file://0012-version.h-Fix-multiple-definitions-of-gVERSION-_SHOR.patch \
             file://0013-Support-for-swig-4.1.0.patch \
+            file://0014-uart-allow-change-the-uart-attribute-immediately.patch \
             file://rules"
 SRCREV = "7786c7ded5c9ce7773890d0e3dc27632898fc6b1"
 


### PR DESCRIPTION
When using the flow control, the rts asserts,
There is also data in the buffer on the sender,
So it can't change the termios attribute when
re-instantiate the device.

When the device is re-instantiated, discard
the input and output buffers

Signed-off-by: chao zeng <chao.zeng@siemens.com>