### PR TITLE
optee-os: align ta_target with u-boot documentation

### DIFF
--- a/recipes-bsp/optee-os/optee-os-iot2050_3.12.0.bb
+++ b/recipes-bsp/optee-os/optee-os-iot2050_3.12.0.bb
@@ -19,7 +19,7 @@ OPTEE_NAME = "iot2050"
 
 OPTEE_PLATFORM = "k3-am65x"
 OPTEE_EXTRA_BUILDARGS = " \
-    CFG_ARM64_core=y CFG_TEE_CORE_LOG_LEVEL=2 ta-targets=ta_arm64 \
+    CFG_ARM64_core=y CFG_TEE_CORE_LOG_LEVEL=2 CFG_USER_TA_TARGETS=ta_arm64 \
     CFG_CONSOLE_UART=1"
 
 dpkg_runbuild_prepend() {


### PR DESCRIPTION
Add CFG_USER_TA_TARGETS instead of ta_targets into optee-os recipe.

https://lists.denx.de/pipermail/u-boot/2021-November/468433.html

Signed-off-by: Ivan Mikhaylov <ivan.mikhaylov@siemens.com>