### PR TITLE
linux-iot2050: The green light is out of control when panic occurs

### DIFF
--- a/recipes-kernel/linux/files/patches-5.10/0001-dmaengine-ti-k3-udma-glue-Add-function-to-get-device.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0001-dmaengine-ti-k3-udma-glue-Add-function-to-get-device.patch
@@ -1,7 +1,7 @@
-From 7a3f7901ac78495fd2deeae885f91cfc784d015f Mon Sep 17 00:00:00 2001
+From 01e9ce59bf86c2b08bf889e98c593943338d2639 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Tue, 8 Dec 2020 11:04:24 +0200
-Subject: [PATCH 001/118] dmaengine: ti: k3-udma-glue: Add function to get
+Subject: [PATCH 001/119] dmaengine: ti: k3-udma-glue: Add function to get
  device pointer for DMA API
 
 Glue layer users should use the device of the DMA for DMA mapping and
@@ -99,5 +99,5 @@ index 5eb34ad973a7..d7c12f31377c 100644
  
  #endif /* K3_UDMA_GLUE_H_ */
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0002-arm64-dts-ti-k3-am65-ringacc-drop-ti-dma-ring-reset-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0002-arm64-dts-ti-k3-am65-ringacc-drop-ti-dma-ring-reset-.patch
@@ -1,7 +1,7 @@
-From 96fa6368bb1f631e3f0007332f3b3e1c9b87acc3 Mon Sep 17 00:00:00 2001
+From 4dd936584d86a8909bb0821edde2f5fed14f8454 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Sat, 29 Aug 2020 21:41:39 +0300
-Subject: [PATCH 002/118] arm64: dts: ti: k3-am65: ringacc: drop ti,
+Subject: [PATCH 002/119] arm64: dts: ti: k3-am65: ringacc: drop ti,
  dma-ring-reset-quirk
 
 Remove obsolete "ti,dma-ring-reset-quirk" Ringacc DT property.
@@ -39,5 +39,5 @@ index 29aaf8dca6f6..044042b166d9 100644
  			ti,sci-dev-id = <195>;
  			msi-parent = <&inta_main_udmass>;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0003-arm64-dts-ti-k3-am65-mcu-Add-MCU-domain-R5F-cluster-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0003-arm64-dts-ti-k3-am65-mcu-Add-MCU-domain-R5F-cluster-.patch
@@ -1,7 +1,7 @@
-From abb99fe6362ea754030fefbb1132fe178b4f3de6 Mon Sep 17 00:00:00 2001
+From ea991c0c066e4e36a4ff2a02341dadad528cb4bc Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 28 Oct 2020 22:37:55 -0500
-Subject: [PATCH 003/118] arm64: dts: ti: k3-am65-mcu: Add MCU domain R5F
+Subject: [PATCH 003/119] arm64: dts: ti: k3-am65-mcu: Add MCU domain R5F
  cluster node
 
 The AM65x SoCs have a single dual-core Arm Cortex-R5F processor (R5FSS)
@@ -95,5 +95,5 @@ index 044042b166d9..7454c8cec0cc 100644
 +	};
  };
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0004-arm64-dts-ti-k3-am65-Cleanup-disabled-nodes-at-SoC-d.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0004-arm64-dts-ti-k3-am65-Cleanup-disabled-nodes-at-SoC-d.patch
@@ -1,7 +1,7 @@
-From 4302aec87ffcd04b3b427cf2c6dd7329e16cd639 Mon Sep 17 00:00:00 2001
+From 238975183e0f413e7e6af536053a9fda457f737e Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Fri, 13 Nov 2020 15:18:22 -0600
-Subject: [PATCH 004/118] arm64: dts: ti: k3-am65*: Cleanup disabled nodes at
+Subject: [PATCH 004/119] arm64: dts: ti: k3-am65*: Cleanup disabled nodes at
  SoC dtsi level
 
 The device tree standard states that when the status property is
@@ -121,5 +121,5 @@ index 937dd7280c7a..8c082af489f5 100644
 +	status = "disabled";
 +};
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0005-arm64-dts-ti-am65-j721e-Fix-up-un-necessary-status-s.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0005-arm64-dts-ti-am65-j721e-Fix-up-un-necessary-status-s.patch
@@ -1,7 +1,7 @@
-From 7e6d0d38dbb9ecaec40c6bd114a190c3c70db701 Mon Sep 17 00:00:00 2001
+From cfc3585ccd5ab224309a94e6318ba1f355a70630 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Fri, 13 Nov 2020 15:18:24 -0600
-Subject: [PATCH 005/118] arm64: dts: ti: am65/j721e: Fix up un-necessary
+Subject: [PATCH 005/119] arm64: dts: ti: am65/j721e: Fix up un-necessary
  status set to "okay" for crypto
 
 The default state of a device tree node is "okay". There is no specific
@@ -44,5 +44,5 @@ index 6ffdebd60122..d386b38b5b0b 100644
  				<&main_udmap 0x4001>;
  		dma-names = "tx", "rx1", "rx2";
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0006-arm64-dts-ti-k3-mmc-fix-dtbs_check-warnings.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0006-arm64-dts-ti-k3-mmc-fix-dtbs_check-warnings.patch
@@ -1,7 +1,7 @@
-From 1e9e0ce5f597a81cb06fe2c9fd6afa6e1b40f28e Mon Sep 17 00:00:00 2001
+From 57f338ecf2bde7ac33333ec67649d3d0630d316b Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 15 Jan 2021 21:30:16 +0200
-Subject: [PATCH 006/118] arm64: dts: ti: k3: mmc: fix dtbs_check warnings
+Subject: [PATCH 006/119] arm64: dts: ti: k3: mmc: fix dtbs_check warnings
 
 Now the dtbs_check produces below warnings
  sdhci@4f80000: clock-names:0: 'clk_ahb' was expected
@@ -129,5 +129,5 @@ index d386b38b5b0b..4f8bbad8731c 100644
  		assigned-clock-parents = <&k3_clks 93 1>;
  		ti,otap-del-sel = <0x2>;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0007-arm64-dts-ti-k3-am65-main-Add-device_type-to-pcie-_r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0007-arm64-dts-ti-k3-am65-main-Add-device_type-to-pcie-_r.patch
@@ -1,7 +1,7 @@
-From df5654b83079b816f97e59f22442451783c7ee16 Mon Sep 17 00:00:00 2001
+From 96a6d6ce628aa74e6a0038b4d5189a4613bdae4a Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Feb 2021 20:32:56 +0100
-Subject: [PATCH 007/118] arm64: dts: ti: k3-am65-main: Add device_type to
+Subject: [PATCH 007/119] arm64: dts: ti: k3-am65-main: Add device_type to
  pcie*_rc nodes
 
 This is demanded by the parent binding of ti,am654-pcie-rc, see
@@ -36,5 +36,5 @@ index 29c647f35464..00cd06ff98ee 100644
  
  	pcie1_ep: pcie-ep@5600000 {
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0008-arm64-dts-ti-k3-am65-main-Add-ICSSG-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0008-arm64-dts-ti-k3-am65-main-Add-ICSSG-nodes.patch
@@ -1,7 +1,7 @@
-From 4e181216098a40fb76f7c63e0798e56d47282c22 Mon Sep 17 00:00:00 2001
+From eea612d75cd528a085aa3a9da195904ca11355ca Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Thu, 4 Mar 2021 10:07:11 -0600
-Subject: [PATCH 008/118] arm64: dts: ti: k3-am65-main: Add ICSSG nodes
+Subject: [PATCH 008/119] arm64: dts: ti: k3-am65-main: Add ICSSG nodes
 
 Add the DT nodes for the ICSSG0, ICSSG1 and ICSSG2 processor subsystems
 that are present on the K3 AM65x SoCs. The three ICSSGs are identical
@@ -475,5 +475,5 @@ index 00cd06ff98ee..67047f108130 100644
 +	};
  };
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0009-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0009-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
@@ -1,7 +1,7 @@
-From 6826a5ba8b482fc4bb5becef8f96c1b3db910724 Mon Sep 17 00:00:00 2001
+From 258543f44587124e0f84f8152e233e613a57e24b Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 20 Feb 2021 13:49:51 +0100
-Subject: [PATCH 009/118] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
+Subject: [PATCH 009/119] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
 
 Add the DT entry for a watchdog based on RTI1.
 
@@ -37,5 +37,5 @@ index 7454c8cec0cc..0388c02c2203 100644
 +	};
  };
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0010-arm64-dts-ti-Add-support-for-Siemens-IOT2050-boards.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0010-arm64-dts-ti-Add-support-for-Siemens-IOT2050-boards.patch
@@ -1,7 +1,7 @@
-From 1d669c763d4615e124e9bb7dc69d2e2ceff06f1b Mon Sep 17 00:00:00 2001
+From 72d60c59aa0dfd9d00f56a9a49f5b8890a8f813e Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Mar 2021 15:33:43 +0100
-Subject: [PATCH 010/118] arm64: dts: ti: Add support for Siemens IOT2050
+Subject: [PATCH 010/119] arm64: dts: ti: Add support for Siemens IOT2050
  boards
 
 Add support for two Siemens SIMATIC IOT2050 variants, Basic and
@@ -836,5 +836,5 @@ index 000000000000..ec9617c13cdb
 +	status = "disabled";
 +};
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0011-arm64-dts-ti-k3-am65-j721e-am64-Map-the-dma-navigato.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0011-arm64-dts-ti-k3-am65-j721e-am64-Map-the-dma-navigato.patch
@@ -1,7 +1,7 @@
-From 4f6a29565478e48baca234f7db41423f24b369e7 Mon Sep 17 00:00:00 2001
+From f4e51edaa1af45928c241279e566fca23a26dc5f Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Mon, 10 May 2021 09:54:29 -0500
-Subject: [PATCH 011/118] arm64: dts: ti: k3-am65|j721e|am64: Map the dma /
+Subject: [PATCH 011/119] arm64: dts: ti: k3-am65|j721e|am64: Map the dma /
  navigator subsystem via explicit ranges
 
 Instead of using empty ranges property, lets map explicitly the address
@@ -102,5 +102,5 @@ index e581cb1d87ee..d766c7fe02af 100644
  		dma-ranges;
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0012-arm64-dts-ti-k3-Introduce-reg-definition-for-interru.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0012-arm64-dts-ti-k3-Introduce-reg-definition-for-interru.patch
@@ -1,7 +1,7 @@
-From 9459f7de770e30b4e1c6cb3497878980ae201dbb Mon Sep 17 00:00:00 2001
+From 957e51e66f17e9078f496880be1a1dc8eacac8fc Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Tue, 11 May 2021 14:48:21 -0500
-Subject: [PATCH 012/118] arm64: dts: ti: k3*: Introduce reg definition for
+Subject: [PATCH 012/119] arm64: dts: ti: k3*: Introduce reg definition for
  interrupt routers
 
 Interrupt routers are memory mapped peripherals, that are organized
@@ -162,5 +162,5 @@ index d766c7fe02af..282bbdc359ac 100644
  		interrupt-controller;
  		interrupt-parent = <&gic500>;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0013-mmc-sdhci_am654-Use-pm_runtime_resume_and_get-to-rep.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0013-mmc-sdhci_am654-Use-pm_runtime_resume_and_get-to-rep.patch
@@ -1,7 +1,7 @@
-From 7dece4acefd346f3d91dac239f472fa677a03cc8 Mon Sep 17 00:00:00 2001
+From 837bb3f0f6799a9389bc4914af3f1efcc6929d00 Mon Sep 17 00:00:00 2001
 From: Tian Tao <tiantao6@hisilicon.com>
 Date: Fri, 21 May 2021 08:59:35 +0800
-Subject: [PATCH 013/118] mmc: sdhci_am654: Use pm_runtime_resume_and_get() to
+Subject: [PATCH 013/119] mmc: sdhci_am654: Use pm_runtime_resume_and_get() to
  replace open coding
 
 use pm_runtime_resume_and_get() to replace pm_runtime_get_sync and
@@ -34,5 +34,5 @@ index a64ea143d185..c4799a16a61f 100644
  	base = devm_platform_ioremap_resource(pdev, 1);
  	if (IS_ERR(base)) {
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0014-arm64-dts-ti-k3-am65-iot2050-common-Disable-mailbox-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0014-arm64-dts-ti-k3-am65-iot2050-common-Disable-mailbox-.patch
@@ -1,7 +1,7 @@
-From d9f8c6d7080aa8afa64c5a62e2f31bed8bb1cec9 Mon Sep 17 00:00:00 2001
+From 0e7ebb8d053743475f129334dd6bf1b6a9cde1b0 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 14 May 2021 16:20:16 -0500
-Subject: [PATCH 014/118] arm64: dts: ti: k3-am65-iot2050-common: Disable
+Subject: [PATCH 014/119] arm64: dts: ti: k3-am65-iot2050-common: Disable
  mailbox nodes
 
 There are no sub-mailbox devices defined currently for both the
@@ -80,5 +80,5 @@ index de763ca9251c..f4ec9ed52939 100644
 +	status = "disabled";
 +};
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0015-arm64-dts-ti-k3-am65-Add-support-for-UHS-I-modes-in-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0015-arm64-dts-ti-k3-am65-Add-support-for-UHS-I-modes-in-.patch
@@ -1,7 +1,7 @@
-From 439502cf5032deed64467ae37e47ff9ecc9bee25 Mon Sep 17 00:00:00 2001
+From db9ebd9365b0285ae3ea5f7e2a5d356e21a94f60 Mon Sep 17 00:00:00 2001
 From: Aswath Govindraju <a-govindraju@ti.com>
 Date: Sat, 29 May 2021 09:07:49 +0530
