### PR TITLE
classes/npm: let gyp use python3

### DIFF
--- a/classes/npm.bbclass
+++ b/classes/npm.bbclass
@@ -34,7 +34,7 @@ NPM_CLASS_PACKAGE ?= "npm"
 OWN_NPM_CLASS_PACKAGE ?= "0"
 
 # needed as gyp from bullseye does not establish /usr/bin/python
-NPM_EXTRA_DEPS = "${@'python' if d.getVar('NPM_REBUILD') == '1' else ''}"
+NPM_EXTRA_DEPS = "${@'python-is-python3' if d.getVar('NPM_REBUILD') == '1' else ''}"
 
 python() {
     src_uri = (d.getVar('SRC_URI', True) or "").split()


### PR DESCRIPTION
While gyp needs /usr/bin/python, it will happily work with python3
(removing the need to to pull python2): use Debian's package
python-is-python3 instead of python

Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>