### PR TITLE
Integrate support for Coral 

### DIFF
--- a/.github/workflows/free-disk-space/action.yml
+++ b/.github/workflows/free-disk-space/action.yml
@@ -1,0 +1,8 @@
+name: 'Free Disk Space'
+description: 'Remove content of the provided image to free disk space for the build'
+runs:
+  using: "composite"
+  steps:
+      - name: Remove /usr/local/* to free disk space
+        run:  sudo rm -rf /usr/local/*
+        shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Free Disk Space
+        uses: ./.github/workflows/free-disk-space
       - name: Build image
         run: ./kas-container build kas-iot2050-example.yml
       - name: Upload image
@@ -25,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Free Disk Space
+        uses: ./.github/workflows/free-disk-space
       - name: Build image
         run: ./kas-container build kas-iot2050-example.yml:kas/opt/preempt-rt.yml
       - name: Upload image
@@ -41,6 +45,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Free Disk Space
+        uses: ./.github/workflows/free-disk-space
       - name: Build bootloader image for PG1
         run: ./kas-container build kas-iot2050-boot-pg1.yml
       - name: Build bootloader image for PG2

--- a/Kconfig
+++ b/Kconfig
@@ -75,6 +75,18 @@ config KAS_INCLUDE_RT
 	default "kas/opt/preempt-rt.yml"
 	depends on PREEMPT_RT
 
+config CORAL
+	bool "Google Coral Edge TPU support"
+	default y
+	help
+	  Add driver and libraries to use a Google Coral Edge TPU accelerator
+	  card if it is installed in the IOT2050 extension slot.
+
+config KAS_INCLUDE_NO_CORAL
+	string
+	default "kas/opt/no-coral.yml"
+	depends on !CORAL
+
 comment "Build options"
 
 config SDK

--- a/kas/iot2050.yml
+++ b/kas/iot2050.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) Siemens AG, 2019
+# Copyright (c) Siemens AG, 2019-2022
 #
 # Authors:
 #  Le Jin <le.jin@siemens.com>
@@ -30,6 +30,17 @@ repos:
     refspec: 74036ebaab5265d62cdf90f563acd5b4d3b8b6d2
     layers:
       meta:
+    patches:
+      deb-build-profiles:
+        repo: meta-coral
+        path: patches/isar/0001-add-support-for-debian-build-profiles-and-options.patch
+      adjust-kernel-recipe:
+        repo: meta-coral
+        path: patches/isar/0002-refactor-linux-custom.inc-to-use-ISAR-s-DEB_BUILD_PR.patch
+
+  meta-coral:
+    url: https://github.com/siemens/meta-coral
+    refspec: f0202eaabc39b167d3e86e8595c6f97331f29293
 
 bblayers_conf_header:
   standard: |

--- a/kas/opt/no-coral.yml
+++ b/kas/opt/no-coral.yml
@@ -1,0 +1,16 @@
+#
+# Copyright (c) Siemens AG, 2022
+#
+# Authors:
+#  Jan Kiszka <jan.kiszka@siemens.com>
+#
+# This file is subject to the terms and conditions of the MIT License.  See
+# COPYING.MIT file in the top-level directory.
+#
+
+header:
+  version: 10
+
+local_conf_header:
+  disable-coral: |
+    IOT2050_CORAL_SUPPORT = "0"

--- a/recipes-core/images/iot2050-image-example.bb
+++ b/recipes-core/images/iot2050-image-example.bb
@@ -108,3 +108,11 @@ IMAGE_INSTALL += " \
     node-red-gpio \
     node-red-preinstalled-nodes \
     "
+
+IOT2050_CORAL_SUPPORT ?= "1"
+
+IMAGE_INSTALL += "${@ ' \
+    python3-pycoral \
+    pycoral-examples \
+    gasket-module-${KERNEL_NAME} \
+    ' if d.getVar('IOT2050_CORAL_SUPPORT') == '1' else ''}"

--- a/recipes-security/openssl/openssl_latest.bb
+++ b/recipes-security/openssl/openssl_latest.bb
@@ -18,14 +18,12 @@ CHANGELOG_V="<orig-version>+iot2050"
 
 KEEP_INSTALLED_ON_CLEAN = "1"
 
+DEB_BUILD_OPTIONS += "nocheck"
+
 do_prepare_build() {
 	deb_add_changelog
 
 	cd ${S}
 	quilt import ${WORKDIR}/*.patch
 	quilt push -a
-}
-
-dpkg_runbuild_prepend() {
-	export DEB_BUILD_OPTIONS="nocheck"
 }


### PR DESCRIPTION
Add Google Coral packages to the example image by default. This increases our storage demand, so include the github running VM cleanup that @gylstorffq developed for #115.