-Subject: [PATCH 015/118] arm64: dts: ti: k3-am65: Add support for UHS-I modes
+Subject: [PATCH 015/119] arm64: dts: ti: k3-am65: Add support for UHS-I modes
  in MMCSD1 subsystem
 
 UHS-I speed modes are supported in AM65 S.R. 2.0 SoC[1].
@@ -108,5 +108,5 @@ index 8c082af489f5..fea6a8243d75 100644
  	pinctrl-0 = <&main_mmc1_pins_default>;
  	ti,driver-strength-ohm = <50>;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0016-arm64-dts-ti-k3-am65-main-Add-ICSSG-MDIO-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0016-arm64-dts-ti-k3-am65-main-Add-ICSSG-MDIO-nodes.patch
@@ -1,7 +1,7 @@
-From 868dc7de7c92cb29d6302760fa77c73bf16e6248 Mon Sep 17 00:00:00 2001
+From e4ae555b623fdbbaddf5c9f23dd71b99671bbd3f Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 1 Jun 2021 10:00:31 -0500
-Subject: [PATCH 016/118] arm64: dts: ti: k3-am65-main: Add ICSSG MDIO nodes
+Subject: [PATCH 016/119] arm64: dts: ti: k3-am65-main: Add ICSSG MDIO nodes
 
 The ICSSGs on K3 AM65x SoCs contain an MDIO controller that can
 be used to control external PHYs associated with the Industrial
@@ -125,5 +125,5 @@ index fea6a8243d75..b47fc2a1e59d 100644
 +	status = "disabled";
 +};
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0017-arm64-dts-ti-iot2050-Configure-r5f-cluster-on-basic-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0017-arm64-dts-ti-iot2050-Configure-r5f-cluster-on-basic-.patch
@@ -1,7 +1,7 @@
-From d73a5ea673496131b8478859308e9f12d4c438e5 Mon Sep 17 00:00:00 2001
+From 556b2d71ef9e152a2072c162a7d0c284152c8aa0 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 2 Jun 2021 08:56:15 +0200
-Subject: [PATCH 017/118] arm64: dts: ti: iot2050: Configure r5f cluster on
+Subject: [PATCH 017/119] arm64: dts: ti: iot2050: Configure r5f cluster on
  basic variant in split mode
 
 Lockstep mode is not supported here. So turn it off to avoid warnings
@@ -28,5 +28,5 @@ index 4f7e3f2a6265..94bb5dd39122 100644
 +	ti,cluster-mode = <0>;
 +};
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0018-arm64-dts-ti-am65-align-ti-pindir-d0-out-d1-in-prope.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0018-arm64-dts-ti-am65-align-ti-pindir-d0-out-d1-in-prope.patch
@@ -1,7 +1,7 @@
-From 78d7a8954f39ac89d7a86fb379286878cc09cfa6 Mon Sep 17 00:00:00 2001
+From 512ed5c0763e769345e9b43dd060c3ff46f58077 Mon Sep 17 00:00:00 2001
 From: Aswath Govindraju <a-govindraju@ti.com>
 Date: Tue, 8 Jun 2021 10:44:13 +0530
-Subject: [PATCH 018/118] arm64: dts: ti: am65: align ti,pindir-d0-out-d1-in
+Subject: [PATCH 018/119] arm64: dts: ti: am65: align ti,pindir-d0-out-d1-in
  property with dt-shema
 
 ti,pindir-d0-out-d1-in property is expected to be of type boolean.
@@ -46,5 +46,5 @@ index b47fc2a1e59d..56dc855a5f13 100644
  	flash@0{
  		compatible = "jedec,spi-nor";
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0019-firmware-ti_sci-rm-Add-support-for-tx_tdtype-paramet.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0019-firmware-ti_sci-rm-Add-support-for-tx_tdtype-paramet.patch
@@ -1,7 +1,7 @@
-From 201581a7c6ca8d91135a3b594ae3c903d4e205f6 Mon Sep 17 00:00:00 2001
+From 7d784d6362d1f27e18d9f4c11b85ab073446ccff Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:02 -0700
-Subject: [PATCH 019/118] firmware: ti_sci: rm: Add support for tx_tdtype
+Subject: [PATCH 019/119] firmware: ti_sci: rm: Add support for tx_tdtype
  parameter for tx channel
 
 The system controller's resource manager have support for configuring the
@@ -86,5 +86,5 @@ index cf27b080e148..d254d99fd45b 100644
  
  /**
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0020-firmware-ti_sci-Use-struct-ti_sci_resource_desc-in-g.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0020-firmware-ti_sci-Use-struct-ti_sci_resource_desc-in-g.patch
@@ -1,7 +1,7 @@
-From a964810f23910b5c1c0a85ee7ea6f1ade83d05ba Mon Sep 17 00:00:00 2001
+From 1939821030a64d73e8a5c4d0a955cab1ff7285d8 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:03 -0700
-Subject: [PATCH 020/118] firmware: ti_sci: Use struct ti_sci_resource_desc in
+Subject: [PATCH 020/119] firmware: ti_sci: Use struct ti_sci_resource_desc in
  get_range ops
 
 Use the ti_sci_resource_desc directly and update it's start and num members
@@ -177,5 +177,5 @@ index d254d99fd45b..6cd537db4d33 100644
   * struct ti_sci_resource - Structure representing a resource assigned
   *			    to a device.
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0021-firmware-ti_sci-rm-Add-support-for-second-resource-r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0021-firmware-ti_sci-rm-Add-support-for-second-resource-r.patch
@@ -1,7 +1,7 @@
-From 77148768c1ca36782540b068bdfb8e7b7632fcc7 Mon Sep 17 00:00:00 2001
+From 4aa598294cb857cc994b45b57205a4ea674caac5 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:03 -0700
-Subject: [PATCH 021/118] firmware: ti_sci: rm: Add support for second resource
+Subject: [PATCH 021/119] firmware: ti_sci: rm: Add support for second resource
  range
 
 Sysfw added support for a second range in the resource range API to be able
@@ -174,5 +174,5 @@ index 6cd537db4d33..9699b260de59 100644
  };
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0022-soc-ti-ti_sci_inta_msi-Add-support-for-second-range-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0022-soc-ti-ti_sci_inta_msi-Add-support-for-second-range-.patch
@@ -1,7 +1,7 @@
-From 3ad8a348de3d87f0a47ad87b6088a922bd4d02d3 Mon Sep 17 00:00:00 2001
+From f483145bc39186de85342f51c41f10f36f76ca11 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:04 -0700
-Subject: [PATCH 022/118] soc: ti: ti_sci_inta_msi: Add support for second
+Subject: [PATCH 022/119] soc: ti: ti_sci_inta_msi: Add support for second
  range in resource ranges
 
 Allocate MSI entries for both first and second range if they are valid
@@ -36,5 +36,5 @@ index 0eb9462f609e..a1d9c027022a 100644
  
  	return count;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0023-firmware-ti_sci-rm-Add-support-for-extended_ch_type-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0023-firmware-ti_sci-rm-Add-support-for-extended_ch_type-.patch
@@ -1,7 +1,7 @@
-From 9f3de90dc04ed00b3185b4c9c3a476968329f350 Mon Sep 17 00:00:00 2001
+From ea9cb6a950b09bd9d01d616119027a6861a09ffa Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:05 -0700
-Subject: [PATCH 023/118] firmware: ti_sci: rm: Add support for
+Subject: [PATCH 023/119] firmware: ti_sci: rm: Add support for
  extended_ch_type for tx channel
 
 Sysfw added 'extended_ch_type' to the tx_ch_cfg_req message which should be
@@ -91,5 +91,5 @@ index 9699b260de59..6978afc00823 100644
  
  /**
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0024-firmware-ti_sci-rm-Remove-ring_get_config-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0024-firmware-ti_sci-rm-Remove-ring_get_config-support.patch
@@ -1,7 +1,7 @@
-From 3a14e51fc33f0a5cdde74486ca6785b53c44e56b Mon Sep 17 00:00:00 2001
+From d54c9e4d20c866315fde8157f6138505b89cff37 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:05 -0700
-Subject: [PATCH 024/118] firmware: ti_sci: rm: Remove ring_get_config support
+Subject: [PATCH 024/119] firmware: ti_sci: rm: Remove ring_get_config support
 
 The ring_get_cfg (0x1111 message) is not used and it is not supported by
 sysfw for a long time.
@@ -200,5 +200,5 @@ index 6978afc00823..6710d7ac7a72 100644
  
  /**
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0025-firmware-ti_sci-rm-Add-new-ops-for-ring-configuratio.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0025-firmware-ti_sci-rm-Add-new-ops-for-ring-configuratio.patch
@@ -1,7 +1,7 @@
-From c59c747aea59df711bf35a368ccecb8ed6970792 Mon Sep 17 00:00:00 2001
+From 7b963933fe2c83a7f0592861dc822dbdcb904e3b Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:06 -0700
-Subject: [PATCH 025/118] firmware: ti_sci: rm: Add new ops for ring
+Subject: [PATCH 025/119] firmware: ti_sci: rm: Add new ops for ring
  configuration
 
 The sysfw ring configuration message has been extended to include virtid
@@ -198,5 +198,5 @@ index 6710d7ac7a72..d1711050cd9d 100644
  
  /**
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0026-soc-ti-k3-ringacc-Use-the-ti_sci-set_cfg-callback-fo.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0026-soc-ti-k3-ringacc-Use-the-ti_sci-set_cfg-callback-fo.patch
@@ -1,7 +1,7 @@
-From e67f7ab42c598740da245f461cb44e63ad743440 Mon Sep 17 00:00:00 2001
+From c942edd119598c35598ce9e63fea4d23b408f896 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:07 -0700
-Subject: [PATCH 026/118] soc: ti: k3-ringacc: Use the ti_sci set_cfg callback
+Subject: [PATCH 026/119] soc: ti: k3-ringacc: Use the ti_sci set_cfg callback
  for ring configuration
 
 Switch to the new set_cfg to configure the ring.
@@ -142,5 +142,5 @@ index 1147dc4c1d59..9ddd77113c5a 100644
  	return ret;
  }
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0027-firmware-ti_sci-rm-Remove-unused-config-from-ti_sci_.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0027-firmware-ti_sci-rm-Remove-unused-config-from-ti_sci_.patch
@@ -1,7 +1,7 @@
-From b52a49d481aedcfee6a30b772b39038fd9c83a12 Mon Sep 17 00:00:00 2001
+From 4985c5c2e7897851743097725e63473c2a8bc7cf Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:07 -0700
-Subject: [PATCH 027/118] firmware: ti_sci: rm: Remove unused config() from
+Subject: [PATCH 027/119] firmware: ti_sci: rm: Remove unused config() from
  ti_sci_rm_ringacc_ops
 
 The ringacc driver has been converted to use the new set_cfg function to
@@ -127,5 +127,5 @@ index d1711050cd9d..0aad7009b50e 100644
  		       const struct ti_sci_msg_rm_ring_cfg *params);
  };
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0028-soc-ti-k3-ringacc-Use-correct-device-for-allocation-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0028-soc-ti-k3-ringacc-Use-correct-device-for-allocation-.patch
@@ -1,7 +1,7 @@
-From 0178e1728745fc4a911b02c347eef9692ee84013 Mon Sep 17 00:00:00 2001
+From aced7f7f91159d1e6106e31f5b923dbca5f8efe1 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:22 -0700
-Subject: [PATCH 028/118] soc: ti: k3-ringacc: Use correct device for
+Subject: [PATCH 028/119] soc: ti: k3-ringacc: Use correct device for
  allocation in RING mode
 
 In RING mode the ringacc does not access the ring memory. In this access
@@ -126,5 +126,5 @@ index 5a472eca5ee4..658dc71d2901 100644
  
  #define K3_RINGACC_RING_ID_ANY (-1)
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0029-soc-ti-pruss-Remove-wrong-check-against-get_match_da.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0029-soc-ti-pruss-Remove-wrong-check-against-get_match_da.patch
@@ -1,7 +1,7 @@
-From 3c43cf32b8651a36ee609e9e8d38c3cf93ed94c1 Mon Sep 17 00:00:00 2001
+From f9d7760e5e4da7f5656f6fff424b80aa9f0b9597 Mon Sep 17 00:00:00 2001
 From: Grzegorz Jaszczyk <grzegorz.jaszczyk@linaro.org>
 Date: Sat, 21 Nov 2020 19:22:25 -0800
-Subject: [PATCH 029/118] soc: ti: pruss: Remove wrong check against
+Subject: [PATCH 029/119] soc: ti: pruss: Remove wrong check against
  *get_match_data return value
 
 Since the of_device_get_match_data() doesn't return error code, remove
@@ -43,5 +43,5 @@ index cc0b4ad7a3d3..5d6e7132a5c4 100644
  	ret = dma_set_coherent_mask(dev, DMA_BIT_MASK(32));
  	if (ret) {
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0030-soc-ti-pruss-Correct-the-pruss_clk_init-error-trace-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0030-soc-ti-pruss-Correct-the-pruss_clk_init-error-trace-.patch
@@ -1,7 +1,7 @@
-From 09f68ee7d4a5be640db99ed9c56baa9cff032e98 Mon Sep 17 00:00:00 2001
+From 1d1d75b27ffac979973888266704897cc27a52d0 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 24 Jan 2021 20:51:37 -0800
-Subject: [PATCH 030/118] soc: ti: pruss: Correct the pruss_clk_init error
+Subject: [PATCH 030/119] soc: ti: pruss: Correct the pruss_clk_init error
  trace text
 
 The pruss_clk_init() function can register more than one clock.
@@ -28,5 +28,5 @@ index 5d6e7132a5c4..1d6890134312 100644
  	}
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0031-soc-ti-pruss-Refactor-the-CFG-sub-module-init.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0031-soc-ti-pruss-Refactor-the-CFG-sub-module-init.patch
@@ -1,7 +1,7 @@
-From 408da169fd05954f67422b69c182c59543570327 Mon Sep 17 00:00:00 2001
+From c0b27a001f9ccb7565ae6c9d40d7ab8040b4f14b Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 31 Jan 2021 20:53:43 -0800
-Subject: [PATCH 031/118] soc: ti: pruss: Refactor the CFG sub-module init
+Subject: [PATCH 031/119] soc: ti: pruss: Refactor the CFG sub-module init
 
 The CFG sub-module is not present on some earlier SoCs like the
 DA850/OMAPL-138 in the TI Davinci family. Refactor out the CFG
@@ -134,5 +134,5 @@ index 1d6890134312..f22ac1edbdd0 100644
  	pm_runtime_put_sync(dev);
  rpm_disable:
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0032-soc-ti-k3-ringacc-Use-of_device_get_match_data.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0032-soc-ti-k3-ringacc-Use-of_device_get_match_data.patch
@@ -1,7 +1,7 @@
-From e75c57ddd0d2dca8a719d1c7de1664692cceccb4 Mon Sep 17 00:00:00 2001
+From 4ae941e095393c63738be485c5efa9b2b64523c9 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 31 Jan 2021 20:58:49 -0800
-Subject: [PATCH 032/118] soc: ti: k3-ringacc: Use of_device_get_match_data()
+Subject: [PATCH 032/119] soc: ti: k3-ringacc: Use of_device_get_match_data()
 
 Simplify the retrieval of getting the match data in the probe
 function by directly using of_device_get_match_data() instead
@@ -44,5 +44,5 @@ index 7fdb688452f7..db3f705da7a0 100644
  	ringacc = devm_kzalloc(dev, sizeof(*ringacc), GFP_KERNEL);
  	if (!ringacc)
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0033-remoteproc-ti_k3-fix-Wcast-function-type-warning.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0033-remoteproc-ti_k3-fix-Wcast-function-type-warning.patch
@@ -1,7 +1,7 @@
-From 780cbbda3b4d6844474068cc0b9b96b574944829 Mon Sep 17 00:00:00 2001
+From b0c09a8eb070e520cfff62925a737892fabe1c33 Mon Sep 17 00:00:00 2001
 From: Arnd Bergmann <arnd@arndb.de>
 Date: Mon, 26 Oct 2020 17:05:23 +0100
-Subject: [PATCH 033/118] remoteproc: ti_k3: fix -Wcast-function-type warning
+Subject: [PATCH 033/119] remoteproc: ti_k3: fix -Wcast-function-type warning
 
 The function cast causes a warning with "make W=1"
 
@@ -79,5 +79,5 @@ index afeb9d6e4313..b68384455726 100644
  		return ret;
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0034-remoteproc-Add-a-rproc_set_firmware-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0034-remoteproc-Add-a-rproc_set_firmware-API.patch
@@ -1,7 +1,7 @@
-From 45c511cd51003520e278a4d9ef58f4eec6873cdf Mon Sep 17 00:00:00 2001
+From a7aeff02164ef9414676e72cb62b91f7f3f2d8c0 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 20 Nov 2020 21:20:42 -0600
-Subject: [PATCH 034/118] remoteproc: Add a rproc_set_firmware() API
+Subject: [PATCH 034/119] remoteproc: Add a rproc_set_firmware() API
 
 A new API, rproc_set_firmware() is added to allow the remoteproc platform
 drivers and remoteproc client drivers to be able to configure a custom
@@ -159,5 +159,5 @@ index 3fa3ba6498e8..e8ac041c64d9 100644
  int rproc_coredump_add_segment(struct rproc *rproc, dma_addr_t da, size_t size);
  int rproc_coredump_add_custom_segment(struct rproc *rproc,
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0035-remoteproc-pru-Add-a-PRU-remoteproc-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0035-remoteproc-pru-Add-a-PRU-remoteproc-driver.patch
@@ -1,7 +1,7 @@
-From f8f8c77fc640e76591c659ed34ce024c70f940c8 Mon Sep 17 00:00:00 2001
+From 208ed278bdd0977cc36b808e7209800df37028fd Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:09:58 +0100
-Subject: [PATCH 035/118] remoteproc: pru: Add a PRU remoteproc driver
+Subject: [PATCH 035/119] remoteproc: pru: Add a PRU remoteproc driver
 
 The Programmable Real-Time Unit Subsystem (PRUSS) consists of
 dual 32-bit RISC cores (Programmable Real-Time Units, or PRUs)
@@ -524,5 +524,5 @@ index 000000000000..d33392bbd8af
 +MODULE_DESCRIPTION("PRU-ICSS Remote Processor Driver");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0036-remoteproc-pru-Add-support-for-PRU-specific-interrup.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0036-remoteproc-pru-Add-support-for-PRU-specific-interrup.patch
@@ -1,7 +1,7 @@
-From 689e7258ae463d74c1d0d11818407e0f3993cd8f Mon Sep 17 00:00:00 2001
+From 3a5b04fa54dd05cf16c13511c09cac02e70d6f08 Mon Sep 17 00:00:00 2001
 From: Grzegorz Jaszczyk <grzegorz.jaszczyk@linaro.org>
 Date: Tue, 8 Dec 2020 15:09:59 +0100
-Subject: [PATCH 036/118] remoteproc: pru: Add support for PRU specific
+Subject: [PATCH 036/119] remoteproc: pru: Add support for PRU specific
  interrupt configuration
 
 The firmware blob can contain optional ELF sections: .resource_table
@@ -352,5 +352,5 @@ index 000000000000..8ee9c3171610
 +
 +#endif	/* _PRU_RPROC_H_ */
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0037-remoteproc-pru-Add-pru-specific-debugfs-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0037-remoteproc-pru-Add-pru-specific-debugfs-support.patch
@@ -1,7 +1,7 @@
-From 3d9f8312393731a7cc7fee70364e98a29ef4399f Mon Sep 17 00:00:00 2001
+From 9bef37e249a924af620df1d77ac03c24832bbf4d Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:10:00 +0100
-Subject: [PATCH 037/118] remoteproc: pru: Add pru-specific debugfs support
+Subject: [PATCH 037/119] remoteproc: pru: Add pru-specific debugfs support
 
 The remoteproc core creates certain standard debugfs entries,
 that does not give a whole lot of useful information for the
@@ -223,5 +223,5 @@ index 72e64d15f0dc..59240fd82f56 100644
  
  	return 0;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0038-remoteproc-pru-Add-support-for-various-PRU-cores-on-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0038-remoteproc-pru-Add-support-for-various-PRU-cores-on-.patch
@@ -1,7 +1,7 @@
-From 3dd1224abd96d69a312a3fd5b87523570296fdb0 Mon Sep 17 00:00:00 2001
+From 778c7321793634cff527365d4291264a46637af1 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:10:01 +0100
-Subject: [PATCH 038/118] remoteproc: pru: Add support for various PRU cores on
+Subject: [PATCH 038/119] remoteproc: pru: Add support for various PRU cores on
  K3 AM65x SoCs
 
 The K3 AM65x family of SoCs have the next generation of the PRU-ICSS
@@ -294,5 +294,5 @@ index 59240fd82f56..421ebbc1c02d 100644
  };
  MODULE_DEVICE_TABLE(of, pru_rproc_match);
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0039-remoteproc-pru-Fix-loading-of-GNU-Binutils-ELF.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0039-remoteproc-pru-Fix-loading-of-GNU-Binutils-ELF.patch
@@ -1,7 +1,7 @@
-From 74f1f0137b0dc47119f03920083b24b6d07c9cc9 Mon Sep 17 00:00:00 2001
+From 029c68725a6a84189163c36921f996f4dfa10313 Mon Sep 17 00:00:00 2001
 From: Dimitar Dimitrov <dimitar@dinux.eu>
 Date: Wed, 30 Dec 2020 12:50:05 +0200
