### PR TITLE
install-on-emmc: Add a case where the button has been pressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ The installation can also be triggered automatically by creating the file
 `/etc/install-on-emmc` on the vanilla image by mounting it under Linux and
 executing, e.g., `touch <mountpoint>/etc/install-on-emmc`.
 
+The installation can also be triggered by keeping pressing the user button 
+during startup at the first boot.
+
 ## Selecting a boot device
 
 By default, the boot loader will pick the first bootable device. If that device

--- a/recipes-core/install-on-emmc/files/install-on-emmc.sh
+++ b/recipes-core/install-on-emmc/files/install-on-emmc.sh
@@ -84,12 +84,14 @@ if [ "${EMMC_DEV}" = "${BOOT_DEV}" ]; then
 fi
 
 # Presence of /etc/install-on-emmc skips button check
+GPIO_PIN=$(gpiofind USER-button)
 if [ -e /etc/install-on-emmc ]; then
 	echo "Found /etc/install-on-emmc, starting installation on eEMMC"
+elif [ $(gpioget ${GPIO_PIN}) = 0 ]; then
+	echo "USER button has been pressed, starting installation on eEMM "
 else
 	echo "Press USER button to install on eMMC, you have 20 seconds"
 	echo "WARNING: All data on eMMC will be overwritten!"
-	GPIO_PIN=$(gpiofind USER-button)
 
 	blink ${LED_ORANGE} 1
 


### PR DESCRIPTION
As we can press the button to remove the emmc from boot_targets,
besides they'd like to install image to emmc. It is hard for user
to press the button,release the button then again pressing the button
to trigger the install process.

The easiest way is to keep pressing the button without thinking
So add one condition to detect the key has alreay been pressed always.

Signed-off-by: chao zeng <chao.zeng@siemens.com>