### PR TITLE
Fix SWUpdate build

### DIFF
--- a/.github/workflows/free-disk-space/action.yml
+++ b/.github/workflows/free-disk-space/action.yml
@@ -3,6 +3,11 @@ description: 'Remove content of the provided image to free disk space for the bu
 runs:
   using: "composite"
   steps:
-      - name: Remove /usr/local/* to free disk space
-        run:  sudo rm -rf /usr/local/*
+      - name:  Free disk space
+        run: |
+          sudo apt-get purge 'dotnet*' google-chrome-stable 'temurin*' google-cloud-sdk hhvm azure-cli 'mongodb*' powershell firefox chromium 'llvm*' 'libllvm*' 'adoptopenjdk*' 'mysql*' libgl1-mesa-dri apache2 'mono*'
+          sudo rm -rf /usr/local/* /opt/hostedtoolcache /opt/pipx* /opt/az
+        shell: bash
+      - name: Show disk space usage
+        run:  df -h
         shell: bash

--- a/kas/iot2050.yml
+++ b/kas/iot2050.yml
@@ -27,24 +27,17 @@ repos:
 
   isar:
     url: https://github.com/ilbers/isar
-    refspec: 74036ebaab5265d62cdf90f563acd5b4d3b8b6d2
+    refspec: cf3f18a649ff42726677a58b224b9bb58ea4ba46
     layers:
       meta:
-    patches:
-      deb-build-profiles:
-        repo: meta-coral
-        path: patches/isar/0001-add-support-for-debian-build-profiles-and-options.patch
-      adjust-kernel-recipe:
-        repo: meta-coral
-        path: patches/isar/0002-refactor-linux-custom.inc-to-use-ISAR-s-DEB_BUILD_PR.patch
 
   meta-coral:
     url: https://github.com/siemens/meta-coral
-    refspec: f0202eaabc39b167d3e86e8595c6f97331f29293
+    refspec: 9d0a1f60ae955ee2edca6caf98312e79accb98e2
 
   cip-core:
     url: https://gitlab.com/cip-project/cip-core/isar-cip-core.git
-    refspec: 0feddaa6dd65c5a1b56ff6fcb18b4e748e53972f
+    refspec: ed318f247beef10e0433c6ed699b4c1ab008fa6a
 
 bblayers_conf_header:
   standard: |


### PR DESCRIPTION
Fix the swupdate build error by bumping isar-cip-core to ed318f247beef10e0433c6ed699b4c1ab008fa6a.

Also bump ISAR and meta-coral refspec to drop the patches introduced by https://github.com/siemens/meta-iot2050/pull/259.

On my machine the build needs currently 52G disk memory.

An out-of-disk error occurred during building. Free disk space by purging the following packages:
- dotnet
- google-chrom-stable
-  temurin java
- google-cloud-sdk
- hhvm
- azure-cli
- llvm*

Also delete all content below /opt and /usr/local.

This leads to free disk space of 65G.


This is a workaround until a slim build environment is provided, see https://github.com/actions/virtual-environments/issues/5098. 