### PR TITLE
iot2050-image-example: add armhf compat libraries

### DIFF
--- a/kas/iot2050.yml
+++ b/kas/iot2050.yml
@@ -52,3 +52,5 @@ local_conf_header:
     ISAR_CROSS_COMPILE = "1"
   ccache:
     USE_CCACHE = "1"
+  compatsupport: |
+    ISAR_ENABLE_COMPAT_ARCH = "1"

--- a/recipes-core/images/iot2050-image-example.bb
+++ b/recipes-core/images/iot2050-image-example.bb
@@ -81,16 +81,25 @@ IOT2050_DEBIAN_BT_PACKAGES = " \
     bluez \
     pulseaudio-module-bluetooth \
     "
+
 # alsa support
 IOT2050_DEBIAN_ALSA_PACKAGES = " \
     alsa-utils \
     alsa-tools \
     "
+
+# multiarch support
+IOT2050_DEBIAN_MULTIARCH_PACKAGES = " \
+    libc6:armhf \
+    libstdc++6:armhf \
+    "
+
 IMAGE_PREINSTALL += " \
     ${IOT2050_DEBIAN_DEBUG_PACKAGES} \
     ${IOT2050_DEBIAN_WIFI_PACKAGES} \
     ${IOT2050_DEBIAN_BT_PACKAGES} \
     ${IOT2050_DEBIAN_ALSA_PACKAGES} \
+    ${IOT2050_DEBIAN_MULTIARCH_PACKAGES} \
     "
 
 IMAGE_INSTALL += " \


### PR DESCRIPTION
As could not compile the 32bit application on the native machine.
it should use cross-compile method.
Some 32bit applications need to be transplanted and applied on iot2050,
so add armhf compat libraries.
besides enable compt support,can get corresponding supported sdk

Signed-off-by: chao zeng <chao.zeng@siemens.com>