### PR TITLE
u-boot-iot2050: Fix the filesize command issue

### DIFF
--- a/recipes-bsp/u-boot/files/0023-iot2050-Add-script-for-signing-artifacts.patch
+++ b/recipes-bsp/u-boot/files/0023-iot2050-Add-script-for-signing-artifacts.patch
@@ -92,7 +92,7 @@ index 00000000000..5ccb4e8fb02
 +
 +REVISION=${2:-0}
 +SHA_VAL=$(openssl dgst -sha512 -hex tispl.bin | sed -e "s/^.*= //g")
-+BIN_SIZE=$(filesize tispl.bin)
++BIN_SIZE=$(stat -c %s tispl.bin)
 +
 +cat <<EOF >$TEMP_X509
 +[ req ]


### PR DESCRIPTION
Turn `filesize` to `stat -c %s`.

Signed-off-by: Baocheng Su <baocheng.su@siemens.com>