### PR TITLE
SWUpdate: Use DEB_BUILD_PROFILES

### DIFF
--- a/recipes-core/swupdate/swupdate_%.bbappend
+++ b/recipes-core/swupdate/swupdate_%.bbappend
@@ -7,8 +7,5 @@
 # SPDX-License-Identifier: MIT
 
 # Set pacakge build options
-# cross: for crosscompiling
-# nodocs: for no documentation
-# nocheck: do not build test
 # pkg.swupdate.bpo: Avoid mtd read errors during swupdate processing
-SWUPDATE_BUILD_PROFILES += "cross nodoc nocheck pkg.swupdate.bpo"
+DEB_BUILD_PROFILES += "pkg.swupdate.bpo"


### PR DESCRIPTION
Use DEB_BUILD_PROFILES to set pkg.swupdate.bpo to avoid
error messages during accessing mtd<X> device.

This fixes #265 .