-Subject: [PATCH 039/118] remoteproc: pru: Fix loading of GNU Binutils ELF
+Subject: [PATCH 039/119] remoteproc: pru: Fix loading of GNU Binutils ELF
 
 PRU port of GNU Binutils lacks support for separate address spaces.
 PRU IRAM addresses are marked with artificial offset to differentiate
@@ -48,5 +48,5 @@ index 421ebbc1c02d..a113e150d5d5 100644
  	    da + len <= PRU_IRAM_DA + pru->mem_regions[PRU_IOMEM_IRAM].size) {
  		offset = da - PRU_IRAM_DA;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0040-remoteproc-pru-Fix-firmware-loading-crashes-on-K3-So.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0040-remoteproc-pru-Fix-firmware-loading-crashes-on-K3-So.patch
@@ -1,7 +1,7 @@
-From 2fdf087d6ea8bdf0d79f1f028c88aff534a7682f Mon Sep 17 00:00:00 2001
+From 0d383f35f8c8f604cd28924e2ebc456937796158 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Mon, 15 Mar 2021 15:58:59 -0500
-Subject: [PATCH 040/118] remoteproc: pru: Fix firmware loading crashes on K3
+Subject: [PATCH 040/119] remoteproc: pru: Fix firmware loading crashes on K3
  SoCs
 
 The K3 PRUs are 32-bit processors and in general have some limitations
@@ -36,5 +36,5 @@ index a113e150d5d5..21105592a83d 100644
  					       filesz);
  			if (ret) {
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0041-remoteproc-pru-Fixup-interrupt-parent-logic-for-fw-e.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0041-remoteproc-pru-Fixup-interrupt-parent-logic-for-fw-e.patch
@@ -1,7 +1,7 @@
-From 73cf263b9f828611c8a9bb8cc4146e5b5e1f53fd Mon Sep 17 00:00:00 2001
+From 6bf4f199019674b565fd2e4bcd03945871bde936 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:39 -0500
-Subject: [PATCH 041/118] remoteproc: pru: Fixup interrupt-parent logic for fw
+Subject: [PATCH 041/119] remoteproc: pru: Fixup interrupt-parent logic for fw
  events
 
 The PRU firmware interrupt mapping logic in pru_handle_intrmap() uses
@@ -74,5 +74,5 @@ index 21105592a83d..773c09d01958 100644
  	return ret;
  }
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0042-remoteproc-pru-Fix-wrong-success-return-value-for-fw.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0042-remoteproc-pru-Fix-wrong-success-return-value-for-fw.patch
@@ -1,7 +1,7 @@
-From f8decd3cc37f9b4058336e905537ef13d26a778e Mon Sep 17 00:00:00 2001
+From 48381160333cca6de0dfbad26e8e95a0b8431a23 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:40 -0500
-Subject: [PATCH 042/118] remoteproc: pru: Fix wrong success return value for
+Subject: [PATCH 042/119] remoteproc: pru: Fix wrong success return value for
  fw events
 
 The irq_create_fwspec_mapping() returns a proper virq value on success
@@ -41,5 +41,5 @@ index 773c09d01958..e0c5fce8bccd 100644
  		}
  	}
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0043-remoteproc-pru-Fix-and-cleanup-firmware-interrupt-ma.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0043-remoteproc-pru-Fix-and-cleanup-firmware-interrupt-ma.patch
@@ -1,7 +1,7 @@
-From 24dffa08a60dd035ca7ebc84c2ff1f24ea1c02ba Mon Sep 17 00:00:00 2001
+From b7c543aad3fd3f9e52435069371da7a79d45e653 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:41 -0500
-Subject: [PATCH 043/118] remoteproc: pru: Fix and cleanup firmware interrupt
+Subject: [PATCH 043/119] remoteproc: pru: Fix and cleanup firmware interrupt
  mapping logic
 
 The PRU firmware interrupt mappings are configured and unconfigured in
@@ -95,5 +95,5 @@ index e0c5fce8bccd..d8597027a93e 100644
  	return 0;
  }
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0044-watchdog-Start-watchdog-in-watchdog_set_last_hw_keep.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0044-watchdog-Start-watchdog-in-watchdog_set_last_hw_keep.patch
@@ -1,7 +1,7 @@
-From a70f71435aeb270461b903fbac329c5dbe5b8f53 Mon Sep 17 00:00:00 2001
+From fdefc948f42dbf4fc3e3d89a5b9df4e29129355b Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 30 Jul 2021 21:19:38 +0200
-Subject: [PATCH 044/118] watchdog: Start watchdog in
+Subject: [PATCH 044/119] watchdog: Start watchdog in
  watchdog_set_last_hw_keepalive only if appropriate
 
 We must not pet a running watchdog when handle_boot_enabled is off
@@ -33,5 +33,5 @@ index 2946f3a63110..2ee017442dfc 100644
  EXPORT_SYMBOL_GPL(watchdog_set_last_hw_keepalive);
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0045-arm64-dts-ti-iot2050-Flip-mmc-device-ordering-on-Adv.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0045-arm64-dts-ti-iot2050-Flip-mmc-device-ordering-on-Adv.patch
@@ -1,7 +1,7 @@
-From abc18492a5539993d5285a556e4a9126b96a2570 Mon Sep 17 00:00:00 2001
+From 7e32ce311f4c7b26afc0e9cf7c37c97c16da4984 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 1 Sep 2021 21:52:11 +0200
-Subject: [PATCH 045/118] arm64: dts: ti: iot2050: Flip mmc device ordering on
+Subject: [PATCH 045/119] arm64: dts: ti: iot2050: Flip mmc device ordering on
  Advanced devices
 
 This ensures that the SD card will remain mmc0 across Basic and Advanced
