### PR TITLE
u-boot-iot2050: Make dependencies compatible with downstream machine

### DIFF
--- a/recipes-bsp/u-boot/u-boot-iot2050.inc
+++ b/recipes-bsp/u-boot/u-boot-iot2050.inc
@@ -26,9 +26,9 @@ SPI_FLASH_DEPLOY_IMG = "iot2050-image-boot.bin"
 DEPENDS += "swig"
 
 # Build environment
-DEPENDS += "trusted-firmware-a-iot2050 optee-os-iot2050 k3-rti-wdt"
+DEPENDS += "trusted-firmware-a-iot2050 optee-os-${MACHINE} k3-rti-wdt"
 DEBIAN_BUILD_DEPENDS =. "openssl, libssl-dev:native, libssl-dev:arm64, \
-    trusted-firmware-a-iot2050, optee-os-iot2050, k3-rti-wdt, \
+    trusted-firmware-a-iot2050, optee-os-${MACHINE}, k3-rti-wdt, \
     swig:native, python3-dev:native, python3-pkg-resources,"
 
 U_BOOT_CONFIG_PACKAGE = "1"


### PR DESCRIPTION
If downstream creates a new machine based on conf/machine/iot2050.conf
the dependency to optee-os-iot2050 is no longer fulfilled. Rename
optee-os-iot2050 to optee-os-${Machine} to allow downstream defined
machines.

Signed-off-by: Quirin Gylstorff <quirin.gylstorff@siemens.com>