### PR TITLE
u-boot: fix the issue that board can't load the correct dtb

### DIFF
--- a/recipes-bsp/u-boot/files/0001-iot2050-binman-add-missing-msg-for-blobs.patch
+++ b/recipes-bsp/u-boot/files/0001-iot2050-binman-add-missing-msg-for-blobs.patch
@@ -1,7 +1,7 @@
-From 4415d5cba8301616ba5fbd304f14425b787e830e Mon Sep 17 00:00:00 2001
+From f306b24341841d9d5bf3d1be5155f46e2c6c9d95 Mon Sep 17 00:00:00 2001
 From: Ivan Mikhaylov <ivan.mikhaylov@siemens.com>
 Date: Thu, 9 Dec 2021 16:10:53 +0000
-Subject: [PATCH 1/8] iot2050: binman: add missing-msg for blobs
+Subject: [PATCH 1/9] iot2050: binman: add missing-msg for blobs
 
 Add the 'missing-msg' for blobs for more detailed output on missing system
 firmware and SEBoot blobs.
@@ -16,7 +16,7 @@ Signed-off-by: Simon Glass <sjg@chromium.org>
  2 files changed, 16 insertions(+)
 
 diff --git a/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi b/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
-index 69479d7b18e..27058370ccc 100644
+index 69479d7b18..27058370cc 100644
 --- a/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
 +++ b/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
 @@ -18,6 +18,7 @@
@@ -54,7 +54,7 @@ index 69479d7b18e..27058370ccc 100644
  	};
  };
 diff --git a/tools/binman/missing-blob-help b/tools/binman/missing-blob-help
-index dc2d9c98111..551ca87f6cb 100644
+index dc2d9c9811..551ca87f6c 100644
 --- a/tools/binman/missing-blob-help
 +++ b/tools/binman/missing-blob-help
 @@ -18,6 +18,17 @@ scp-sunxi:

--- a/recipes-bsp/u-boot/files/0002-watchdog-rti_wdt-Add-10-safety-margin-to-clock-frequ.patch
+++ b/recipes-bsp/u-boot/files/0002-watchdog-rti_wdt-Add-10-safety-margin-to-clock-frequ.patch
@@ -1,7 +1,7 @@
-From 95d5104cdcf2e804fc5eb846245a5a85cfbafdba Mon Sep 17 00:00:00 2001
+From 637337e8228d68fd9cc8742f4631a5ef0f31c4f8 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 21 Feb 2022 17:09:08 +0100
-Subject: [PATCH 2/8] watchdog: rti_wdt: Add 10% safety margin to clock
+Subject: [PATCH 2/9] watchdog: rti_wdt: Add 10% safety margin to clock
  frequency
 
 When running against RC_OSC_32k, the watchdog may suffer from running
@@ -19,7 +19,7 @@ Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
  1 file changed, 11 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/watchdog/rti_wdt.c b/drivers/watchdog/rti_wdt.c
-index 253286d349b..8d93f19b984 100644
+index 253286d349..8d93f19b98 100644
 --- a/drivers/watchdog/rti_wdt.c
 +++ b/drivers/watchdog/rti_wdt.c
 @@ -41,7 +41,7 @@

--- a/recipes-bsp/u-boot/files/0003-mtd-spi-Convert-is_locked-callback-to-is_unlocked.patch
+++ b/recipes-bsp/u-boot/files/0003-mtd-spi-Convert-is_locked-callback-to-is_unlocked.patch
@@ -1,7 +1,7 @@
-From 40171361d1e9b429fc56af825d633c0dc2a4ffdc Mon Sep 17 00:00:00 2001
+From 28e2fcc8f8b3232faf44e421c43dd6258a6f0ec9 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 23 Feb 2022 10:26:16 +0100
-Subject: [PATCH 3/8] mtd: spi: Convert is_locked callback to is_unlocked
+Subject: [PATCH 3/9] mtd: spi: Convert is_locked callback to is_unlocked
 
 There was no user of this callback after 5b66fdb29dc3 anymore, and its
 semantic as now inconsistent between stm and sst26. What we need for the
@@ -15,7 +15,7 @@ Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
  2 files changed, 16 insertions(+), 16 deletions(-)
 
 diff --git a/drivers/mtd/spi/spi-nor-core.c b/drivers/mtd/spi/spi-nor-core.c