@@ -27,5 +27,5 @@ index 1008e9162ba2..6261ca8ee2d8 100644
  
  	chosen {
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0046-arm64-dts-ti-iot2050-Disable-SR2.0-only-PRUs.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0046-arm64-dts-ti-iot2050-Disable-SR2.0-only-PRUs.patch
@@ -1,7 +1,7 @@
-From 2fb0050859879e563c0a76dfd461decb9cfc95a7 Mon Sep 17 00:00:00 2001
+From 66f95e028febab82fca7197aee585849dae8f678 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 1 Sep 2021 19:58:30 +0200
-Subject: [PATCH 046/118] arm64: dts: ti: iot2050: Disable SR2.0-only PRUs
+Subject: [PATCH 046/119] arm64: dts: ti: iot2050: Disable SR2.0-only PRUs
 
 The IOT2050 devices described so far are using SR1.0 silicon, thus do
 not have the additional PRUs of the ICSSG of the SR2.0. Disable them.
@@ -44,5 +44,5 @@ index 6261ca8ee2d8..58c8e64d5885 100644
 +	status = "disabled";
 +};
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0047-arm64-dts-ti-iot2050-Add-enabled-mailboxes-and-carve.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0047-arm64-dts-ti-iot2050-Add-enabled-mailboxes-and-carve.patch
@@ -1,7 +1,7 @@
-From cdf6fc8692ded5de1f07b5bf57b913f8d09fcb71 Mon Sep 17 00:00:00 2001
+From 20997c5bfc263e7b76a5e5b157ba6a1552180c46 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 9 Sep 2021 08:01:16 +0200
-Subject: [PATCH 047/118] arm64: dts: ti: iot2050: Add/enabled mailboxes and
+Subject: [PATCH 047/119] arm64: dts: ti: iot2050: Add/enabled mailboxes and
  carve-outs for R5F cores
 
 Analogously to the am654-base-board, configure the mailboxes for the the
@@ -62,5 +62,5 @@ index 58c8e64d5885..b29537088289 100644
  	status = "disabled";
  };
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0048-arm64-dts-ti-iot2050-Prepare-for-adding-2nd-generati.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0048-arm64-dts-ti-iot2050-Prepare-for-adding-2nd-generati.patch
@@ -1,7 +1,7 @@
-From fe440dc4af4e1455d7d8aeb593061561a53f1de0 Mon Sep 17 00:00:00 2001
+From 23e27c7b0a8d97307e38656dd8a1bca4e38670dc Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 7 Sep 2021 17:49:55 +0200
-Subject: [PATCH 048/118] arm64: dts: ti: iot2050: Prepare for adding
+Subject: [PATCH 048/119] arm64: dts: ti: iot2050: Prepare for adding
  2nd-generation boards
 
 The current IOT2050 devices are Product Generation 1 (PG1), using SR1.0
@@ -14,16 +14,16 @@ dts files.
 
 Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
 ---
- .../dts/ti/k3-am65-iot2050-common-pg1.dtsi    | 46 +++++++++++++++
- .../boot/dts/ti/k3-am65-iot2050-common.dtsi   | 35 +-----------
- ...ts => k3-am6528-iot2050-basic-common.dtsi} | 12 +---
- .../boot/dts/ti/k3-am6528-iot2050-basic.dts   | 56 +++----------------
- ...=> k3-am6548-iot2050-advanced-common.dtsi} |  8 +--
- .../dts/ti/k3-am6548-iot2050-advanced.dts     | 50 +++--------------
- 6 files changed, 67 insertions(+), 140 deletions(-)
+ .../dts/ti/k3-am65-iot2050-common-pg1.dtsi    | 46 ++++++++++++++
+ .../boot/dts/ti/k3-am65-iot2050-common.dtsi   | 35 +----------
+ .../ti/k3-am6528-iot2050-basic-common.dtsi    | 60 +++++++++++++++++++
+ .../boot/dts/ti/k3-am6528-iot2050-basic.dts   | 56 +++--------------
+ .../ti/k3-am6548-iot2050-advanced-common.dtsi | 56 +++++++++++++++++
+ .../dts/ti/k3-am6548-iot2050-advanced.dts     | 50 +++-------------
+ 6 files changed, 178 insertions(+), 125 deletions(-)
  create mode 100644 arch/arm64/boot/dts/ti/k3-am65-iot2050-common-pg1.dtsi
- copy arch/arm64/boot/dts/ti/{k3-am6528-iot2050-basic.dts => k3-am6528-iot2050-basic-common.dtsi} (80%)
- copy arch/arm64/boot/dts/ti/{k3-am6548-iot2050-advanced.dts => k3-am6548-iot2050-advanced-common.dtsi} (85%)
+ create mode 100644 arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-common.dtsi
+ create mode 100644 arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-common.dtsi
 
 diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050-common-pg1.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050-common-pg1.dtsi
 new file mode 100644
@@ -144,44 +144,72 @@ index b29537088289..65da226847f4 100644
 -&tx_pru2_1 {
 -	status = "disabled";
 -};
-diff --git a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-common.dtsi
-similarity index 80%
-copy from arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts
-copy to arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-common.dtsi
-index 94bb5dd39122..4a9bf7d7c07d 100644
---- a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts
+diff --git a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-common.dtsi b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-common.dtsi
+new file mode 100644
+index 000000000000..4a9bf7d7c07d
+--- /dev/null
 +++ b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic-common.dtsi
-@@ -4,20 +4,14 @@
-  *
-  * Authors:
-  *   Le Jin <le.jin@siemens.com>
-- *   Jan Kiszka <jan.kiszk@siemens.com>
+@@ -0,0 +1,60 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (c) Siemens AG, 2018-2021
++ *
++ * Authors:
++ *   Le Jin <le.jin@siemens.com>
 + *   Jan Kiszka <jan.kiszka@siemens.com>
-  *
-- * AM6528-based (dual-core) IOT2050 Basic variant
-- * 1 GB RAM, no eMMC, main_uart0 on connector X30
++ *
 + * Common bits of the IOT2050 Basic variant, PG1 and PG2
-  */
- 
--/dts-v1/;
--
- #include "k3-am65-iot2050-common.dtsi"
- 
- / {
--	compatible = "siemens,iot2050-basic", "ti,am654";
--	model = "SIMATIC IOT2050 Basic";
--
- 	memory@80000000 {
- 		device_type = "memory";
- 		/* 1G RAM */
-@@ -61,6 +55,6 @@ &main_uart0 {
- };
- 
- &mcu_r5fss0 {
--	/* lock-step mode not supported on this board */
++ */
++
++#include "k3-am65-iot2050-common.dtsi"
++
++/ {
++	memory@80000000 {
++		device_type = "memory";
++		/* 1G RAM */
++		reg = <0x00000000 0x80000000 0x00000000 0x40000000>;
++	};
++
++	cpus {
++		cpu-map {
++			/delete-node/ cluster1;
++		};
++		/delete-node/ cpu@100;
++		/delete-node/ cpu@101;
++	};
++
++	/delete-node/ l2-cache1;
++};
++
++/* eMMC */
++&sdhci0 {
++	status = "disabled";
++};
++
++&main_pmx0 {
++	main_uart0_pins_default: main-uart0-pins-default {
++		pinctrl-single,pins = <
++			AM65X_IOPAD(0x01e4, PIN_INPUT,  0)  /* (AF11) UART0_RXD */
++			AM65X_IOPAD(0x01e8, PIN_OUTPUT, 0)  /* (AE11) UART0_TXD */
++			AM65X_IOPAD(0x01ec, PIN_INPUT,  0)  /* (AG11) UART0_CTSn */
++			AM65X_IOPAD(0x01f0, PIN_OUTPUT, 0)  /* (AD11) UART0_RTSn */
++			AM65X_IOPAD(0x0188, PIN_INPUT,  1)  /* (D25) UART0_DCDn */
++			AM65X_IOPAD(0x018c, PIN_INPUT,  1)  /* (B26) UART0_DSRn */
++			AM65X_IOPAD(0x0190, PIN_OUTPUT, 1)  /* (A24) UART0_DTRn */
++			AM65X_IOPAD(0x0194, PIN_INPUT,  1)  /* (E24) UART0_RIN */
++		>;
++	};
++};
++
++&main_uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&main_uart0_pins_default>;
++};
++
++&mcu_r5fss0 {
 +	/* lock-step mode not supported on Basic boards */
- 	ti,cluster-mode = <0>;
- };
++	ti,cluster-mode = <0>;
++};
 diff --git a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts b/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts
 index 94bb5dd39122..87928ff28214 100644
 --- a/arch/arm64/boot/dts/ti/k3-am6528-iot2050-basic.dts
@@ -257,36 +285,68 @@ index 94bb5dd39122..87928ff28214 100644
 -	/* lock-step mode not supported on this board */
 -	ti,cluster-mode = <0>;
  };
-diff --git a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-common.dtsi
-similarity index 85%
-copy from arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts
-copy to arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-common.dtsi
-index ec9617c13cdb..d25e8b26187f 100644
---- a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts
+diff --git a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-common.dtsi b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-common.dtsi
+new file mode 100644
+index 000000000000..d25e8b26187f
+--- /dev/null
 +++ b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-common.dtsi
-@@ -4,10 +4,9 @@
-  *
-  * Authors:
-  *   Le Jin <le.jin@siemens.com>
-- *   Jan Kiszka <jan.kiszk@siemens.com>
+@@ -0,0 +1,56 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (c) Siemens AG, 2018-2021
++ *
++ * Authors:
++ *   Le Jin <le.jin@siemens.com>
 + *   Jan Kiszka <jan.kiszka@siemens.com>
-  *
-- * AM6548-based (quad-core) IOT2050 Advanced variant
-- * 2 GB RAM, 16 GB eMMC, USB-serial converter on connector X30
++ *
 + * Common bits of the IOT2050 Advanced variant, PG1 and PG2
-  */
- 
- /dts-v1/;
-@@ -15,9 +14,6 @@
- #include "k3-am65-iot2050-common.dtsi"
- 
- / {
--	compatible = "siemens,iot2050-advanced", "ti,am654";
--	model = "SIMATIC IOT2050 Advanced";
--
- 	memory@80000000 {
- 		device_type = "memory";
- 		/* 2G RAM */
++ */
++
++/dts-v1/;
++
++#include "k3-am65-iot2050-common.dtsi"
++
++/ {
++	memory@80000000 {
++		device_type = "memory";
++		/* 2G RAM */
++		reg = <0x00000000 0x80000000 0x00000000 0x80000000>;
++	};
++};
++
++&main_pmx0 {
++	main_mmc0_pins_default: main-mmc0-pins-default {
++		pinctrl-single,pins = <
++			AM65X_IOPAD(0x01a8, PIN_INPUT_PULLDOWN, 0)  /* (B25) MMC0_CLK */
++			AM65X_IOPAD(0x01ac, PIN_INPUT_PULLUP,   0)  /* (B27) MMC0_CMD */
++			AM65X_IOPAD(0x01a4, PIN_INPUT_PULLUP,   0)  /* (A26) MMC0_DAT0 */
++			AM65X_IOPAD(0x01a0, PIN_INPUT_PULLUP,   0)  /* (E25) MMC0_DAT1 */
++			AM65X_IOPAD(0x019c, PIN_INPUT_PULLUP,   0)  /* (C26) MMC0_DAT2 */
++			AM65X_IOPAD(0x0198, PIN_INPUT_PULLUP,   0)  /* (A25) MMC0_DAT3 */
++			AM65X_IOPAD(0x0194, PIN_INPUT_PULLUP,   0)  /* (E24) MMC0_DAT4 */
++			AM65X_IOPAD(0x0190, PIN_INPUT_PULLUP,   0)  /* (A24) MMC0_DAT5 */
++			AM65X_IOPAD(0x018c, PIN_INPUT_PULLUP,   0)  /* (B26) MMC0_DAT6 */
++			AM65X_IOPAD(0x0188, PIN_INPUT_PULLUP,   0)  /* (D25) MMC0_DAT7 */
++			AM65X_IOPAD(0x01b8, PIN_OUTPUT_PULLUP,  7)  /* (B23) MMC0_SDWP */
++			AM65X_IOPAD(0x01b4, PIN_INPUT_PULLUP,   0)  /* (A23) MMC0_SDCD */
++			AM65X_IOPAD(0x01b0, PIN_INPUT,          0)  /* (C25) MMC0_DS */
++		>;
++	};
++};
++
++/* eMMC */
++&sdhci0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&main_mmc0_pins_default>;
++	bus-width = <8>;
++	non-removable;
++	ti,driver-strength-ohm = <50>;
++	disable-wp;
++};
++
++&main_uart0 {
++	status = "disabled";
++};
 diff --git a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts
 index ec9617c13cdb..077f165bdc68 100644
 --- a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced.dts
@@ -357,5 +417,5 @@ index ec9617c13cdb..077f165bdc68 100644
 -	status = "disabled";
  };
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
@@ -1,7 +1,7 @@
-From 18aff536825cb030c6684e05a41ccab22d4832bc Mon Sep 17 00:00:00 2001
+From c75a69f45ffac2272d3d8a8ea267db78b32c7f50 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 21 Jun 2021 11:04:56 +0200
-Subject: [PATCH 049/118] arm64: dts: ti: iot2050: Add support for product
+Subject: [PATCH 049/119] arm64: dts: ti: iot2050: Add support for product
  generation 2 boards
 
 This adds the devices trees for IOT2050 Product Generation 2 (PG2)
