### PR TITLE
optee-os-iot2050: Make Name compatible with downstream machine

### DIFF
--- a/recipes-bsp/optee-os/optee-os-iot2050_3.12.0.bb
+++ b/recipes-bsp/optee-os/optee-os-iot2050_3.12.0.bb
@@ -15,6 +15,8 @@ SRC_URI[sha256sum] = "b13991099f25d00dac479db93b55034cb93d206e296f2c7aa9c42b92bc
 
 S = "${WORKDIR}/optee_os-${PV}"
 
+OPTEE_NAME = "iot2050"
+
 OPTEE_PLATFORM = "k3-am65x"
 OPTEE_EXTRA_BUILDARGS = " \
     CFG_ARM64_core=y CFG_TEE_CORE_LOG_LEVEL=2 ta-targets=ta_arm64 \


### PR DESCRIPTION
If downstream creates a new machine based on conf/machine/iot2050.conf
the dependency to optee-os-iot2050 is no longer fulfilled. Change
OPTEE_NAME from `${MACHINE}` to `iot2050`.

Signed-off-by: Quirin Gylstorff <quirin.gylstorff@siemens.com>