-index 4388a08a90d..6459a101a44 100644
+index 4388a08a90..6459a101a4 100644
 --- a/drivers/mtd/spi/spi-nor-core.c
 +++ b/drivers/mtd/spi/spi-nor-core.c
 @@ -1308,13 +1308,13 @@ static int stm_unlock(struct spi_nor *nor, loff_t ofs, uint64_t len)
@@ -87,7 +87,7 @@ index 4388a08a90d..6459a101a44 100644
  #endif
  
 diff --git a/include/linux/mtd/spi-nor.h b/include/linux/mtd/spi-nor.h
-index 4ceeae623de..f857a94db71 100644
+index 4ceeae623d..f857a94db7 100644
 --- a/include/linux/mtd/spi-nor.h
 +++ b/include/linux/mtd/spi-nor.h
 @@ -506,8 +506,8 @@ struct spi_flash {

--- a/recipes-bsp/u-boot/files/0004-sf-Query-write-protection-status-before-operating-th.patch
+++ b/recipes-bsp/u-boot/files/0004-sf-Query-write-protection-status-before-operating-th.patch
@@ -1,7 +1,7 @@
-From fb8c19671c4b1c4303abeccd49d053cb39ce447a Mon Sep 17 00:00:00 2001
+From 83c37e11d1f747fe9a68b3d322865f69fe527cfc Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 2 Feb 2022 07:20:43 +0100
-Subject: [PATCH 4/8] sf: Query write-protection status before operating the
+Subject: [PATCH 4/9] sf: Query write-protection status before operating the
  flash
 
 Do not suggest successful operation if a flash area to be changed is
@@ -17,7 +17,7 @@ Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
  1 file changed, 12 insertions(+)
 
 diff --git a/cmd/sf.c b/cmd/sf.c
-index eac27ed2d77..d4b70d26c48 100644
+index eac27ed2d7..d4b70d26c4 100644
 --- a/cmd/sf.c
 +++ b/cmd/sf.c
 @@ -287,6 +287,12 @@ static int do_spi_flash_read_write(int argc, char *const argv[])

--- a/recipes-bsp/u-boot/files/0005-arm-dts-iot2050-Add-cfg-register-space-for-ringacc-a.patch
+++ b/recipes-bsp/u-boot/files/0005-arm-dts-iot2050-Add-cfg-register-space-for-ringacc-a.patch
@@ -1,7 +1,7 @@
-From 7c7ad3d0988cfa5f2e569f1016bbb8036816fd9b Mon Sep 17 00:00:00 2001
+From f1bf616a87260616e586c1e20d1b7408780565cd Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 15 Feb 2022 22:15:40 +0100
-Subject: [PATCH 5/8] arm: dts: iot2050: Add cfg register space for ringacc and
+Subject: [PATCH 5/9] arm: dts: iot2050: Add cfg register space for ringacc and
  udmap
 
 Recent unrelated fixes (9876ae7db6da) revealed that we were missing bits
@@ -14,7 +14,7 @@ Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
  1 file changed, 24 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm/dts/k3-am65-iot2050-common-u-boot.dtsi b/arch/arm/dts/k3-am65-iot2050-common-u-boot.dtsi
-index 286e25f3794..d80c5501d2f 100644
+index 286e25f379..d80c5501d2 100644
 --- a/arch/arm/dts/k3-am65-iot2050-common-u-boot.dtsi
 +++ b/arch/arm/dts/k3-am65-iot2050-common-u-boot.dtsi
 @@ -1,6 +1,6 @@

--- a/recipes-bsp/u-boot/files/0006-board-siemens-iot2050-Split-the-build-for-PG1-and-PG.patch
+++ b/recipes-bsp/u-boot/files/0006-board-siemens-iot2050-Split-the-build-for-PG1-and-PG.patch
@@ -1,7 +1,7 @@
-From 706a83f6facf0e1069cfc71c182761becf0c5154 Mon Sep 17 00:00:00 2001
+From 59b7d7775d644a2fae0cb57a35e3eb650ffd5029 Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Wed, 12 Jan 2022 15:05:27 +0800
-Subject: [PATCH 6/8] board: siemens: iot2050: Split the build for PG1 and PG2
+Subject: [PATCH 6/9] board: siemens: iot2050: Split the build for PG1 and PG2
 
 Due to different signature keys, the PG1 and the PG2 boards can no
 longer use the same FSBL (tiboot3). This makes it impossible anyway to
@@ -21,18 +21,18 @@ Signed-off-by: Su Baocheng <baocheng.su@siemens.com>
 [Jan: refactor config option into targets, tweak some wordings]
 Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
 ---
- arch/arm/dts/k3-am65-iot2050-boot-image.dtsi  | 80 ++++++-------------
- board/siemens/iot2050/Kconfig                 | 28 ++++++-
- board/siemens/iot2050/board.c                 | 12 +--
- ...ot2050_defconfig => iot2050_pg1_defconfig} |  2 +-
- ...ot2050_defconfig => iot2050_pg2_defconfig} |  5 +-
- doc/board/siemens/iot2050.rst                 | 15 +++-
- 6 files changed, 65 insertions(+), 77 deletions(-)
- copy configs/{iot2050_defconfig => iot2050_pg1_defconfig} (99%)
- rename configs/{iot2050_defconfig => iot2050_pg2_defconfig} (95%)
+ arch/arm/dts/k3-am65-iot2050-boot-image.dtsi  |  80 ++++------
+ board/siemens/iot2050/Kconfig                 |  28 +++-
+ board/siemens/iot2050/board.c                 |  12 +-
+ ...ot2050_defconfig => iot2050_pg1_defconfig} |   2 +-
+ configs/iot2050_pg2_defconfig                 | 139 ++++++++++++++++++
+ doc/board/siemens/iot2050.rst                 |  15 +-
+ 6 files changed, 202 insertions(+), 74 deletions(-)
+ rename configs/{iot2050_defconfig => iot2050_pg1_defconfig} (99%)
+ create mode 100644 configs/iot2050_pg2_defconfig
 
 diff --git a/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi b/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