@@ -158,5 +158,5 @@ index 000000000000..f00dc86d01b9
 +	ti,cluster-mode = <0>;
 +};
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
@@ -1,7 +1,7 @@
-From d015fec92e923f9c2f5d06b89a5150932110b5b3 Mon Sep 17 00:00:00 2001
+From df55a48a3f79e1b1c62ca072bb7e401e46d9c925 Mon Sep 17 00:00:00 2001
 From: Tomi Valkeinen <tomi.valkeinen@ti.com>
 Date: Mon, 31 May 2021 16:31:35 +0530
-Subject: [PATCH 050/118] arm64: dts: ti: k3-am65-main: fix DSS irq trigger
+Subject: [PATCH 050/119] arm64: dts: ti: k3-am65-main: fix DSS irq trigger
  type
 
 DSS irq trigger type is set to IRQ_TYPE_EDGE_RISING. For some reason this
@@ -35,5 +35,5 @@ index 9338f1042232..9b1a016162b2 100644
  		dma-coherent;
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0051-irqdomain-Export-of_phandle_args_to_fwspec.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0051-irqdomain-Export-of_phandle_args_to_fwspec.patch
@@ -1,7 +1,7 @@
-From e2e14f439f530b49f6aba20dd4b23d45e6af336b Mon Sep 17 00:00:00 2001
+From 7f8a9154385400c5de94558942245edf136c2901 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:46 +0530
-Subject: [PATCH 051/118] irqdomain: Export of_phandle_args_to_fwspec()
+Subject: [PATCH 051/119] irqdomain: Export of_phandle_args_to_fwspec()
 
 Export of_phandle_args_to_fwspec() to be used by drivers.
 of_phandle_args_to_fwspec() can be used by drivers to get irq specifier
