### PR TITLE
bugfix:switchserialmode:make sure the settings have time to be set

### DIFF
--- a/recipes-app/switchserialmode/files/src/switchserialmode.c
+++ b/recipes-app/switchserialmode/files/src/switchserialmode.c
@@ -1197,6 +1197,7 @@ static void cp210x_command_handle(int argc, char **argv)
 
 static void cp210x_hardware_reset(void)
 {
+    usleep(60*1000);
     gpio_set("CP2102N-RESET", 0);
     sleep(1);
     gpio_set("CP2102N-RESET", 1);


### PR DESCRIPTION
When switch serial mode, sometimes cp2102n would fall into bootloader mode.
the device can not be identified as /dev/ttyUSB0.

Add a 60ms dealy to make sure the settings have time to be set before reset.

Signed-off-by: chao zeng <chao.zeng@siemens.com>