-index 27058370ccc..3135ad04715 100644
+index 27058370cc..3135ad0471 100644
 --- a/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
 +++ b/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
 @@ -1,6 +1,6 @@
@@ -179,7 +179,7 @@ index 27058370ccc..3135ad04715 100644
  		};
  	};
 diff --git a/board/siemens/iot2050/Kconfig b/board/siemens/iot2050/Kconfig
-index 8f634c172c1..e264bec2d44 100644
+index 8f634c172c..e264bec2d4 100644
 --- a/board/siemens/iot2050/Kconfig
 +++ b/board/siemens/iot2050/Kconfig
 @@ -1,20 +1,40 @@
@@ -228,7 +228,7 @@ index 8f634c172c1..e264bec2d44 100644
  config SYS_BOARD
  	default "iot2050"
 diff --git a/board/siemens/iot2050/board.c b/board/siemens/iot2050/board.c
-index b965ae9fa49..050ddb5899b 100644
+index b965ae9fa4..050ddb5899 100644
 --- a/board/siemens/iot2050/board.c
 +++ b/board/siemens/iot2050/board.c
 @@ -55,14 +55,6 @@ static bool board_is_advanced(void)
@@ -263,9 +263,9 @@ index b965ae9fa49..050ddb5899b 100644
  			fdtfile = "ti/k3-am6528-iot2050-basic-pg2.dtb";
 diff --git a/configs/iot2050_defconfig b/configs/iot2050_pg1_defconfig
 similarity index 99%
-copy from configs/iot2050_defconfig
-copy to configs/iot2050_pg1_defconfig
-index 4a87a3394de..bdec46c1638 100644
+rename from configs/iot2050_defconfig
+rename to configs/iot2050_pg1_defconfig
+index 4a87a3394d..bdec46c163 100644
 --- a/configs/iot2050_defconfig
 +++ b/configs/iot2050_pg1_defconfig
 @@ -8,7 +8,7 @@ CONFIG_SPL_LIBCOMMON_SUPPORT=y
@@ -277,39 +277,153 @@ index 4a87a3394de..bdec46c1638 100644
  CONFIG_ENV_SIZE=0x20000
  CONFIG_ENV_OFFSET=0x680000
  CONFIG_ENV_SECT_SIZE=0x20000
