### PR TITLE
Revert "iot2050-image: Warn users about firmware incompatibility"

### DIFF
--- a/recipes-core/images/iot2050-image-base.bb
+++ b/recipes-core/images/iot2050-image-base.bb
@@ -56,8 +56,3 @@ python image_postprocess_restore_sources_list () {
     else:
         bb.note('No need to restore sources for mainline packages')
 }
-
-python do_image_append() {
-    bb.warn('This image is NOT COMPATIBLE with current official firmware releases!\n'
-            'It is recommended to build release V01.01.01 instead.')
-}


### PR DESCRIPTION
This reverts commit 597839ae5d8fcb1f0c51e61e8a220814ff6008a8.

New firmware 1.2.1 is now officially available.
