### PR TITLE
Chao/fix partuuid

### DIFF
--- a/recipes-core/regen-rootfs-uuid/files/regen-rootfs-uuid.sh
+++ b/recipes-core/regen-rootfs-uuid/files/regen-rootfs-uuid.sh
@@ -16,7 +16,12 @@ if [ "${ROOT_DEV}" = "${BOOT_DEV}" ]; then
 	exit 1
 fi
 
-OLD_UUID=$(sfdisk --part-uuid ${BOOT_DEV} ${ROOT_PART})
+if [ $# -lt 1 ];then
+	OLD_UUID=$(sfdisk --part-uuid ${BOOT_DEV} ${ROOT_PART})
+else
+	OLD_UUID="$1"
+fi
+
 NEW_UUID=$(uuidgen)
 
 sfdisk --part-uuid ${BOOT_DEV} ${ROOT_PART} ${NEW_UUID}


### PR DESCRIPTION
After lots of testing,the error `waiting for partuuid` can not be resolved

when install image to emmc may show `the primary gpt table corrupt,the backup gpt table appears ok`
in this situation, using `sfdisk --part-uuid` can not get the changed partuuid instead of get the previous original emmc
partuuid not the new one(same as boot media part-uuid)

so in the script regen-rootfs-uuid `sed -i 's/'${OLD_UUID}'/'${NEW_UUID}'/i' /etc/default/u-boot-script` 
replacement fails

finally, it would result in `waiting for partuuid.....`