### PR TITLE
openssl: Drop pinning to BASE_DISTRO_CODENAME

### DIFF
--- a/recipes-security/openssl/openssl_latest.bb
+++ b/recipes-security/openssl/openssl_latest.bb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) Siemens AG, 2020
+# Copyright (c) Siemens AG, 2020-2022
 #
 # Authors:
 #  Jan Kiszka <jan.kiszka@siemens.com>
@@ -11,7 +11,7 @@
 inherit dpkg
 
 SRC_URI = " \
-    apt://${PN}/${BASE_DISTRO_CODENAME} \
+    apt://${PN} \
     file://0001-make-bnrand_range-reliable-with-deterministic-run-ti.patch;apply=no \
     "
 CHANGELOG_V="<orig-version>+iot2050"


### PR DESCRIPTION
This is neither needed anymore because we have no additional version in
out apt sources. Nor does it work when there is an update in -security
while the pinning pulls from the release repo:

The following packages will be DOWNGRADED:
  libssl1.1
0 upgraded, 580 newly installed, 1 downgraded, 0 to remove and 0 not upgraded.
E: Packages were downgraded and -y was used without --allow-downgrades.