-diff --git a/configs/iot2050_defconfig b/configs/iot2050_pg2_defconfig
-similarity index 95%
-rename from configs/iot2050_defconfig
-rename to configs/iot2050_pg2_defconfig
-index 4a87a3394de..1bee7c46175 100644
---- a/configs/iot2050_defconfig
+diff --git a/configs/iot2050_pg2_defconfig b/configs/iot2050_pg2_defconfig
+new file mode 100644
+index 0000000000..1bee7c4617
+--- /dev/null
 +++ b/configs/iot2050_pg2_defconfig
-@@ -8,13 +8,13 @@ CONFIG_SPL_LIBCOMMON_SUPPORT=y
- CONFIG_SPL_LIBGENERIC_SUPPORT=y
- CONFIG_NR_DRAM_BANKS=2
- CONFIG_SOC_K3_AM6=y
--CONFIG_TARGET_IOT2050_A53=y
+@@ -0,0 +1,139 @@
++CONFIG_ARM=y
++CONFIG_SKIP_LOWLEVEL_INIT=y
++CONFIG_ARCH_K3=y
++CONFIG_SYS_MALLOC_LEN=0x2000000
++CONFIG_SYS_MALLOC_F_LEN=0x8000
++CONFIG_SPL_GPIO=y
++CONFIG_SPL_LIBCOMMON_SUPPORT=y
++CONFIG_SPL_LIBGENERIC_SUPPORT=y
++CONFIG_NR_DRAM_BANKS=2
++CONFIG_SOC_K3_AM6=y
 +CONFIG_TARGET_IOT2050_A53_PG2=y
- CONFIG_ENV_SIZE=0x20000
- CONFIG_ENV_OFFSET=0x680000
- CONFIG_ENV_SECT_SIZE=0x20000
- CONFIG_DM_GPIO=y
- CONFIG_SPL_DM_SPI=y
--CONFIG_DEFAULT_DEVICE_TREE="k3-am6528-iot2050-basic"
++CONFIG_ENV_SIZE=0x20000
++CONFIG_ENV_OFFSET=0x680000
++CONFIG_ENV_SECT_SIZE=0x20000
++CONFIG_DM_GPIO=y
++CONFIG_SPL_DM_SPI=y
 +CONFIG_DEFAULT_DEVICE_TREE="k3-am6528-iot2050-basic-pg2"
