### PR TITLE
npm: Skip dh_strip_nondeterminism for npm packages

### DIFF
--- a/classes/npm.bbclass
+++ b/classes/npm.bbclass
@@ -243,3 +243,11 @@ do_install() {
 
     dpkg_undo_mounts
 }
+
+do_prepare_build_append() {
+    # disable slow stripping - not enough value for our ad-hoc npm packaging
+    cat <<EOF >> ${S}/debian/rules
+
+override_dh_strip_nondeterminism:
+EOF
+}


### PR DESCRIPTION
As our packaging is not clean anyway and this step takes a long while
with packages that have many files, maybe even longer with bullseye now,
simply skip it. Saves several minutes build time for many packages.
