### PR TITLE
customizations-base: Do not package /etc/hosts, modify it

### DIFF
--- a/recipes-core/customizations-base/customizations-base_0.1-iot2050-debian.bb
+++ b/recipes-core/customizations-base/customizations-base_0.1-iot2050-debian.bb
@@ -15,14 +15,9 @@ include local.inc
 
 DESCRIPTION = "IOT2050 reference image customizations"
 
-SRC_URI = " \
-    file://postinst.tmpl \
-    file://hosts.tmpl"
+SRC_URI = "file://postinst.tmpl"
 
-TEMPLATE_FILES = "postinst.tmpl hosts.tmpl"
+TEMPLATE_FILES = "postinst.tmpl"
 TEMPLATE_VARS = "HOSTNAME"
 
-do_install() {
-    install -v -d ${D}/etc
-    install -v -m 644 ${WORKDIR}/hosts ${D}/etc/
-}
+DEBIAN_DEPENDS = "netbase"

--- a/recipes-core/customizations-base/files/hosts.tmpl
+++ b/recipes-core/customizations-base/files/hosts.tmpl
@@ -1,7 +1,0 @@
-127.0.0.1	localhost
-127.0.1.1	${HOSTNAME}
-
-# The following lines are desirable for IPv6 capable hosts
-::1     localhost ip6-localhost ip6-loopback
-ff02::1 ip6-allnodes
-ff02::2 ip6-allrouters

--- a/recipes-core/customizations-base/files/postinst.tmpl
+++ b/recipes-core/customizations-base/files/postinst.tmpl
@@ -8,7 +8,8 @@
 # COPYING.MIT file in the top-level directory.
 #
 
-echo "${HOSTNAME}" > /etc/hostname
+echo $HOSTNAME > /etc/hostname
+echo "127.0.0.1	${HOSTNAME}" >> /etc/hosts
 
 # set nodejs environment for module searching
 echo "NODE_PATH=\"/usr/lib/node_modules/:/usr/local/lib/node_modules/\"" >> /etc/environment


### PR DESCRIPTION
This avoids conflicts with other packages that want to adjust this file,
e.g. docker.io. And it's simpler because we can now let netbase deliver
the foundation.

This should resolve #262 (once merged into stable as well).