- CONFIG_SPL_TEXT_BASE=0x80080000
- CONFIG_SPL_SERIAL=y
- CONFIG_SPL_STACK_R_ADDR=0x82000000
-@@ -60,7 +60,6 @@ CONFIG_CMD_TIME=y
- # CONFIG_ISO_PARTITION is not set
- CONFIG_OF_CONTROL=y
- CONFIG_SPL_OF_CONTROL=y
--CONFIG_OF_LIST="k3-am6528-iot2050-basic k3-am6548-iot2050-advanced"
- CONFIG_SPL_MULTI_DTB_FIT=y
- CONFIG_SPL_OF_LIST="k3-am65-iot2050-spl"
- CONFIG_SPL_MULTI_DTB_FIT_NO_COMPRESSION=y
++CONFIG_SPL_TEXT_BASE=0x80080000
++CONFIG_SPL_SERIAL=y
++CONFIG_SPL_STACK_R_ADDR=0x82000000
++CONFIG_ENV_OFFSET_REDUND=0x6a0000
++CONFIG_SPL_SPI_FLASH_SUPPORT=y
++CONFIG_SPL_SPI=y
++CONFIG_DISTRO_DEFAULTS=y
++# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_SPL_LOAD_FIT=y
++# CONFIG_USE_SPL_FIT_GENERATOR is not set
++CONFIG_OF_BOARD_SETUP=y
++CONFIG_BOOTSTAGE=y
++CONFIG_SHOW_BOOT_PROGRESS=y
++CONFIG_SPL_SHOW_BOOT_PROGRESS=y
++CONFIG_CONSOLE_MUX=y
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_SPL_BOARD_INIT=y
++CONFIG_SPL_SYS_MALLOC_SIMPLE=y
++CONFIG_SPL_STACK_R=y
++CONFIG_SPL_SEPARATE_BSS=y
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_USE_SECTOR=y
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_SECTOR=0x1400
++CONFIG_SPL_DM_MAILBOX=y
++CONFIG_SPL_DM_SPI_FLASH=y
++CONFIG_SPL_DM_RESET=y
++CONFIG_SPL_POWER_DOMAIN=y
++# CONFIG_SPL_SPI_FLASH_TINY is not set
++CONFIG_SPL_SPI_FLASH_SFDP_SUPPORT=y
++CONFIG_SPL_SPI_LOAD=y
++CONFIG_SYS_SPI_U_BOOT_OFFS=0x280000
++CONFIG_SYS_PROMPT="IOT2050> "
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_DFU=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_I2C=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_REMOTEPROC=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_WDT=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_TIME=y
++# CONFIG_ISO_PARTITION is not set
++CONFIG_OF_CONTROL=y
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_SPL_MULTI_DTB_FIT=y
++CONFIG_SPL_OF_LIST="k3-am65-iot2050-spl"
++CONFIG_SPL_MULTI_DTB_FIT_NO_COMPRESSION=y
++CONFIG_ENV_IS_IN_SPI_FLASH=y
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
++CONFIG_DM=y
++CONFIG_SPL_DM=y
++CONFIG_SPL_DM_SEQ_ALIAS=y
++CONFIG_SPL_REGMAP=y
++CONFIG_SPL_OF_TRANSLATE=y
++CONFIG_CLK=y
++CONFIG_SPL_CLK=y
++CONFIG_CLK_TI_SCI=y
++CONFIG_DFU_MMC=y
++CONFIG_DFU_RAM=y
++CONFIG_DFU_SF=y
++CONFIG_DMA_CHANNELS=y
++CONFIG_TI_K3_NAVSS_UDMA=y
++CONFIG_TI_SCI_PROTOCOL=y
++CONFIG_DA8XX_GPIO=y
++CONFIG_DM_PCA953X=y
++CONFIG_DM_I2C=y
++CONFIG_I2C_SET_DEFAULT_BUS_NUM=y
++CONFIG_SYS_I2C_OMAP24XX=y
++CONFIG_LED=y
++CONFIG_SPL_LED=y
++CONFIG_LED_GPIO=y
++CONFIG_SPL_LED_GPIO=y
++CONFIG_DM_MAILBOX=y
++CONFIG_K3_SEC_PROXY=y
++CONFIG_MMC_HS200_SUPPORT=y
++CONFIG_MMC_SDHCI=y
++CONFIG_MMC_SDHCI_ADMA=y
++CONFIG_MMC_SDHCI_AM654=y
++CONFIG_DM_SPI_FLASH=y
++CONFIG_SPI_FLASH_SFDP_SUPPORT=y
++CONFIG_SPI_FLASH_STMICRO=y
++CONFIG_SPI_FLASH_WINBOND=y
++# CONFIG_SPI_FLASH_USE_4K_SECTORS is not set
++CONFIG_DM_ETH=y
++CONFIG_PCI=y
++CONFIG_PCI_KEYSTONE=y
++CONFIG_PHY=y
++CONFIG_AM654_PHY=y
++CONFIG_OMAP_USB2_PHY=y
++CONFIG_PINCTRL=y
++# CONFIG_PINCTRL_GENERIC is not set
++CONFIG_SPL_PINCTRL=y
++# CONFIG_SPL_PINCTRL_GENERIC is not set
++CONFIG_PINCTRL_SINGLE=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_TI_SCI_POWER_DOMAIN=y
++CONFIG_REMOTEPROC_TI_K3_R5F=y
++CONFIG_DM_RESET=y
++CONFIG_RESET_TI_SCI=y
++CONFIG_DM_SERIAL=y
++CONFIG_SOC_DEVICE=y
++CONFIG_SOC_DEVICE_TI_K3=y
++CONFIG_SOC_TI=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_CADENCE_QSPI=y
++CONFIG_SYSRESET=y
++CONFIG_SPL_SYSRESET=y
++CONFIG_SYSRESET_TI_SCI=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_DWC3=y
++CONFIG_USB_DWC3_GENERIC=y
++CONFIG_USB_KEYBOARD=y
++# CONFIG_WATCHDOG is not set
++# CONFIG_WATCHDOG_AUTOSTART is not set
++CONFIG_WDT=y
++CONFIG_WDT_K3_RTI=y
++CONFIG_WDT_K3_RTI_LOAD_FW=y
++CONFIG_OF_LIBFDT_OVERLAY=y
 diff --git a/doc/board/siemens/iot2050.rst b/doc/board/siemens/iot2050.rst