@@ -55,5 +55,5 @@ index c6b419db68ef..a17e4ce3811d 100644
  unsigned int irq_create_fwspec_mapping(struct irq_fwspec *fwspec)
  {
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0052-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0052-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
@@ -1,7 +1,7 @@
-From 3ae60cd248a02fa9f2a1aed6e544fdebc585abfe Mon Sep 17 00:00:00 2001
+From f3339188da17a9d357f41003b75c94342a79793a Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:47 +0530
-Subject: [PATCH 052/118] PCI: keystone: Convert to using hierarchy domain for
+Subject: [PATCH 052/119] PCI: keystone: Convert to using hierarchy domain for
  legacy interrupts
 
 K2G provides separate IRQ lines for each of the four legacy interrupts.
@@ -318,5 +318,5 @@ index 90482d5246ff..0493e43ba416 100644
  err:
  	of_node_put(intc_np);
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
@@ -1,7 +1,7 @@
-From 6fbb01738fb415801007e25e6962e8c965f90580 Mon Sep 17 00:00:00 2001
+From 586a97a0bb7b77123849d617234863e09795548a Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:48 +0530
-Subject: [PATCH 053/118] PCI: keystone: Add PCI legacy interrupt support for
+Subject: [PATCH 053/119] PCI: keystone: Add PCI legacy interrupt support for
  AM654
 
 Add PCI legacy interrupt support for AM654. AM654 has a single HW
@@ -135,5 +135,5 @@ index 0493e43ba416..0460ed2a277a 100644
  		return ret;
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
@@ -1,7 +1,7 @@
-From a42300009644e3549472ca14648b07ecfed243cf Mon Sep 17 00:00:00 2001
+From 62b90f39540344cd0f0b82fa818cd17124aea917 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:49 +0530
-Subject: [PATCH 054/118] PCI: keystone: Add workaround for Errata #i2037
+Subject: [PATCH 054/119] PCI: keystone: Add workaround for Errata #i2037
  (AM65x SR 1.0)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -110,5 +110,5 @@ index 0460ed2a277a..bb7190400ba8 100644
  DECLARE_PCI_FIXUP_ENABLE(PCI_ANY_ID, PCI_ANY_ID, ks_pcie_quirk);
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0055-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0055-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
@@ -1,7 +1,7 @@
-From af16fed3807c9be3777284270ceed919d65ebf25 Mon Sep 17 00:00:00 2001
+From 5f81916b5f29fc4befe188bf117a19630794b0a6 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:38:07 +0530
-Subject: [PATCH 055/118] arm64: dts: ti: k3-am65-main: Add properties to
+Subject: [PATCH 055/119] arm64: dts: ti: k3-am65-main: Add properties to
  support legacy interrupts
 
 Add DT properties in PCIe DT node to support legacy interrupts.
@@ -82,5 +82,5 @@ index 9b1a016162b2..b786daed9639 100644
  
  	pcie1_ep: pcie-ep@5600000 {
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0056-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0056-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
@@ -1,7 +1,7 @@
-From 0ee4d816ac51e946a4c2cf7d4ec8acb639f0b1a7 Mon Sep 17 00:00:00 2001
+From 22dc142af8d8b077e44df03b9db032d3934e5e87 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 20 Nov 2020 21:01:54 -0600
-Subject: [PATCH 056/118] remoteproc: Fix unbalanced boot with sysfs for no
+Subject: [PATCH 056/119] remoteproc: Fix unbalanced boot with sysfs for no
  auto-boot rprocs
 
 The remoteproc core performs automatic boot and shutdown of a remote
@@ -73,5 +73,5 @@ index 1dbef895e65e..3b05230641c8 100644
  		dev_err(&rproc->dev, "Unrecognised option: %s\n", buf);
  		ret = -EINVAL;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Introduce-deny_sysfs_ops-flag.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Introduce-deny_sysfs_ops-flag.patch
@@ -1,7 +1,7 @@
-From 9566b2e022f1cd74300ea8c7bdca737ec7b70485 Mon Sep 17 00:00:00 2001
+From a04ca45cba3b9bf840258cc87b248cbed2a3d49f Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 13:05:28 -0500
-Subject: [PATCH 057/118] remoteproc: Introduce deny_sysfs_ops flag
+Subject: [PATCH 057/119] remoteproc: Introduce deny_sysfs_ops flag
 
 The remoteproc framework provides sysfs interfaces for changing the
 firmware name and for starting/stopping a remote processor through
@@ -95,5 +95,5 @@ index e8ac041c64d9..02425aac6100 100644
  	int nb_vdev;
  	u8 elf_class;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
@@ -1,7 +1,7 @@
-From 8fa387356193dd3f8dcd96889962d044e711ceb2 Mon Sep 17 00:00:00 2001
+From 1c35d71198d9bede7755919a3699bcc9f1dd0591 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:32:29 -0500
-Subject: [PATCH 058/118] remoteproc: pru: Add APIs to get and put the PRU
+Subject: [PATCH 058/119] remoteproc: pru: Add APIs to get and put the PRU
  cores
 
 Add two new APIs, pru_rproc_get() and pru_rproc_put(), to the PRU
@@ -279,5 +279,5 @@ index 000000000000..1a97856b463a
 +
 +#endif /* __LINUX_PRUSS_H */
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
@@ -1,7 +1,7 @@
-From 4c88ce9f46c959ff426ca4137f8798d8b8b22f9f Mon Sep 17 00:00:00 2001
+From 3c0a50b999321b5c7dea6640b08179d3c02c39bf Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 16 Dec 2020 17:52:37 +0100
-Subject: [PATCH 059/118] remoteproc: pru: Deny rproc sysfs ops for PRU client
+Subject: [PATCH 059/119] remoteproc: pru: Deny rproc sysfs ops for PRU client
  driven boots
 
 The PRU remoteproc driver is not configured for 'auto-boot' by default,
@@ -41,5 +41,5 @@ index 0b57b3f7747f..8fac021adc52 100644
  
  	put_device(&rproc->dev);
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
@@ -1,7 +1,7 @@
-From 62255f5c519ecf01ac4cd4f76c1647884d2fadb4 Mon Sep 17 00:00:00 2001
+From 379a37eb5606b85d7608b3ef81e3fd9b0398815c Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Fri, 26 Mar 2021 15:43:53 -0500
-Subject: [PATCH 060/118] remoteproc: pru: Add pru_rproc_set_ctable() function
+Subject: [PATCH 060/119] remoteproc: pru: Add pru_rproc_set_ctable() function
 
 Some firmwares expect the OS drivers to configure the CTABLE
 entries publishing dynamically allocated memory regions. For
@@ -182,5 +182,5 @@ index 1a97856b463a..e1740ff06962 100644
  
  static inline bool is_pru_rproc(struct device *dev)
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Configure-firmware-based-on-client-se.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Configure-firmware-based-on-client-se.patch
@@ -1,7 +1,7 @@
-From 3b6f5e3b257ee95ef065fd774ba01b4e21b1f474 Mon Sep 17 00:00:00 2001
+From 20a00961a7fb23bf9fa30504ab0979aa977f85e2 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:50:14 -0500
-Subject: [PATCH 061/118] remoteproc: pru: Configure firmware based on client
+Subject: [PATCH 061/119] remoteproc: pru: Configure firmware based on client
  setup
 
 Client device node property firmware-name is now used to configure
@@ -104,5 +104,5 @@ index 90c097ebc27e..c346899d5e3b 100644
  	pru->client_np = NULL;
  	rproc->deny_sysfs_ops = false;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0062-soc-ti-pruss-Add-pruss_get-put-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0062-soc-ti-pruss-Add-pruss_get-put-API.patch
@@ -1,7 +1,7 @@
-From 9fcfa8b94ca04ba0d7469776aa73064ffd9df7d2 Mon Sep 17 00:00:00 2001
+From 2555d1c425a7f2b20f72968ec9fc8dca091ce925 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:58:00 -0500
-Subject: [PATCH 062/118] soc: ti: pruss: Add pruss_get()/put() API
+Subject: [PATCH 062/119] soc: ti: pruss: Add pruss_get()/put() API
 
 Add two new get and put API, pruss_get() and pruss_put() to the
 PRUSS platform driver to allow client drivers to request a handle
@@ -176,5 +176,5 @@ index ecfded30ed05..4d1321f0d326 100644
  
  /*
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
@@ -1,7 +1,7 @@
-From 801663d092c00ba746890bf1788392f4c4c3af7d Mon Sep 17 00:00:00 2001
+From f55c49a51cee3d9c95aa5255307d8169cf2c01cd Mon Sep 17 00:00:00 2001
 From: "Andrew F. Davis" <afd@ti.com>
 Date: Fri, 26 Mar 2021 16:11:42 -0500
-Subject: [PATCH 063/118] soc: ti: pruss: Add
+Subject: [PATCH 063/119] soc: ti: pruss: Add
  pruss_{request,release}_mem_region() API
 
 Add two new API - pruss_request_mem_region() & pruss_release_mem_region(),
@@ -236,5 +236,5 @@ index 4d1321f0d326..f1d1197fd91a 100644
  	struct clk *iep_clk_mux;
  };
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
@@ -1,7 +1,7 @@
-From ebe83c407096ff77435d0fabb727c5c422c76580 Mon Sep 17 00:00:00 2001
+From 8a8719e74e760dc5bb1cebeb4f3cb36fbbe3a45e Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:27:34 -0500
-Subject: [PATCH 064/118] soc: ti: pruss: Add pruss_cfg_read()/update() API
+Subject: [PATCH 064/119] soc: ti: pruss: Add pruss_cfg_read()/update() API
 
 Add two new generic API pruss_cfg_read() and pruss_cfg_update() to
 the PRUSS platform driver to allow other drivers to read and program
@@ -209,5 +209,5 @@ index 40de553d4446..a4f59a46c331 100644
  
  #if IS_ENABLED(CONFIG_PRU_REMOTEPROC)
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
@@ -1,7 +1,7 @@
-From f20835fa37b8ac3126bef948c5f9cba156dd7418 Mon Sep 17 00:00:00 2001
+From eed3865cba1c5a2c64e9eeb91bc727a28fc4b702 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 11 Dec 2020 19:48:09 +0100
-Subject: [PATCH 065/118] soc: ti: pruss: Add helper functions to set GPI mode,
+Subject: [PATCH 065/119] soc: ti: pruss: Add helper functions to set GPI mode,
  MII_RT_event and XFR
 
 The PRUSS CFG module is represented as a syscon node and is currently
@@ -82,5 +82,5 @@ index a4f59a46c331..ba5b728d5015 100644
 +
  #endif /* __LINUX_PRUSS_H */
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
@@ -1,7 +1,7 @@
-From d103d01f3ed58361c07b339d17573cfc87cb9031 Mon Sep 17 00:00:00 2001
+From c719aa5875b433af56f3e815feb81a67183e0d6f Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:38:11 -0500
-Subject: [PATCH 066/118] soc: ti: pruss: Add helper function to enable OCP
+Subject: [PATCH 066/119] soc: ti: pruss: Add helper function to enable OCP
  master ports
 
 The PRU-ICSS subsystem on OMAP-architecture based SoCS (AM33xx, AM437x
@@ -178,5 +178,5 @@ index ba5b728d5015..5fdd6f03446d 100644
  
  #if IS_ENABLED(CONFIG_PRU_REMOTEPROC)
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
@@ -1,7 +1,7 @@
-From 067a1552aec430e014f11b39e74cd0f615d86739 Mon Sep 17 00:00:00 2001
+From e60b02867a63ab06abc23038184cf2a28d45cae1 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 09:24:51 -0500
-Subject: [PATCH 067/118] soc: ti: pruss: Add helper functions to get/set
+Subject: [PATCH 067/119] soc: ti: pruss: Add helper functions to get/set
  PRUSS_CFG_GPMUX
 
 Add two new helper functions pruss_cfg_get_gpmux() & pruss_cfg_set_gpmux()
@@ -71,5 +71,5 @@ index f1d1197fd91a..d6abfdd17631 100644
 +
  #endif	/* _PRUSS_DRIVER_H_ */
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0068-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0068-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
@@ -1,7 +1,7 @@
-From 745c3882f3c86cae59b7c1ba69855bd02d00c82c Mon Sep 17 00:00:00 2001
+From db4fa3d6372cab0ff17c0f269ede2a0390697fe6 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 10:11:42 -0500
-Subject: [PATCH 068/118] remoteproc/pru: add support for configuring GPMUX
+Subject: [PATCH 068/119] remoteproc/pru: add support for configuring GPMUX
  based on client setup
 
 Client device node property ti,pruss-gp-mux-sel can now be used to
@@ -75,5 +75,5 @@ index c346899d5e3b..7ef176170b18 100644
  
  	mutex_lock(&pru->lock);
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0069-net-ethernet-ti-prueth-Add-IEP-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0069-net-ethernet-ti-prueth-Add-IEP-driver.patch
@@ -1,7 +1,7 @@
-From 8f902858363f80034a21a89932139a42ad0bf0a2 Mon Sep 17 00:00:00 2001
+From 2ef3fe79f4a1ace254a3bb968a41a381fc51814c Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 20 Apr 2021 13:17:30 +0530
-Subject: [PATCH 069/118] net: ethernet: ti: prueth: Add IEP driver
+Subject: [PATCH 069/119] net: ethernet: ti: prueth: Add IEP driver
 
 Add a driver for Industrial Ethernet Peripheral (IEP) block of PRUSS to
 support timestamping of ethernet packets and thus support PTP and PPS
@@ -1146,5 +1146,5 @@ index 000000000000..a41e18df666e
 +
 +#endif /* __NET_TI_ICSS_IEP_H */
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0070-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0070-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
@@ -1,7 +1,7 @@
-From 78ad4241b67421e67c38c1c187c26dbb73b514d1 Mon Sep 17 00:00:00 2001
+From 381016ac7b850549e8e858ddd83558b39c29570d Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Tue, 20 Apr 2021 13:17:31 +0530
-Subject: [PATCH 070/118] HACK: net: ethernet: ti: icss-iep: Fix sync0
+Subject: [PATCH 070/119] HACK: net: ethernet: ti: icss-iep: Fix sync0
  generation on a compare event
 
 commit 41e5c46849b5 ("net: ethernet: ti: icss-iep: Add support for generating
@@ -119,5 +119,5 @@ index 234972a034a9..22034d41c988 100644
  EXPORT_SYMBOL_GPL(icss_iep_put);
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0071-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0071-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
@@ -1,7 +1,7 @@
-From 60b572e25d8e35e8ef3742e423b0a0742d01455a Mon Sep 17 00:00:00 2001
+From 450593e21956f68341540ebda7eb70c1b06a4a7b Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:28 +0300
-Subject: [PATCH 071/118] net: ethernet: ti: icss_iep: drop
+Subject: [PATCH 071/119] net: ethernet: ti: icss_iep: drop
  ICSS_IEP_CAPx_FALL_REGy
 
 ICSS_IEP_CAPx_FALL_REGy are not used, but cause indexation issues in
@@ -80,5 +80,5 @@ index 22034d41c988..60a284c6c0c9 100644
  		[ICSS_IEP_CMP_CFG_REG] = 0x40,
  		[ICSS_IEP_CMP_STAT_REG] = 0x44,
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
@@ -1,7 +1,7 @@
-From c74706ee3e3c437dbb884cfcdfc42106196f05ee Mon Sep 17 00:00:00 2001
+From 1cc6195ca4079596811eb01ce5595dac63f7548d Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:29 +0300
-Subject: [PATCH 072/118] net: ethernet: ti: icss_iep: fix access to x_REG1 in
+Subject: [PATCH 072/119] net: ethernet: ti: icss_iep: fix access to x_REG1 in
  non 64bit mode
 
 Do not access x_REG1 registers in non 64bit mode.
@@ -93,5 +93,5 @@ index 60a284c6c0c9..73c0a31e8245 100644
  			pevent.type = PTP_CLOCK_EXTTS;
  			pevent.index = i;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
@@ -1,7 +1,7 @@
-From 84642db14e786cd75b5e09cdc63b198b4106306a Mon Sep 17 00:00:00 2001
+From c6dcd01c3e4d59aac22e0d019cf5192c09c23b07 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:30 +0300
-Subject: [PATCH 073/118] net: ethernet: ti: icss_iep: disable extts and pps if
+Subject: [PATCH 073/119] net: ethernet: ti: icss_iep: disable extts and pps if
  no slow compensation or non 64bit mode
 
 Disable extts and pps if no slow compensation support or non 64bit mode.
@@ -37,5 +37,5 @@ index 73c0a31e8245..c0bcb1d1180a 100644
  
  put_iep_device:
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
@@ -1,7 +1,7 @@
-From 7ae3ddd4b61c073a33161d2c16793eab8416f17f Mon Sep 17 00:00:00 2001
+From 8f167475915738534a1b4d7754858c938f6996d6 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:31 +0300
-Subject: [PATCH 074/118] net: ethernet: ti: icss_iep: fix pps irq race vs pps
+Subject: [PATCH 074/119] net: ethernet: ti: icss_iep: fix pps irq race vs pps
  disable
 
 When PPS is disabled the PPS IRQ can be running and PPS timer started which
@@ -123,5 +123,5 @@ index c0bcb1d1180a..ead1e7c94021 100644
  	mutex_unlock(&iep->ptp_clk_mutex);
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
@@ -1,7 +1,7 @@
-From 0961dd65d33fd3cfd9c6af60e2ec609e46394abb Mon Sep 17 00:00:00 2001
+From 13c8741b550353332516139e14daeb89e5af2114 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:32 +0300
-Subject: [PATCH 075/118] net: ethernet: ti: icss_iep: improve icss_iep_gettime
+Subject: [PATCH 075/119] net: ethernet: ti: icss_iep: improve icss_iep_gettime
 
 There are few issues with icss_iep_gettime():
 - it has to be very fast, but it's not protected from interruption
@@ -69,5 +69,5 @@ index ead1e7c94021..cbec01328a71 100644
  
  static void icss_iep_enable(struct icss_iep *iep)
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
@@ -1,7 +1,7 @@
-From 9bf5e97a7e8181388cf518a7a6af2d49c4b68805 Mon Sep 17 00:00:00 2001
+From f8907a50264ee6106f9df2e453eb067dedb7b6ab Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:33 +0300
-Subject: [PATCH 076/118] net: ethernet: ti: icss_iep: simplify peroutput
+Subject: [PATCH 076/119] net: ethernet: ti: icss_iep: simplify peroutput
  processing
 
 simplify peroutput processing
@@ -114,5 +114,5 @@ index cbec01328a71..b39d4c08c6c9 100644
  		hrtimer_start(&iep->sync_timer, ms_to_ktime(110), /* 100ms + buffer */
  			      HRTIMER_MODE_REL);
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
@@ -1,7 +1,7 @@
-From a71ee9b5c0fc7f7d8c461f4a38a1b7235dc0ccd9 Mon Sep 17 00:00:00 2001
+From dc0bc7bd60bd34f00128448e45d9c2f90a119ce5 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:34 +0300
-Subject: [PATCH 077/118] net: ethernet: ti: icss_iep: use readl/writel in
+Subject: [PATCH 077/119] net: ethernet: ti: icss_iep: use readl/writel in
  cap_cmp_handler
 
 Use readl/writel in cap_cmp_handler and timer handler instead of regmap
@@ -102,5 +102,5 @@ index b39d4c08c6c9..e2663dd5cf38 100644
  	return HRTIMER_NORESTART;
  }
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
@@ -1,7 +1,7 @@
-From eb458f3b70173d21ff0151bc7e1e5c0d041aa06c Mon Sep 17 00:00:00 2001
+From 1704556423960a0976ca067c7b44285ab439329b Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:35 +0300
-Subject: [PATCH 078/118] net: ethernet: ti: icss_iep: switch to .gettimex64()
+Subject: [PATCH 078/119] net: ethernet: ti: icss_iep: switch to .gettimex64()
 
 The .gettime64() is deprecated by commit 916444df305e ("ptp: deprecate
 gettime64() in favor of gettimex64()").
@@ -95,5 +95,5 @@ index e2663dd5cf38..c0497b448d68 100644
  	.enable		= icss_iep_ptp_enable,
  };
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
@@ -1,7 +1,7 @@
-From 8600a63674b05b345f2c5dac2e9e632f4d3bd9dd Mon Sep 17 00:00:00 2001
+From ff58878e47655ec09162966bf0bf75ef96cd27df Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Thu, 29 Apr 2021 18:13:36 +0300
-Subject: [PATCH 079/118] net: ethernet: ti: icss_iep: Update compare registers
+Subject: [PATCH 079/119] net: ethernet: ti: icss_iep: Update compare registers
  after changing ptp clock time
 
 Consider the scenario where PPS is enabled, then iep set_time or adjust_time is
@@ -60,5 +60,5 @@ index c0497b448d68..8bad9c86775a 100644
  
  static u64 icss_iep_gettime(struct icss_iep *iep,
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
@@ -1,7 +1,7 @@
-From 32ea082d2e162b7a5ce913484bde9d4ed3031c87 Mon Sep 17 00:00:00 2001
+From fa3a9cee1e41c56afb61840d9512d9d218ca315a Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:37 +0300
-Subject: [PATCH 080/118] net: ethernet: ti: icss_iep: request cmp_cap irq from
+Subject: [PATCH 080/119] net: ethernet: ti: icss_iep: request cmp_cap irq from
  probe
 
 The current INTC design allows to define IEP cmp_cap IRQ explicitly for IEP
@@ -106,5 +106,5 @@ index 8bad9c86775a..df74b5fd17e9 100644
  	if (IS_ERR(iep_clk))
  		return PTR_ERR(iep_clk);
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
@@ -1,7 +1,7 @@
-From 0c4ae8ea3bb385129eaaf0c84ff05ca67f9f8f0c Mon Sep 17 00:00:00 2001
+From 2347652f91471bb4f58dc5e885a663e8dcfd40c7 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:38 +0300
-Subject: [PATCH 081/118] net: ethernet: ti: icss_iep: set phc time to system
+Subject: [PATCH 081/119] net: ethernet: ti: icss_iep: set phc time to system
  time on init
 
 Following customer feedback IEP PHC time has to be set to system time on
@@ -28,5 +28,5 @@ index df74b5fd17e9..08b456f0bc12 100644
  	iep->clk_tick_time = def_inc;
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
@@ -1,7 +1,7 @@
-From ba0fb92955b85a0bf90d2ad73f9c0481adbc2e1f Mon Sep 17 00:00:00 2001
+From a4012b49e603dd1761afd67656a39287eced215e Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:39 +0300
-Subject: [PATCH 082/118] net: ethernet: ti: icss_iep: use
+Subject: [PATCH 082/119] net: ethernet: ti: icss_iep: use
  devm_platform_ioremap_resource
 
 Use devm_platform_ioremap_resource() in probe to simplify code.
@@ -35,5 +35,5 @@ index 08b456f0bc12..640f483854d0 100644
  		return -ENODEV;
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0083-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0083-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
@@ -1,7 +1,7 @@
-From 043a134d8d46f1bd497db5e114d0bbe326e46378 Mon Sep 17 00:00:00 2001
+From 843af8fda02233fef10e8168d76b4fcb1216f9f8 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 16 Mar 2021 18:00:25 -0500
-Subject: [PATCH 083/118] arm64: dts: ti: k3-am65-main: Add ICSSG IEP nodes
+Subject: [PATCH 083/119] arm64: dts: ti: k3-am65-main: Add ICSSG IEP nodes
 
 The ICSSG IP on AM65x SoCs have two Industrial Ethernet Peripherals (IEPs)
 to manage/generate Industrial Ethernet functions such as time stamping.
@@ -77,5 +77,5 @@ index b786daed9639..d0e565fb5e12 100644
  			compatible = "ti,pruss-mii", "syscon";
  			reg = <0x32000 0x100>;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0084-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0084-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
@@ -1,7 +1,7 @@
-From 352dc62c5c36c6d2ad23c7429ecca275af836a3e Mon Sep 17 00:00:00 2001
+From 1126b30e03abe1668a75edea5b0c3669f2312a87 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:22 +0300
-Subject: [PATCH 084/118] dt-bindings: net: Add binding for ti,icssg-prueth
+Subject: [PATCH 084/119] dt-bindings: net: Add binding for ti,icssg-prueth
  device
 
 This is the DT binding document for the ICSSG Dual-EMAC Ethernet
@@ -149,5 +149,5 @@ index 000000000000..67609e26afa5
 +		};
 +	};
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0085-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0085-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
@@ -1,7 +1,7 @@
-From c3be05c640f3ac35f0349ab0f861d3c552f0bd57 Mon Sep 17 00:00:00 2001
+From e284c50dea8af3a0bf9c4f4e74a7aef9b3b9cb74 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:23 +0300
-Subject: [PATCH 085/118] net: ti: icssg-prueth: Add ICSSG ethernet driver
+Subject: [PATCH 085/119] net: ti: icssg-prueth: Add ICSSG ethernet driver
 
 This is the Ethernet driver for TI SoCs with the
 ICSSG PRU Sub-system running dual-EMAC firmware.
@@ -4497,5 +4497,5 @@ index 5fdd6f03446d..2a034c08b4c2 100644
  /*
   * enum pruss_gp_mux_sel - PRUSS GPI/O Mux modes for the
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0086-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0086-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
@@ -1,7 +1,7 @@
-From eaf14682c7e545e897968d32b9552e4162774a50 Mon Sep 17 00:00:00 2001
+From 5e471d35348065f59bff49f2e72c659424ec67fd Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:24 +0300
-Subject: [PATCH 086/118] net: ethernet: ti: icssg_prueth: add 10M full duplex
+Subject: [PATCH 086/119] net: ethernet: ti: icssg_prueth: add 10M full duplex
  support
 
 For 10M support RGMII need to be configured in inband mode and FW has to be
@@ -250,5 +250,5 @@ index bf52d350bdd0..644a22b53424 100644
  #define TAS_GATE_MASK_LIST0                                0x0100
  /*TAS gate mask for windows list1*/
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
@@ -1,7 +1,7 @@
-From 98dd46caaa1f2df7a6389dc584d60c94b14f3fc6 Mon Sep 17 00:00:00 2001
+From 19ecbe9e2d5fc8bd195482a5bce7853b450a13b5 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:25 +0300
-Subject: [PATCH 087/118] net: ethernet: ti: icssg_prueth: Use DMA device for
+Subject: [PATCH 087/119] net: ethernet: ti: icssg_prueth: Use DMA device for
  DMA API
 
 For DMA API the DMA device should be used as cpsw does not accesses to
@@ -342,5 +342,5 @@ index 69c558eb004d..2e8d45c8c25d 100644
  	struct k3_udma_glue_rx_channel *rx_chn;
  	u32 descs_num;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
@@ -1,7 +1,7 @@
-From 12d4d1a80249c134f663c5c2dbaf22b09cb000e0 Mon Sep 17 00:00:00 2001
+From 50cf7dc10c0eeba189a97b2c29e1b6eeacc69812 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:26 +0300
-Subject: [PATCH 088/118] net: ethernet: ti: icss_iep: add icss_iep_get_idx()
+Subject: [PATCH 088/119] net: ethernet: ti: icss_iep: add icss_iep_get_idx()
  api
 
 Add icss_iep_get_idx() API to allow retrieve IEP from phandle list in DT.
@@ -59,5 +59,5 @@ index a41e18df666e..eefc8c8bd8cc 100644
  int icss_iep_init(struct icss_iep *iep, const struct icss_iep_clockops *clkops,
  		  void *clockops_data, u32 cycle_time_ns);
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
@@ -1,7 +1,7 @@
-From ce1a000c10b8e7e5d8131881e0710f25b99f8918 Mon Sep 17 00:00:00 2001
+From a87f792cb0ef87b0eb6189be7d92460a5c9f608e Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:27 +0300
-Subject: [PATCH 089/118] net: ethernet: ti: icss_iep: use readl() in
+Subject: [PATCH 089/119] net: ethernet: ti: icss_iep: use readl() in
  icss_iep_get_count_low/hi()
 
 Use readl() in icss_iep_get_count_low/hi() to speed up hot path.
@@ -35,5 +35,5 @@ index 51f8717fc446..23e72e0ffe46 100644
  	return val;
  }
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
@@ -1,7 +1,7 @@
-From 2fdcd242488e6110efe413e7e8bf26a527b3ffe8 Mon Sep 17 00:00:00 2001
+From 61c151b14453e6fe6581a24fea1cd9c8caa0fdaf Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:28 +0300
-Subject: [PATCH 090/118] net: ethernet: ti: icss_iep: fix init for sr2.0
+Subject: [PATCH 090/119] net: ethernet: ti: icss_iep: fix init for sr2.0
 
 There are two issues with IEP initialization for ICSSG SR2.0 where only one
 IEP0 is used in shadow mode:
@@ -147,5 +147,5 @@ index 23e72e0ffe46..eec7e9fb1f61 100644
  	dev_set_drvdata(dev, iep);
  	icss_iep_disable(iep);
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
@@ -1,7 +1,7 @@
-From dc61819613feab4d9619c224c738d707bd7d3687 Mon Sep 17 00:00:00 2001
+From 646a8e569ab1dbf1e703ae0fdd1e1d6ba71479c2 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:29 +0300
-Subject: [PATCH 091/118] net: ethernet: ti: icss_iep: sr2.0 fix NULL pointer
+Subject: [PATCH 091/119] net: ethernet: ti: icss_iep: sr2.0 fix NULL pointer
  exception on pps stop
 
 The NULL pointer exception is observed on pps stop - fix it as timer is not
@@ -38,5 +38,5 @@ index eec7e9fb1f61..0ed54c8251e2 100644
  	}
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0092-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0092-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
@@ -1,7 +1,7 @@
-From 9801bc6f46a6ab949c84398578a0c100da290319 Mon Sep 17 00:00:00 2001
+From bc15fb3390ccdf5804c1f699e3379db31073e335 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:30 +0300
-Subject: [PATCH 092/118] net: ti: ethernet: icssg-prueth: add packet
+Subject: [PATCH 092/119] net: ti: ethernet: icssg-prueth: add packet
  timestamping and ptp support
 
 Add packet timestamping TS and PTP PHC clock support.
