### PR TITLE
iot2050-image-example: add mode switching tool for usb devices

### DIFF
--- a/recipes-core/images/iot2050-image-example.bb
+++ b/recipes-core/images/iot2050-image-example.bb
@@ -60,6 +60,7 @@ IOT2050_DEBIAN_DEBUG_PACKAGES = " \
     net-tools \
     i2c-tools \
     sudo \
+    usb-modeswitch \
     "
 
 # wifi support


### PR DESCRIPTION
Several new USB devices have their proprietary Windows drivers onboard,
especially WAN dongles.

they act like a flash storage,usb-modeswitch can switch  the device
from "usb-storage" to "usbserial".

Signed-off-by: chao zeng <chao.zeng@siemens.com>