-index 7e97f817ce4..fd3431fa3f8 100644
+index 7e97f817ce..fd3431fa3f 100644
 --- a/doc/board/siemens/iot2050.rst
 +++ b/doc/board/siemens/iot2050.rst
 @@ -24,9 +24,10 @@ Binary dependencies can be found in

--- a/recipes-bsp/u-boot/files/0007-arm-dts-iot2050-Use-the-auto-generator-nodes-for-fdt.patch
+++ b/recipes-bsp/u-boot/files/0007-arm-dts-iot2050-Use-the-auto-generator-nodes-for-fdt.patch
@@ -1,7 +1,7 @@
-From 96cb235042c65dcb85d26d0428a8dafff64b35dd Mon Sep 17 00:00:00 2001
+From de72d7649c4cbc739f71363c13beec788c1b0182 Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Wed, 12 Jan 2022 14:52:01 +0800
-Subject: [PATCH 7/8] arm: dts: iot2050: Use the auto generator nodes for fdt
+Subject: [PATCH 7/9] arm: dts: iot2050: Use the auto generator nodes for fdt
 
 Refactor according to the entry `fit: Entry containing a FIT` of
 document tools/binman/README.entries.
@@ -15,7 +15,7 @@ Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
  2 files changed, 8 insertions(+), 37 deletions(-)
 
 diff --git a/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi b/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
-index 3135ad04715..46669576864 100644
+index 3135ad0471..4666957686 100644
 --- a/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
 +++ b/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
 @@ -32,6 +32,7 @@
@@ -88,7 +88,7 @@ index 3135ad04715..46669576864 100644
  					loadables = "k3-rti-wdt-firmware";
  #endif
 diff --git a/configs/iot2050_pg2_defconfig b/configs/iot2050_pg2_defconfig
-index 1bee7c46175..c8c21f71e25 100644
+index 1bee7c4617..c8c21f71e2 100644
 --- a/configs/iot2050_pg2_defconfig
 +++ b/configs/iot2050_pg2_defconfig
 @@ -60,6 +60,7 @@ CONFIG_CMD_TIME=y

--- a/recipes-bsp/u-boot/files/0008-iot2050-Update-firmware-layout.patch
+++ b/recipes-bsp/u-boot/files/0008-iot2050-Update-firmware-layout.patch
@@ -1,7 +1,7 @@
-From 709c811bccc2c04dfe95f60982fb6ca9b3b7e7c5 Mon Sep 17 00:00:00 2001
+From 8e6389d24179073cad9543405a3c11600e4c46ea Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 14 Jan 2022 18:52:06 +0100
-Subject: [PATCH 8/8] iot2050: Update firmware layout
+Subject: [PATCH 8/9] iot2050: Update firmware layout
 
 The latest version of the binary-only firmware parts come in a combined
 form of FSBL and sysfw containers. This implies some layout changes to
@@ -27,7 +27,7 @@ Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
  5 files changed, 11 insertions(+), 35 deletions(-)
 
 diff --git a/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi b/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
-index 46669576864..3ee0842e993 100644
+index 4666957686..3ee0842e99 100644
 --- a/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
 +++ b/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
 @@ -25,15 +25,15 @@
@@ -81,7 +81,7 @@ index 46669576864..3ee0842e993 100644
  	};
  };
 diff --git a/configs/iot2050_pg1_defconfig b/configs/iot2050_pg1_defconfig
-index bdec46c1638..826367ea779 100644
+index bdec46c163..826367ea77 100644
 --- a/configs/iot2050_pg1_defconfig
 +++ b/configs/iot2050_pg1_defconfig
 @@ -44,7 +44,7 @@ CONFIG_SPL_POWER_DOMAIN=y
@@ -94,7 +94,7 @@ index bdec46c1638..826367ea779 100644
  CONFIG_CMD_ASKENV=y
  CONFIG_CMD_DFU=y
 diff --git a/configs/iot2050_pg2_defconfig b/configs/iot2050_pg2_defconfig
