### PR TITLE
swupdate: Avoid variable name clash with image_uuid.bbclass

### DIFF
--- a/recipes-core/images/iot2050-image-swu-example.bb
+++ b/recipes-core/images/iot2050-image-swu-example.bb
@@ -8,10 +8,10 @@
 # COPYING.MIT file in the top-level directory.
 #
 
-IMAGE_UUID = "image_uuid"
-IMAGE_UUID_secureboot = ""
+USE_IMAGE_UUID = "image_uuid"
+USE_IMAGE_UUID_secureboot = ""
 
-inherit ${IMAGE_UUID}
+inherit ${USE_IMAGE_UUID}
 
 # generate a swu image for a/b updating via swupdate
 IMAGE_FSTYPES = "wic-swu-img"


### PR DESCRIPTION
That class uses the same variable - but for the purpose of setting the
UUID value.

Reported-by: Vijai Kumar K <Vijaikumar_Kanagarajan@mentor.com>
Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>