### PR TITLE
Fix the wrong u-boot-iot2050 provider when building example image

### DIFF
--- a/conf/distro/iot2050-debian.conf
+++ b/conf/distro/iot2050-debian.conf
@@ -1,9 +1,10 @@
 #
-# Copyright (c) Siemens AG, 2019-2021
+# Copyright (c) Siemens AG, 2019-2022
 #
 # Authors:
 #  Le Jin <le.jin@siemens.com>
 #  Jan Kiszka <jan.kiszka@siemens.com>
+#  Su Baocheng <baocheng.su@siemens.com>
 #
 # This file is subject to the terms and conditions of the MIT License.  See
 # COPYING.MIT file in the top-level directory.
@@ -15,7 +16,8 @@ DISTRO_NAME = "IOT2050 Debian System"
 
 HOSTNAME ??= "iot2050-debian"
 
-PREFERRED_VERSION_u-boot-iot2050 ?= "2021.04"
+PREFERRED_VERSION_u-boot-iot2050-pg1 ?= "2021.04"
+PREFERRED_VERSION_u-boot-iot2050-pg2 ?= "2021.04"
 PREFERRED_VERSION_linux-iot2050 ?= "5.10.%"
 PREFERRED_VERSION_linux-iot2050-rt ?= "5.10.%"
 

--- a/conf/machine/iot2050.conf
+++ b/conf/machine/iot2050.conf
@@ -1,8 +1,9 @@
 #
-# Copyright (c) Siemens AG, 2019
+# Copyright (c) Siemens AG, 2019-2022
 #
 # Authors:
 #  Le Jin <le.jin@siemens.com>
+#  Su Baocheng <baocheng.su@siemens.com>
 #
 # This file is subject to the terms and conditions of the MIT License.  See
 # COPYING.MIT file in the top-level directory.
@@ -11,6 +12,7 @@
 DISTRO_ARCH ?= "arm64"
 
 PREFERRED_PROVIDER_u-boot-${MACHINE} ?= "u-boot-iot2050-pg2"
+PREFERRED_PROVIDER_u-boot-${MACHINE}-config ?= "u-boot-iot2050-pg2"
 
 KERNEL_NAME ?= "iot2050"
 


### PR DESCRIPTION
Since the u-boot recipes have been splitted for PG1 and PG2, the example
image building uses the wrong upstream provider, due to the PREFERRED_VERSION_
prefix is not defined for the new -pgX PN.

Meanwhile the preferred u-boot-iot2050-config provider should be
adjust accordingly.

Signed-off-by: Su Baocheng <baocheng.su@siemens.com>