### PR TITLE
Add Isar patch to fix expand-on-first-boot

### DIFF
--- a/isar-patches/0001-expand-on-first-boot-Resolve-errors-in-helper-script.patch
+++ b/isar-patches/0001-expand-on-first-boot-Resolve-errors-in-helper-script.patch
@@ -1,0 +1,33 @@
+From 4eb6ec788b772c80f4529242928566ade2f16596 Mon Sep 17 00:00:00 2001
+From: Jan Kiszka <jan.kiszka@siemens.com>
+Date: Tue, 24 May 2022 20:25:11 +0200
+Subject: [PATCH] expand-on-first-boot: Resolve errors in helper script
+
+Missing quotes broke the -n test, and as we are at it, also resolve the
+shellcheck warnings.
+
+Fixes: 15214487e19e ("expand-on-first-boot: Add support for devicemapper")
+Reported-by: Felix Moessbauer <felix.moessbauer@siemens.com>
+Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
+---
+ .../expand-on-first-boot/files/expand-last-partition.sh       | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/meta/recipes-support/expand-on-first-boot/files/expand-last-partition.sh b/meta/recipes-support/expand-on-first-boot/files/expand-last-partition.sh
+index bb371e9f..8a8b7c98 100755
+--- a/meta/recipes-support/expand-on-first-boot/files/expand-last-partition.sh
++++ b/meta/recipes-support/expand-on-first-boot/files/expand-last-partition.sh
+@@ -11,8 +11,8 @@ set -e
+ 
+ ROOT_DEV="$(findmnt / -o source -n)"
+ ROOT_DEV_NAME=${ROOT_DEV##*/}
+-ROOT_DEV_SLAVE=$(ls -d /sys/block/${ROOT_DEV_NAME}/slaves/* 2>/dev/null | head -1)
+-if [ -n ${ROOT_DEV_SLAVE} ]; then
++ROOT_DEV_SLAVE=$(find /sys/block/"${ROOT_DEV_NAME}"/slaves/* 2>/dev/null | head -1)
++if [ -n "${ROOT_DEV_SLAVE}" ]; then
+ 	ROOT_DEV=/dev/${ROOT_DEV_SLAVE##*/}
+ fi
+ 
+-- 
+2.35.3
+

--- a/kas/iot2050.yml
+++ b/kas/iot2050.yml
@@ -36,6 +36,8 @@ repos:
         path: patches/isar/0001-Fix-permissions-when-splitting-rootfs-folders-across.patch
       expand-with-dm:
         path: isar-patches/0001-expand-on-first-boot-Add-support-for-devicemapper.patch
+      fix-expand-with-dm:
+        path: isar-patches/0001-expand-on-first-boot-Resolve-errors-in-helper-script.patch
 
   meta-coral:
     url: https://github.com/siemens/meta-coral


### PR DESCRIPTION
Currently, expand-on-first-boot is broken for the "normal" example image
due to the previously added Isar patch for the swupdate image. Fix it.
Both patches will vanish on next Isar update.