@@ -856,5 +856,5 @@ index 2e8d45c8c25d..156716bf0a76 100644
  
  struct emac_tx_ts_response_sr1 {
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0093-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0093-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
@@ -1,7 +1,7 @@
-From 596d1d83778020fd5a8df06c80c36729cc65e552 Mon Sep 17 00:00:00 2001
+From 220ee9a36ba3cd5702a31ed99ceb4dd5b5c1068c Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:33 +0300
-Subject: [PATCH 093/118] net: ethernet: ti: icssg_prueth: add am64x icssg
+Subject: [PATCH 093/119] net: ethernet: ti: icssg_prueth: add am64x icssg
  support
 
 Add AM64x ICSSG support which is similar to am65x SR2.0, but required:
@@ -120,5 +120,5 @@ index 156716bf0a76..b536ac5ec0bf 100644
  
  struct emac_tx_ts_response_sr1 {
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
@@ -1,7 +1,7 @@
-From d565a0a0b9d915281f95c3755fcfc36d78172e7c Mon Sep 17 00:00:00 2001
+From 7d9707f34ee2a62b209a6796e50515d6178824f3 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 19 May 2021 19:31:36 +0300
-Subject: [PATCH 094/118] net: ethernet: ti: icssg_prueth: am65x SR2.0 add 10M
+Subject: [PATCH 094/119] net: ethernet: ti: icssg_prueth: am65x SR2.0 add 10M
  full duplex support
 
 For for AM65x SR2.0 it's required to enable IEP1 in raw 64bit mode which is
@@ -158,5 +158,5 @@ index b536ac5ec0bf..7cc81c67bf72 100644
  
  /**
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0095-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0095-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
@@ -1,7 +1,7 @@
-From ccb6f8b8bcf23b254fae4d1f0b51265bf5d0ead0 Mon Sep 17 00:00:00 2001
+From 5713793c489814be5092f04f6d6dd290ee5a95a5 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Mon, 21 Jun 2021 15:47:49 +0530
-Subject: [PATCH 095/118] net: ti: icssg_prueth: Free desc pool before DMA
+Subject: [PATCH 095/119] net: ti: icssg_prueth: Free desc pool before DMA
  channel release
 
 Release DMA desc pool associated with channel before releasing the
@@ -48,5 +48,5 @@ index ef7392a2b9da..38d151dca81c 100644
  		 * end after all channel resources are freed
  		 */
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0096-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0096-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
@@ -1,7 +1,7 @@
-From e1f7c7672096f10f474f504b0ef29685831169d1 Mon Sep 17 00:00:00 2001
+From 7c65b1ec71def3c53e10ca51a7bfa92f86234b6a Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:47 +0300
-Subject: [PATCH 096/118] net: ethernet: icssg-prueth: fix rgmii tx delay
+Subject: [PATCH 096/119] net: ethernet: icssg-prueth: fix rgmii tx delay
  configuration
 
 The driver enables RGMII TX delay without checking specified
@@ -125,5 +125,5 @@ index 38d151dca81c..d19a05fd8b06 100644
  		if (ret)
  			goto put_cores;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
@@ -1,7 +1,7 @@
-From fce321b6376c541a5562e7a0518d037f0f090717 Mon Sep 17 00:00:00 2001
+From ceb13b709111825cf1aafe2b1baacbec32ffa0c4 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:48 +0300
-Subject: [PATCH 097/118] net: ethernet: icssg-prueth: enable "fixed-link"
+Subject: [PATCH 097/119] net: ethernet: icssg-prueth: enable "fixed-link"
  connection
 
 The ICSSG has incomplete and incorrect "fixed-link" connection type
@@ -71,5 +71,5 @@ index d19a05fd8b06..3b1769a5e2b3 100644
  		ret = -EPROBE_DEFER;
  		goto free;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
@@ -1,7 +1,7 @@
-From 9fe8f18af949b19c59a226f7f1d2b2597672081d Mon Sep 17 00:00:00 2001
+From 403a023f438fb392151230131b346d7ec6cb6077 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:12 +0300
-Subject: [PATCH 098/118] net: ethernet: icssg-prueth: fix bug 'scheduling
+Subject: [PATCH 098/119] net: ethernet: icssg-prueth: fix bug 'scheduling
  while atomic' from emac_ndo_set_rx_mode()
 
 The .ndo_set_rx_mode() is called with BH disabled and should be atomic, but
@@ -133,5 +133,5 @@ index 7cc81c67bf72..59dec45a3c86 100644
  	struct pruss_mem_region dram;
  };
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
@@ -1,7 +1,7 @@
-From 1b1140f6088a19746908a6f59cde4e49c6e3ede2 Mon Sep 17 00:00:00 2001
+From 75ff0a17500330d5b06b8b5ec9f194b89ba04ed0 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:13 +0300
-Subject: [PATCH 099/118] net: ethernet: icssg-prueth: fix enabling/disabling
+Subject: [PATCH 099/119] net: ethernet: icssg-prueth: fix enabling/disabling
  port in emac_adjust_link()
 
 The port state is set to FORWARD in emac_ndo_open() and never changed, but
@@ -59,5 +59,5 @@ index f212e5904afc..abd062bedebb 100644
  
  reset_tx_chan:
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0100-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0100-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
@@ -1,7 +1,7 @@
-From 4a1be7fe9afc4b4d869ef637c2c41dc99266356f Mon Sep 17 00:00:00 2001
+From ac442005fe5a25afae8b203b27d3d40d10b87540 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 27 Jun 2020 10:53:13 +0200
-Subject: [PATCH 100/118] arm64: dts: ti: iot2050: Add icssg-prueth nodes for
+Subject: [PATCH 100/119] arm64: dts: ti: iot2050: Add icssg-prueth nodes for
  PG1 and PG2 devices
 
 Add the required nodes to enable ICSSG SR1.0 and SR2.0 based prueth
@@ -206,5 +206,5 @@ index 65da226847f4..2faefccca7a9 100644
  
  &icssg1_mdio {
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0101-HACK-setting-the-RJ45-port-led-behavior.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0101-HACK-setting-the-RJ45-port-led-behavior.patch
@@ -1,7 +1,7 @@
-From 95c9dd53a0065a3535457e0819c3c0dbbc843f42 Mon Sep 17 00:00:00 2001
+From 2cc8a982f12b94fdb01d47de0b47ae2ec2fe91ba Mon Sep 17 00:00:00 2001
 From: zengchao <chao.zeng@siemens.com>
 Date: Wed, 6 Nov 2019 11:21:49 +0800
-Subject: [PATCH 101/118] HACK: setting the RJ45 port led behavior
+Subject: [PATCH 101/119] HACK: setting the RJ45 port led behavior
 
 Temporary needed until we have a proper, likely LED-class based
 solution upstream.
@@ -37,5 +37,5 @@ index c716074fdef0..9ee2375782b3 100644
  }
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0102-WIP-feat-extend-led-panic-indicator-on-and-off.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0102-WIP-feat-extend-led-panic-indicator-on-and-off.patch
@@ -1,7 +1,7 @@
-From 63a024c97bb2c85fb0decb1bdbfa369b5ab0a0a3 Mon Sep 17 00:00:00 2001
+From a1555fb9699890252997826015f6b77914d990c1 Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Tue, 22 Dec 2020 15:05:56 +0800
-Subject: [PATCH 102/118] WIP: feat:extend led panic-indicator on and off
+Subject: [PATCH 102/119] WIP: feat:extend led panic-indicator on and off
 
 WIP because upstream strategy is still under discussion.
 
@@ -124,5 +124,5 @@ index 6a8d6409c993..d84423d42f89 100644
  	int 		num_leds;
  	const struct gpio_led *leds;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0103-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0103-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
@@ -1,7 +1,7 @@
-From d8c55854d446024c9cd1227884c8be0f35b3c36b Mon Sep 17 00:00:00 2001
+From 649b5040ae82176137de81445d1c07e4c2b3e8ca Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Mar 2021 15:28:21 +0100
-Subject: [PATCH 103/118] WIP: arm64: dts: ti: iot2050: Add node for generic
+Subject: [PATCH 103/119] WIP: arm64: dts: ti: iot2050: Add node for generic
  spidev
 
 This allows to use mcu_spi0 via userspace spidev.
@@ -33,5 +33,5 @@ index 2faefccca7a9..3510948e9d41 100644
  
  &tscadc0 {
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0104-watchdog-rti-wdt-Provide-set_timeout-handler-to-make.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0104-watchdog-rti-wdt-Provide-set_timeout-handler-to-make.patch
@@ -1,7 +1,7 @@
-From 5527baa53e1abd5f649441bd142642383794435f Mon Sep 17 00:00:00 2001
+From 8e5b1a7b6b57d188e1a89161989b27d26932f9cd Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 13 Sep 2021 12:27:17 +0200
-Subject: [PATCH 104/118] watchdog: rti-wdt: Provide set_timeout handler to
+Subject: [PATCH 104/119] watchdog: rti-wdt: Provide set_timeout handler to
  make existing userspace happy
 
 Prominent userspace - systemd - cannot handle watchdogs without
@@ -57,5 +57,5 @@ index 359302f71f7e..365255b15a0d 100644
  };
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0105-dt-bindings-net-ti-icssg-prueth-Add-documentation-fo.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0105-dt-bindings-net-ti-icssg-prueth-Add-documentation-fo.patch
@@ -1,7 +1,7 @@
-From 4f6059505883285f86e592672e0374b8ee595c0c Mon Sep 17 00:00:00 2001
+From 8712acbd73e529040491181fab19fb8a2caea025 Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Tue, 12 Oct 2021 13:54:41 +0300
-Subject: [PATCH 105/118] dt-bindings: net: ti, icssg-prueth: Add documentation
+Subject: [PATCH 105/119] dt-bindings: net: ti, icssg-prueth: Add documentation
  for half duplex
 
 In order to support half-duplex operation at 10M and 100M link speeds, the
@@ -37,5 +37,5 @@ index 125a204ef2d2..41cba6907fc9 100644
  Example (k3-am654 base board SR2.0, dual-emac):
  ==============================================
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0106-net-ethernet-icssg-prueth-sr1.0-add-support-for-half.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0106-net-ethernet-icssg-prueth-sr1.0-add-support-for-half.patch
@@ -1,7 +1,7 @@
-From 4504df0afdcd6246adc57476835aae2159670447 Mon Sep 17 00:00:00 2001
+From 69b99086016015aa6d203bcb395da841cb94d8e8 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 12 Oct 2021 13:54:42 +0300
-Subject: [PATCH 106/118] net: ethernet: icssg-prueth: sr1.0: add support for
+Subject: [PATCH 106/119] net: ethernet: icssg-prueth: sr1.0: add support for
  half duplex operation
 
 This patch adds support for half duplex operation at 10M and 100M link
@@ -103,5 +103,5 @@ index 59dec45a3c86..917c6f9a2514 100644
  	/* DMA related */
  	struct prueth_tx_chn tx_chns[PRUETH_MAX_TX_QUEUES];
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0107-net-ethernet-icssg-prueth-sr2.0-add-support-for-half.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0107-net-ethernet-icssg-prueth-sr2.0-add-support-for-half.patch
@@ -1,7 +1,7 @@
-From d241aaaffccc17e1da84f39ed121ceaea2c396c8 Mon Sep 17 00:00:00 2001
+From 9685f414af0fc61617a50f81bf3fd24930060f1e Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 12 Oct 2021 13:54:43 +0300
-Subject: [PATCH 107/118] net: ethernet: icssg-prueth: sr2.0: add support for
+Subject: [PATCH 107/119] net: ethernet: icssg-prueth: sr2.0: add support for
  half duplex operation
 
 This patch adds support for half duplex operation at 10M and 100M link
@@ -135,5 +135,5 @@ index 644a22b53424..99225d0f1582 100644
  /* Memory Usage of : DMEM1
   *
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0108-arm64-dts-ti-add-the-support-for-the-half-duplex.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0108-arm64-dts-ti-add-the-support-for-the-half-duplex.patch
@@ -1,7 +1,7 @@
-From 93d8f81ee9892671ec3e32d131f308133272128a Mon Sep 17 00:00:00 2001
+From 1e904f78d8d621c21dcaa5cc69f58dedca51acb1 Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Fri, 22 Oct 2021 13:37:22 +0800
-Subject: [PATCH 108/118] arm64: dts: ti: add the support for the half-duplex
+Subject: [PATCH 108/119] arm64: dts: ti: add the support for the half-duplex
 
 origin from TI and add the dts property to support the half-duplex for ethernet port
 
@@ -31,5 +31,5 @@ index 3510948e9d41..34a4bcec204a 100644
  			local-mac-address = [00 00 00 00 00 00];
  		};
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0109-USB-serial-cp210x-return-early-on-unchanged-termios.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0109-USB-serial-cp210x-return-early-on-unchanged-termios.patch
@@ -1,7 +1,7 @@
-From e59459128f43d5f5ec9170eda76c1b515d6a1744 Mon Sep 17 00:00:00 2001
+From eddd46eb8fdc073aaaf1c5bb23ea8a3c44228019 Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:21 +0100
-Subject: [PATCH 109/118] USB: serial: cp210x: return early on unchanged
+Subject: [PATCH 109/119] USB: serial: cp210x: return early on unchanged
  termios
 
 Return early from set_termios() in case no relevant terminal settings
@@ -46,5 +46,5 @@ index 329fc25f78a4..a9f732c563c8 100644
  	old_cflag = old_termios->c_cflag;
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0110-USB-serial-cp210x-clean-up-line-control-handling.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0110-USB-serial-cp210x-clean-up-line-control-handling.patch
@@ -1,7 +1,7 @@
-From ba3e5ba28ba53a53b32cc33d6969e138ced3b969 Mon Sep 17 00:00:00 2001
+From 900a3b88be3426096a7b51e344d54ea79a99aaaa Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:22 +0100
-Subject: [PATCH 110/118] USB: serial: cp210x: clean up line-control handling
+Subject: [PATCH 110/119] USB: serial: cp210x: clean up line-control handling
 
 Update the line-control settings in one request unconditionally instead
 of setting the word-length, parity and stop-bit settings separately.
@@ -151,5 +151,5 @@ index a9f732c563c8..7a7078de4b5c 100644
  		struct cp210x_flow_ctl flow_ctl;
  		u32 ctl_hs;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0111-USB-serial-cp210x-set-terminal-settings-on-open.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0111-USB-serial-cp210x-set-terminal-settings-on-open.patch
@@ -1,7 +1,7 @@
-From 666c3b76eaf701966f1c81bba7194bcf1092c46c Mon Sep 17 00:00:00 2001
+From c90a158a69206170b134e3dfcc60a503dd8fca59 Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:23 +0100
-Subject: [PATCH 111/118] USB: serial: cp210x: set terminal settings on open
+Subject: [PATCH 111/119] USB: serial: cp210x: set terminal settings on open
 
 Unlike other drivers cp210x have been retrieving the current terminal
 settings from the device on open and reflecting those in termios.
@@ -398,5 +398,5 @@ index 7a7078de4b5c..b0543b2b7423 100644
  }
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0112-USB-serial-cp210x-drop-flow-control-debugging.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0112-USB-serial-cp210x-drop-flow-control-debugging.patch
@@ -1,7 +1,7 @@
-From ac708384f13375e18f5b8a2ddc5449926572d515 Mon Sep 17 00:00:00 2001
+From c66f58bdf7287457e756ad5f4f866419c8f50ca0 Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:24 +0100
-Subject: [PATCH 112/118] USB: serial: cp210x: drop flow-control debugging
+Subject: [PATCH 112/119] USB: serial: cp210x: drop flow-control debugging
 
 Drop some unnecessary flow-control debugging.
 
@@ -43,5 +43,5 @@ index b0543b2b7423..899c854d65d5 100644
  		flow_ctl.ulControlHandshake = cpu_to_le32(ctl_hs);
  		flow_ctl.ulFlowReplace = cpu_to_le32(flow_repl);
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0113-USB-serial-cp210x-refactor-flow-control-handling.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0113-USB-serial-cp210x-refactor-flow-control-handling.patch
@@ -1,7 +1,7 @@
-From c3a00d96e18796a63539b9af4bb08d3741994ef6 Mon Sep 17 00:00:00 2001
+From 558c745a83cae9046075ca0a92856bd21d4337d1 Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:25 +0100
-Subject: [PATCH 113/118] USB: serial: cp210x: refactor flow-control handling
+Subject: [PATCH 113/119] USB: serial: cp210x: refactor flow-control handling
 
 Add a helper function to be used to configure flow control.
 
@@ -152,5 +152,5 @@ index 899c854d65d5..19666329f386 100644
  	/*
  	 * Enable event-insertion mode only if input parity checking is
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0114-USB-serial-cp210x-clean-up-dtr_rts.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0114-USB-serial-cp210x-clean-up-dtr_rts.patch
@@ -1,7 +1,7 @@
-From ef94e945e1aa173b23abe73d14fa3ebd035fadaf Mon Sep 17 00:00:00 2001
+From f0397a87e9fb537bd0a2cb50d9ab5bd2253d9af3 Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:26 +0100
-Subject: [PATCH 114/118] USB: serial: cp210x: clean up dtr_rts()
+Subject: [PATCH 114/119] USB: serial: cp210x: clean up dtr_rts()
 
 Clean up dtr_rts() by renaming the port parameter and adding missing
 whitespace.
@@ -41,5 +41,5 @@ index 19666329f386..68b30960f441 100644
  
  static int cp210x_tiocmget(struct tty_struct *tty)
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0115-USB-serial-cp210x-add-support-for-software-flow-cont.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0115-USB-serial-cp210x-add-support-for-software-flow-cont.patch
@@ -1,7 +1,7 @@
-From 4362fa437ff8bc0de07e74466067df9a840cb6ff Mon Sep 17 00:00:00 2001
+From 39c8dd5f5cfb7a75cef83e3ba02a019639f74e7a Mon Sep 17 00:00:00 2001
 From: Wang Sheng Long <shenglong.wang.ext@siemens.com>
 Date: Mon, 18 Jan 2021 12:13:26 +0100
-Subject: [PATCH 115/118] USB: serial: cp210x: add support for software flow
+Subject: [PATCH 115/119] USB: serial: cp210x: add support for software flow
  control
 
 When data is transmitted between two serial ports, the phenomenon of
@@ -139,5 +139,5 @@ index 68b30960f441..a1c1a52b8680 100644
  			__func__, ctl_hs, flow_repl);
  
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0116-USB-serial-cp210x-fix-control-characters-error-handl.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0116-USB-serial-cp210x-fix-control-characters-error-handl.patch
@@ -1,7 +1,7 @@
-From 38c71b041950d10b8880607f98d9fb65bf0689fe Mon Sep 17 00:00:00 2001
+From a1799dea2bf8d9e24524ad241b3c7f07ab98a0e6 Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 5 Jul 2021 10:20:10 +0200
-Subject: [PATCH 116/118] USB: serial: cp210x: fix control-characters error
+Subject: [PATCH 116/119] USB: serial: cp210x: fix control-characters error
  handling
 
 In the unlikely event that setting the software flow-control characters
@@ -49,5 +49,5 @@ index a1c1a52b8680..4308f37c61bc 100644
  
  	ret = cp210x_read_reg_block(port, CP210X_GET_FLOW, &flow_ctl,
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0117-serial-8250-Fix-RTS-modem-control-while-in-rs485-mod.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0117-serial-8250-Fix-RTS-modem-control-while-in-rs485-mod.patch
@@ -1,7 +1,7 @@
-From a8880d6fc70da8dd72133b892f20046d2b69ea5a Mon Sep 17 00:00:00 2001
+From 004ec8206cb1d1439b92d3ad5a908a840e1ed3d8 Mon Sep 17 00:00:00 2001
 From: Lukas Wunner <lukas@wunner.de>
 Date: Mon, 22 Nov 2021 16:58:24 +0100
-Subject: [PATCH 117/118] serial: 8250: Fix RTS modem control while in rs485
+Subject: [PATCH 117/119] serial: 8250: Fix RTS modem control while in rs485
  mode
 
 Commit f45709df7731 ("serial: 8250: Don't touch RTS modem control while
@@ -99,5 +99,5 @@ index 68a0ff605476..d9a64b1dd5e6 100644
  		ret = 0;
  	}
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0118-net-ethernet-icssg-prueth-Fix-release-of-iep0-on-pro.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0118-net-ethernet-icssg-prueth-Fix-release-of-iep0-on-pro.patch
@@ -1,7 +1,7 @@
-From 8dee4c3b3a59844892c853f3e7b3762219e65d02 Mon Sep 17 00:00:00 2001
+From cfc9a80b1ad4256c4e83a8f1ceb4877d45164e2c Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 30 Nov 2021 10:53:42 +0100
-Subject: [PATCH 118/118] net: ethernet: icssg-prueth: Fix release of iep0 on
+Subject: [PATCH 118/119] net: ethernet: icssg-prueth: Fix release of iep0 on
  probing error
 
 A typo caused crashes in case icss_iep_get_idx succeeded for iep0 but
@@ -26,5 +26,5 @@ index e33aafc9e029..f996273b4ea3 100644
  		prueth->iep1 = NULL;
  		goto free_pool;
 -- 
-2.31.1
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0119-arm64-dts-ti-Indicate-the-green-light-is-off-when-pa.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0119-arm64-dts-ti-Indicate-the-green-light-is-off-when-pa.patch
@@ -1,0 +1,29 @@
+From 5a18765f2d2eee68e6895ed7cb48990725ffda7a Mon Sep 17 00:00:00 2001
+From: chao zeng <chao.zeng@siemens.com>
+Date: Thu, 16 Dec 2021 15:09:25 +0800
+Subject: [PATCH 119/119] arm64: dts: ti: Indicate the green light is off when
+ panic
+
+The green light is out of control when panic occurs.
+it should be off thhen
+
+Signed-off-by: chao zeng <chao.zeng@siemens.com>
+---
+ arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi
+index 34a4bcec204a..733d6925c613 100644
+--- a/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi
++++ b/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi
+@@ -81,6 +81,7 @@ status-led-red {
+ 
+ 		status-led-green {
+ 			gpios = <&wkup_gpio0 24 GPIO_ACTIVE_HIGH>;
++			panic-indicator-off;
+ 		};
+ 
+ 		user-led1-red {
+-- 
+2.34.1
+


### PR DESCRIPTION
The green light is out of control when panic occurs.
it should be off then.

Indicates that the green light is off when panic.Add configuration
to the device tree to fix it.

Signed-off-by: chao zeng <chao.zeng@siemens.com>