-index c8c21f71e25..83866af4c68 100644
+index c8c21f71e2..83866af4c6 100644
 --- a/configs/iot2050_pg2_defconfig
 +++ b/configs/iot2050_pg2_defconfig
 @@ -44,7 +44,7 @@ CONFIG_SPL_POWER_DOMAIN=y
@@ -107,7 +107,7 @@ index c8c21f71e25..83866af4c68 100644
  CONFIG_CMD_ASKENV=y
  CONFIG_CMD_DFU=y
 diff --git a/doc/board/siemens/iot2050.rst b/doc/board/siemens/iot2050.rst
-index fd3431fa3f8..26972e20ae9 100644
+index fd3431fa3f..26972e20ae 100644
 --- a/doc/board/siemens/iot2050.rst
 +++ b/doc/board/siemens/iot2050.rst
 @@ -25,11 +25,7 @@ https://github.com/siemens/meta-iot2050/tree/master/recipes-bsp/u-boot/files/pre
@@ -123,7 +123,7 @@ index fd3431fa3f8..26972e20ae9 100644
  Building
  --------
 diff --git a/tools/binman/missing-blob-help b/tools/binman/missing-blob-help
-index 551ca87f6cb..38371ef8b39 100644
+index 551ca87f6c..38371ef8b3 100644
 --- a/tools/binman/missing-blob-help
 +++ b/tools/binman/missing-blob-help
 @@ -21,13 +21,7 @@ Please read the section on SCP firmware in board/sunxi/README.sunxi64

--- a/recipes-bsp/u-boot/files/0009-board-siemens-fix-the-issue-that-board-can-t-load-th.patch
+++ b/recipes-bsp/u-boot/files/0009-board-siemens-fix-the-issue-that-board-can-t-load-th.patch
@@ -1,0 +1,32 @@
+From a261ae6452c812986e94a801ae552d49a09956ca Mon Sep 17 00:00:00 2001
+From: chao zeng <chao.zeng@siemens.com>
+Date: Thu, 10 Mar 2022 15:38:32 +0800
+Subject: [PATCH 9/9] board:siemens:fix the issue that board can't load the
+ correct dtb
+
+the name like k3-am6528-iot2050-basic-pg2 not the iot2050-basic-pg2.
+so it can't find the correnct dtb.
+
+correct this issue
+
+Signed-off-by: chao zeng <chao.zeng@siemens.com>
+---
+ board/siemens/iot2050/board.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/board/siemens/iot2050/board.c b/board/siemens/iot2050/board.c
+index 050ddb5899..da5fb04e71 100644
+--- a/board/siemens/iot2050/board.c
++++ b/board/siemens/iot2050/board.c
+@@ -159,7 +159,7 @@ int board_fit_config_name_match(const char *name)
+ 		return -1;
+ 
+ 	str_to_upper(name, upper_name, sizeof(upper_name));
+-	if (!strcmp(upper_name, (char *)info->name))
++	if (strstr(upper_name, (char *)info->name))
+ 		return 0;
+ 
+ 	return -1;
+-- 
+2.34.1
+

--- a/recipes-bsp/u-boot/u-boot-iot2050_2022.01.inc
+++ b/recipes-bsp/u-boot/u-boot-iot2050_2022.01.inc
@@ -21,6 +21,7 @@ SRC_URI += " \
     file://0006-board-siemens-iot2050-Split-the-build-for-PG1-and-PG.patch \
     file://0007-arm-dts-iot2050-Use-the-auto-generator-nodes-for-fdt.patch \
     file://0008-iot2050-Update-firmware-layout.patch \
+    file://0009-board-siemens-fix-the-issue-that-board-can-t-load-th.patch \
     "
 
 SRC_URI[sha256sum] = "81b4543227db228c03f8a1bf5ddbc813b0bb8f6555ce46064ef721a6fc680413"


### PR DESCRIPTION
the name like k3-am6528-iot2050-basic-pg2 not the iot2050-basic-pg2.
so it can't find the correnct dtb.

correct this issue

Signed-off-by: chao zeng <chao.zeng@siemens.com>