### PR TITLE
u-boot-iot2050: Fix the PE image validation

### DIFF
--- a/isar-patches/0001-efibootguard-Update-to-release-0.12.patch
+++ b/isar-patches/0001-efibootguard-Update-to-release-0.12.patch
@@ -1,0 +1,77 @@
+From 4e7ea3e468760b19ab3a48faf8acae1a0849a41c Mon Sep 17 00:00:00 2001
+From: Jan Kiszka <jan.kiszka@siemens.com>
+Date: Mon, 11 Jul 2022 15:07:15 +0200
+Subject: [PATCH] efibootguard: Update to release 0.12
+
+Allows to drop our patch. And it's the precondition to add ARM support.
+
+Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
+---
+ ...bootguard_0.11.bb => efibootguard_0.12.bb} |  5 ++--
+ ...efile-Drop-nostdinc-for-EFI-binaries.patch | 28 -------------------
+ 2 files changed, 2 insertions(+), 31 deletions(-)
+ rename recipes-bsp/efibootguard/{efibootguard_0.11.bb => efibootguard_0.12.bb} (85%)
+ delete mode 100644 recipes-bsp/efibootguard/files/0001-Makefile-Drop-nostdinc-for-EFI-binaries.patch
+
+diff --git a/recipes-bsp/efibootguard/efibootguard_0.11.bb b/recipes-bsp/efibootguard/efibootguard_0.12.bb
+similarity index 85%
+rename from recipes-bsp/efibootguard/efibootguard_0.11.bb
+rename to recipes-bsp/efibootguard/efibootguard_0.12.bb
+index ef6cd9c..88dc2ed 100644
+--- a/recipes-bsp/efibootguard/efibootguard_0.11.bb
++++ b/recipes-bsp/efibootguard/efibootguard_0.12.bb
+@@ -19,15 +19,14 @@ MAINTAINER = "Jan Kiszka <jan.kiszka@siemens.com>"
+ SRC_URI = " \
+     https://github.com/siemens/efibootguard/archive/refs/tags/v${PV}.tar.gz;downloadfilename=efitbootguard-v${PV}.tar.gz \
+     file://debian \
+-    file://0001-Makefile-Drop-nostdinc-for-EFI-binaries.patch \
+     "
+-SRC_URI[sha256sum] = "12bd84ff63a34bef56e489b48d4f97955aa4d864eeff9ea2dea1d24a286d8ebe"
++SRC_URI[sha256sum] = "fd670f7a60a605c68ed411a9ab83ac680fbc9a9b5a8fd7b417c049f6cba5b6dc"
+ 
+ PROVIDES = "${PN}"
+ PROVIDES += "${PN}-dev"
+ 
+ DEPENDS = "python3-shtab"
+-BUILD_DEB_DEPENDS = "dh-exec,gnu-efi,libpci-dev,check,pkg-config,python3-shtab"
++BUILD_DEB_DEPENDS = "dh-exec,autoconf-archive,gnu-efi,libpci-dev,check,pkg-config,python3-shtab"
+ BUILD_DEB_DEPENDS_append_amd64 = ",libc6-dev-i386"
+ BUILD_DEB_DEPENDS_append_i386 = ",libc6-dev-i386"
+ 
+diff --git a/recipes-bsp/efibootguard/files/0001-Makefile-Drop-nostdinc-for-EFI-binaries.patch b/recipes-bsp/efibootguard/files/0001-Makefile-Drop-nostdinc-for-EFI-binaries.patch
+deleted file mode 100644
+index 8cc1654..0000000
+--- a/recipes-bsp/efibootguard/files/0001-Makefile-Drop-nostdinc-for-EFI-binaries.patch
++++ /dev/null
+@@ -1,28 +0,0 @@
+-From daf4cb61bec56dac628be83b95a7072c184eabcd Mon Sep 17 00:00:00 2001
+-From: Jan Kiszka <jan.kiszka@siemens.com>
+-Date: Wed, 4 May 2022 11:52:53 +0200
+-Subject: [PATCH] Makefile: Drop -nostdinc for EFI binaries
+-
+-Not needed, also systemd-boot does not use it, and it actually triggers
+-a build failure on Debian 10, possibly on other distros as well.
+-
+-Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
+----
+- Makefile.am | 1 -
+- 1 file changed, 1 deletion(-)
+-
+-diff --git a/Makefile.am b/Makefile.am
+-index f0daa15..7398b85 100644
+---- a/Makefile.am
+-+++ b/Makefile.am
+-@@ -191,7 +191,6 @@ efi_cflags = \
+- 	-Wall \
+- 	-Wextra \
+- 	-std=gnu99 \
+--	-nostdinc \
+- 	-ggdb -O0 \
+- 	-fpic \
+- 	-fshort-wchar \
+--- 
+-2.34.1
+-
+-- 
+2.30.2
+

--- a/kas/iot2050.yml
+++ b/kas/iot2050.yml
@@ -46,6 +46,9 @@ repos:
   cip-core:
     url: https://gitlab.com/cip-project/cip-core/isar-cip-core.git
     refspec: cf5d588527c315b4f16e8b3b3677e62a295b73f2
+    patches:
+      bump-efibootguard:
+        path: isar-patches/0001-efibootguard-Update-to-release-0.12.patch
 
 bblayers_conf_header:
   standard: |

--- a/recipes-bsp/u-boot/files/0001-iot2050-binman-add-missing-msg-for-blobs.patch
+++ b/recipes-bsp/u-boot/files/0001-iot2050-binman-add-missing-msg-for-blobs.patch
@@ -1,7 +1,7 @@
-From cdbc2c04484a4b75a9224682e82775e2e12f8cc8 Mon Sep 17 00:00:00 2001
+From a790bc99d6599716e14c94ec20882b62e7a5f384 Mon Sep 17 00:00:00 2001
 From: Ivan Mikhaylov <ivan.mikhaylov@siemens.com>
 Date: Thu, 9 Dec 2021 16:10:53 +0000
-Subject: [PATCH 01/28] iot2050: binman: add missing-msg for blobs
+Subject: [PATCH 01/31] iot2050: binman: add missing-msg for blobs
 
 Add the 'missing-msg' for blobs for more detailed output on missing system
 firmware and SEBoot blobs.
@@ -76,5 +76,5 @@ index dc2d9c9811..551ca87f6c 100644
  If CONFIG_WDT_K3_RTI_LOAD_FW is enabled, a firmware image is needed for
  the R5F core(s) to trigger the system reset. One possible source is
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0002-watchdog-rti_wdt-Add-10-safety-margin-to-clock-frequ.patch
+++ b/recipes-bsp/u-boot/files/0002-watchdog-rti_wdt-Add-10-safety-margin-to-clock-frequ.patch
@@ -1,7 +1,7 @@
-From 81696f9af691668eba1f1468bd984e19a13ab87d Mon Sep 17 00:00:00 2001
+From fed1c8f377322c69519538267d6687ee611518f9 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 21 Feb 2022 17:09:08 +0100
-Subject: [PATCH 02/28] watchdog: rti_wdt: Add 10% safety margin to clock
+Subject: [PATCH 02/31] watchdog: rti_wdt: Add 10% safety margin to clock
  frequency
 
 When running against RC_OSC_32k, the watchdog may suffer from running
@@ -58,5 +58,5 @@ index 253286d349..8d93f19b98 100644
  	return 0;
  }
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0003-mtd-spi-Convert-is_locked-callback-to-is_unlocked.patch
+++ b/recipes-bsp/u-boot/files/0003-mtd-spi-Convert-is_locked-callback-to-is_unlocked.patch
@@ -1,7 +1,7 @@
-From 06e9d143faab7b5d11547bb8243551aa28242812 Mon Sep 17 00:00:00 2001
+From 9134939b843f567dc99bb5fedaba8cb913d518cc Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 23 Feb 2022 10:26:16 +0100
-Subject: [PATCH 03/28] mtd: spi: Convert is_locked callback to is_unlocked
+Subject: [PATCH 03/31] mtd: spi: Convert is_locked callback to is_unlocked
 
 There was no user of this callback after 5b66fdb29dc3 anymore, and its
 semantic as now inconsistent between stm and sst26. What we need for the
@@ -111,5 +111,5 @@ index 4ceeae623d..f857a94db7 100644
  	int (*octal_dtr_enable)(struct spi_nor *nor);
  	int (*ready)(struct spi_nor *nor);
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0004-sf-Query-write-protection-status-before-operating-th.patch
+++ b/recipes-bsp/u-boot/files/0004-sf-Query-write-protection-status-before-operating-th.patch
@@ -1,7 +1,7 @@
-From 669c37097752c6f28f7ebadcf260f0ee087bf3f7 Mon Sep 17 00:00:00 2001
+From c34265562774cefab994bae793e9a08d914ee7e6 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 2 Feb 2022 07:20:43 +0100
-Subject: [PATCH 04/28] sf: Query write-protection status before operating the
+Subject: [PATCH 04/31] sf: Query write-protection status before operating the
  flash
 
 Do not suggest successful operation if a flash area to be changed is
@@ -47,5 +47,5 @@ index eac27ed2d7..d4b70d26c4 100644
  	printf("SF: %zu bytes @ %#x Erased: ", (size_t)size, (u32)offset);
  	if (ret)
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0005-arm-dts-iot2050-Add-cfg-register-space-for-ringacc-a.patch
+++ b/recipes-bsp/u-boot/files/0005-arm-dts-iot2050-Add-cfg-register-space-for-ringacc-a.patch
@@ -1,7 +1,7 @@
-From e9f2c35605d55babee6855a4e1adc099e441d4be Mon Sep 17 00:00:00 2001
+From 1fa4f3489d94829b3aec1e2641f3550553ab837c Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 15 Feb 2022 22:15:40 +0100
-Subject: [PATCH 05/28] arm: dts: iot2050: Add cfg register space for ringacc
+Subject: [PATCH 05/31] arm: dts: iot2050: Add cfg register space for ringacc
  and udmap
 
 Recent unrelated fixes (9876ae7db6da) revealed that we were missing bits
@@ -56,5 +56,5 @@ index 286e25f379..d80c5501d2 100644
  
  &cbass_wakeup {
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0006-board-siemens-iot2050-Split-the-build-for-PG1-and-PG.patch
+++ b/recipes-bsp/u-boot/files/0006-board-siemens-iot2050-Split-the-build-for-PG1-and-PG.patch
@@ -1,7 +1,7 @@
-From 7f8f57bef286330079bc012116afcea493db6c2c Mon Sep 17 00:00:00 2001
+From ab47d13039310308341cc3ed42052641d6cf3901 Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Wed, 12 Jan 2022 15:05:27 +0800
-Subject: [PATCH 06/28] board: siemens: iot2050: Split the build for PG1 and
+Subject: [PATCH 06/31] board: siemens: iot2050: Split the build for PG1 and
  PG2
 
 Due to different signature keys, the PG1 and the PG2 boards can no
@@ -343,5 +343,5 @@ index 7e97f817ce..fd3431fa3f 100644
  
  Flashing
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0007-arm-dts-iot2050-Use-the-auto-generator-nodes-for-fdt.patch
+++ b/recipes-bsp/u-boot/files/0007-arm-dts-iot2050-Use-the-auto-generator-nodes-for-fdt.patch
@@ -1,7 +1,7 @@
-From c470652def87f8a6e08f741a3a8cae180c505cf0 Mon Sep 17 00:00:00 2001
+From 6b0c3ea196cc2da8782ebc1217951b053fb7438a Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Wed, 12 Jan 2022 14:52:01 +0800
-Subject: [PATCH 07/28] arm: dts: iot2050: Use the auto generator nodes for fdt
+Subject: [PATCH 07/31] arm: dts: iot2050: Use the auto generator nodes for fdt
 
 Refactor according to the entry `fit: Entry containing a FIT` of
 document tools/binman/README.entries.
@@ -118,5 +118,5 @@ index 1bee7c4617..c8c21f71e2 100644
  CONFIG_SPL_OF_LIST="k3-am65-iot2050-spl"
  CONFIG_SPL_MULTI_DTB_FIT_NO_COMPRESSION=y
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0008-iot2050-Update-firmware-layout.patch
+++ b/recipes-bsp/u-boot/files/0008-iot2050-Update-firmware-layout.patch
@@ -1,7 +1,7 @@
-From 82719ac2bd58773480c728841143c8295c15bbed Mon Sep 17 00:00:00 2001
+From 2ad9139bce1ee3eb695c43a74f4289c53ea8b3fd Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 14 Jan 2022 18:52:06 +0100
-Subject: [PATCH 08/28] iot2050: Update firmware layout
+Subject: [PATCH 08/31] iot2050: Update firmware layout
 
 The latest version of the binary-only firmware parts come in a combined
 form of FSBL and sysfw containers. This implies some layout changes to
@@ -142,5 +142,5 @@ index 551ca87f6c..38371ef8b3 100644
  k3-rti-wdt-firmware:
  If CONFIG_WDT_K3_RTI_LOAD_FW is enabled, a firmware image is needed for
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0009-lib-crypto-Enable-more-algorithms-in-cert-verificati.patch
+++ b/recipes-bsp/u-boot/files/0009-lib-crypto-Enable-more-algorithms-in-cert-verificati.patch
@@ -1,7 +1,7 @@
-From 6b4c4fae80f7eba3790d36f23fd22938156853ad Mon Sep 17 00:00:00 2001
+From 5a6b96af7088860782866921325bce83c0e1483f Mon Sep 17 00:00:00 2001
 From: Ilias Apalodimas <ilias.apalodimas@linaro.org>
 Date: Wed, 19 Jan 2022 13:54:41 +0200
-Subject: [PATCH 09/28] lib/crypto: Enable more algorithms in cert verification
+Subject: [PATCH 09/31] lib/crypto: Enable more algorithms in cert verification
 
 Right now the code explicitly limits us to sha1,256 hashes with RSA2048
 encryption.  But the limitation is artificial since U-Boot supports
@@ -76,5 +76,5 @@ index df6033cdb4..3671ed1385 100644
  	info.key = pkey->key;
  	info.keylen = pkey->keylen;
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0010-efi_loader-use-pUs-for-printing-GUIDs.patch
+++ b/recipes-bsp/u-boot/files/0010-efi_loader-use-pUs-for-printing-GUIDs.patch
@@ -1,7 +1,7 @@
-From bba9f7a42eacd852ab06f3170944888b43938202 Mon Sep 17 00:00:00 2001
+From fd38aeb5caa5fbb67e52e0f956a0803f0df73dc7 Mon Sep 17 00:00:00 2001
 From: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>
 Date: Sun, 16 Jan 2022 14:15:31 +0100
-Subject: [PATCH 10/28] efi_loader: use %pUs for printing GUIDs
+Subject: [PATCH 10/31] efi_loader: use %pUs for printing GUIDs
 
 For printing GUIDs with macro EFI_ENTRY use %pUs instead of %pUl to provide
 readable debug output.
@@ -374,5 +374,5 @@ index 3cbb7c96c2..9f1dd74f36 100644
  	ret = efi_get_next_variable_name_int(variable_name_size, variable_name,
  					     vendor);
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0011-efi_loader-correctly-handle-mixed-hashes-and-signatu.patch
+++ b/recipes-bsp/u-boot/files/0011-efi_loader-correctly-handle-mixed-hashes-and-signatu.patch
@@ -1,7 +1,7 @@
-From 5aba47578fc03aed9b2c2aee1c7d6e06648f6f6a Mon Sep 17 00:00:00 2001
+From df674ede84b14db3367eb38f8fd4674b7b725eb8 Mon Sep 17 00:00:00 2001
 From: Ilias Apalodimas <ilias.apalodimas@linaro.org>
 Date: Sat, 29 Jan 2022 00:20:31 +0200
-Subject: [PATCH 11/28] efi_loader: correctly handle mixed hashes and
+Subject: [PATCH 11/31] efi_loader: correctly handle mixed hashes and
  signatures in db
 
 A mix of signatures and hashes in db doesn't always work as intended.
@@ -183,5 +183,5 @@ index 3243e2c60d..eb6886cdcc 100644
  		if (!efi_hash_regions(regs->reg, regs->num, &hash, &size)) {
  			EFI_PRINT("Digesting an image failed\n");
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0012-efi_loader-Improve-console-screen-clearing-and-reset.patch
+++ b/recipes-bsp/u-boot/files/0012-efi_loader-Improve-console-screen-clearing-and-reset.patch
@@ -1,7 +1,7 @@
-From 9de66d264778b9f409e36c2dcce123595fa0e7a2 Mon Sep 17 00:00:00 2001
+From e550c609227c52b05c3993f96c56c4b24fceb5ed Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 25 Apr 2022 10:33:15 +0200
-Subject: [PATCH 12/28] efi_loader: Improve console screen clearing and reset
+Subject: [PATCH 12/31] efi_loader: Improve console screen clearing and reset
 
 Ensure that the default colors are set when clearing the screen so that
 the background is properly filled and succeeding colored outputs will
@@ -55,5 +55,5 @@ index 3b012e1a66..eab187efd2 100644
  	return EFI_EXIT(EFI_SUCCESS);
  }
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0013-env-Complete-generic-support-for-writable-list.patch
+++ b/recipes-bsp/u-boot/files/0013-env-Complete-generic-support-for-writable-list.patch
@@ -1,7 +1,7 @@
-From c7c389ff272b44bae8ea2b5293b88275bed49c5d Mon Sep 17 00:00:00 2001
+From 4fa300bcd9313b1c0b334667e9f4f363e4bbc843 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 28 Feb 2022 12:00:14 +0100
-Subject: [PATCH 13/28] env: Complete generic support for writable list
+Subject: [PATCH 13/31] env: Complete generic support for writable list
 
 This completes what 890feecaab72 started by selecting ENV_APPEND and
 ENV_IS_NOWHERE and by moving this driver to top if the list. This
@@ -76,5 +76,5 @@ index e4dfb92e15..049c34069d 100644
  }
  
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0014-env-Couple-networking-related-variable-flags-to-CONF.patch
+++ b/recipes-bsp/u-boot/files/0014-env-Couple-networking-related-variable-flags-to-CONF.patch
@@ -1,7 +1,7 @@
-From dc2cd973fd8a9cbf5fae621ba809adbef05c8534 Mon Sep 17 00:00:00 2001
+From 9585d3ae8b9618265cdaf94a56aa540b7a060fc1 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 25 Apr 2022 11:15:36 +0200
-Subject: [PATCH 14/28] env: Couple networking-related variable flags to
+Subject: [PATCH 14/31] env: Couple networking-related variable flags to
  CONFIG_NET
 
 Boards may set networking variables programmatically, thus may have
@@ -85,5 +85,5 @@ index 313cb8c49a..b49ec8e80f 100644
   * Check if a string has the format of an Ethernet MAC address
   */
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0015-introduce-CONFIG_DEVICE_TREE_INCLUDES.patch
+++ b/recipes-bsp/u-boot/files/0015-introduce-CONFIG_DEVICE_TREE_INCLUDES.patch
@@ -1,7 +1,7 @@
-From 1110df4ece3c69aa41abf73903c7567c27dcf53a Mon Sep 17 00:00:00 2001
+From c6cfb9ed1ddd251f2efd771368757e6a7c9c8a3e Mon Sep 17 00:00:00 2001
 From: Rasmus Villemoes <rasmus.villemoes@prevas.dk>
 Date: Sun, 21 Nov 2021 14:52:51 +0100
-Subject: [PATCH 15/28] introduce CONFIG_DEVICE_TREE_INCLUDES
+Subject: [PATCH 15/31] introduce CONFIG_DEVICE_TREE_INCLUDES
 
 The build system already automatically looks for and includes an
 in-tree *-u-boot.dtsi when building the control .dtb. However, there
@@ -117,5 +117,5 @@ index 39f03398ed..4ab422c231 100644
  	$(DTC) -O dtb -o $@ -b 0 \
  		-i $(dir $<) $(DTC_FLAGS) \
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0016-tools-Add-script-for-converting-public-key-into-devi.patch
+++ b/recipes-bsp/u-boot/files/0016-tools-Add-script-for-converting-public-key-into-devi.patch
@@ -1,7 +1,7 @@
-From 3e13f8babfcb3010897f6a57f0437f510b439780 Mon Sep 17 00:00:00 2001
+From f2b7490138359861626f2682fe6f1ed32e1783e3 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 14 Feb 2022 07:05:15 +0100
-Subject: [PATCH 16/28] tools: Add script for converting public key into device
+Subject: [PATCH 16/31] tools: Add script for converting public key into device
  tree include
 
 Allows to create a public key device tree dtsi for inclusion into U-Boot
@@ -85,5 +85,5 @@ index 0000000000..1dbb2cc94b
 +out.write('\t};\n')
 +out.write('};\n')
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0017-binman-Include-also-subnodes-in-generator-nodes.patch
+++ b/recipes-bsp/u-boot/files/0017-binman-Include-also-subnodes-in-generator-nodes.patch
@@ -1,7 +1,7 @@
-From ea3b67fe9c7d397de6aac21cdf667199225aa83c Mon Sep 17 00:00:00 2001
+From 52edaeb22e5979dcd867ef1da3fa7b60a462c178 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 28 Feb 2022 17:06:20 +0100
-Subject: [PATCH 17/28] binman: Include also subnodes in generator nodes
+Subject: [PATCH 17/31] binman: Include also subnodes in generator nodes
 
 This allows to prefill fdt and config nodes with hash and signature
 subnodes. It's just important to place the child nodes last so that
@@ -57,5 +57,5 @@ index 99d710c57e..0197ffd159 100644
  			};
  
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0018-image-fit-Make-string-of-algo-parameter-constant.patch
+++ b/recipes-bsp/u-boot/files/0018-image-fit-Make-string-of-algo-parameter-constant.patch
@@ -1,7 +1,7 @@
-From cb56539ab9f31826af334f17fade71e39d83010a Mon Sep 17 00:00:00 2001
+From 5a0239c41af9a4fa342950784ba8c8e6ca924a95 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 14 Jan 2022 10:21:17 +0100
-Subject: [PATCH 18/28] image-fit: Make string of algo parameter constant
+Subject: [PATCH 18/31] image-fit: Make string of algo parameter constant
 
 Modifications would be invalid.
 
@@ -99,5 +99,5 @@ index a6b0a94420..a027155f3c 100644
  
  	node_name = fit_get_name(fit, noffset, NULL);
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0019-mkimage-Allow-to-specify-the-signature-algorithm-on-.patch
+++ b/recipes-bsp/u-boot/files/0019-mkimage-Allow-to-specify-the-signature-algorithm-on-.patch
@@ -1,7 +1,7 @@
-From 15e2a7c91bf904da8727c6f105ac3c4bec8cdf7c Mon Sep 17 00:00:00 2001
+From 99ca3b1e9dee719832691eaed7c9df16f88b97c8 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 14 Jan 2022 10:21:19 +0100
-Subject: [PATCH 19/28] mkimage: Allow to specify the signature algorithm on
+Subject: [PATCH 19/31] mkimage: Allow to specify the signature algorithm on
  the command line
 
 This permits to prepare FIT image description that do not hard-code the
@@ -278,5 +278,5 @@ index fbe883ce36..31738f218b 100644
  			params.os = genimg_get_os_id(optarg);
  			if (params.os < 0) {
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0020-iot2050-Add-watchdog-start-to-bootcmd.patch
+++ b/recipes-bsp/u-boot/files/0020-iot2050-Add-watchdog-start-to-bootcmd.patch
@@ -1,7 +1,7 @@
-From fc9d45296c4102c45e8434a646c0631b1c833e31 Mon Sep 17 00:00:00 2001
+From a54d0925b0a151e17bd3c889ab219224ec0a1188 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 20 Mar 2022 15:00:34 +0100
-Subject: [PATCH 20/28] iot2050: Add watchdog start to bootcmd
+Subject: [PATCH 20/31] iot2050: Add watchdog start to bootcmd
 
 Allows run-time control over watchdog auto-start and the timeout via
 setting the environment variable watchdog_timeout_ms. A value of zero
@@ -84,5 +84,5 @@ index 91ed76bb40..26875afdea 100644
  
  #include <configs/ti_armv7_common.h>
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0021-iot2050-Add-CONFIG_ENV_FLAGS_LIST_STATIC.patch
+++ b/recipes-bsp/u-boot/files/0021-iot2050-Add-CONFIG_ENV_FLAGS_LIST_STATIC.patch
@@ -1,7 +1,7 @@
-From 6c328c33eb676ebf9030452577103b2702446f45 Mon Sep 17 00:00:00 2001
+From 685f0dbedc0d371a26317752a3dda3e45964f203 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 25 Apr 2022 10:42:25 +0200
-Subject: [PATCH 21/28] iot2050: Add CONFIG_ENV_FLAGS_LIST_STATIC
+Subject: [PATCH 21/31] iot2050: Add CONFIG_ENV_FLAGS_LIST_STATIC
 
 Will be needed when CONFIG_ENV_WRITEABLE_LIST is enabled. The listed
 variables shall remain writable, for informational purposes - they have
@@ -31,5 +31,5 @@ index 26875afdea..097fca5e3b 100644
 +
  #endif /* __CONFIG_IOT2050_H */
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0022-arm-dts-iot2050-Allow-verifying-U-Boot-proper-by-SPL.patch
+++ b/recipes-bsp/u-boot/files/0022-arm-dts-iot2050-Allow-verifying-U-Boot-proper-by-SPL.patch
@@ -1,7 +1,7 @@
-From ba696f0562f5d10e2b032c178cb5cdaa246af3a6 Mon Sep 17 00:00:00 2001
+From d3425f5110617dbb6df58a85098febcf9402ee35 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 7 Nov 2021 17:59:17 +0100
-Subject: [PATCH 22/28] arm: dts: iot2050: Allow verifying U-Boot proper by SPL
+Subject: [PATCH 22/31] arm: dts: iot2050: Allow verifying U-Boot proper by SPL
 
 Add hashes and configuration signature stubs to prepare verified boot
 of main U-Boot by SPL.
@@ -71,5 +71,5 @@ index 3ee0842e99..9082a79a03 100644
  		fill@0x680000 {
  			offset = <0x680000>;
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0023-iot2050-Add-script-for-signing-artifacts.patch
+++ b/recipes-bsp/u-boot/files/0023-iot2050-Add-script-for-signing-artifacts.patch
@@ -1,7 +1,7 @@
-From 803acbdead674a74f5c8ba35d35ff6ddb737c040 Mon Sep 17 00:00:00 2001
+From 68da91ce946282c3ca78435fc892e99a4cc9ef99 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 18 Nov 2021 10:56:22 +0100
-Subject: [PATCH 23/28] iot2050: Add script for signing artifacts
+Subject: [PATCH 23/31] iot2050: Add script for signing artifacts
 
 There are many ways to get a signed firmware for the IOT2050 devices,
 namely for the parts under user-control. This script documents one way
@@ -133,5 +133,5 @@ index 0000000000..4d1d79498c
 +#source/tools/binman/binman replace -i flash.bin -f fit@0x380000.fit fit@0x380000
 +dd if=fit@0x380000.fit of=flash.bin bs=$((0x1000)) seek=$((0x380000/0x1000)) conv=notrunc
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0024-arm-dts-iot2050-Optionally-embed-OTP-programming-dat.patch
+++ b/recipes-bsp/u-boot/files/0024-arm-dts-iot2050-Optionally-embed-OTP-programming-dat.patch
@@ -1,7 +1,7 @@
-From 93fb91b1789694ea6dde905d900000491c7b12c0 Mon Sep 17 00:00:00 2001
+From b6443db6e7a9a9e090b958362ec080d0827d129d Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 27 May 2022 11:29:20 +0200
-Subject: [PATCH 24/28] arm: dts: iot2050: Optionally embed OTP programming
+Subject: [PATCH 24/31] arm: dts: iot2050: Optionally embed OTP programming
  data into image
 
 Use external blob otpcmd.bin to replace the 0xff filled OTP programming
@@ -97,5 +97,5 @@ index 38371ef8b3..b0c290b0fc 100644
  If CONFIG_WDT_K3_RTI_LOAD_FW is enabled, a firmware image is needed for
  the R5F core(s) to trigger the system reset. One possible source is
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0025-gpio-da8xx_gpio-Fix-gpio-name-with-address.patch
+++ b/recipes-bsp/u-boot/files/0025-gpio-da8xx_gpio-Fix-gpio-name-with-address.patch
@@ -1,7 +1,7 @@
-From 1f0870ea76a92eca47c63385f0893d3bab6aa8c8 Mon Sep 17 00:00:00 2001
+From 960874d0986851e090df2828e746326b4c8f722b Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Fri, 7 Jan 2022 11:26:24 +0800
-Subject: [PATCH 25/26] gpio: da8xx_gpio: Fix gpio name with address
+Subject: [PATCH 25/31] gpio: da8xx_gpio: Fix gpio name with address
 
 The GPIO bank numbers do not appear in the device tree,
 so make the gpio name based on the address
@@ -38,5 +38,5 @@ index d106e9846d..b310f2dbf6 100644
  }
  
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0026-board-siemens-iot2050-use-the-named-gpio-to-control-.patch
+++ b/recipes-bsp/u-boot/files/0026-board-siemens-iot2050-use-the-named-gpio-to-control-.patch
@@ -1,7 +1,7 @@
-From 2d93be810f813d1c44f627b6004409bb02717a54 Mon Sep 17 00:00:00 2001
+From 5611ee6f3052c523a76d2befacea9a717049b198 Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Wed, 12 Jan 2022 10:34:18 +0800
-Subject: [PATCH 26/26] board: siemens: iot2050: use the named gpio to control
+Subject: [PATCH 26/31] board: siemens: iot2050: use the named gpio to control
  the user-button
 
 User-button is controlled by the mcu domain gpio number 25.
@@ -29,5 +29,5 @@ index 2be5d1eefc..be30b9c4d1 100644
  	    dm_gpio_set_dir_flags(&gpio, GPIOD_IS_IN) < 0)
  		return false;
 -- 
-2.32.0
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0027-arm-dts-add-the-m.2-support.patch
+++ b/recipes-bsp/u-boot/files/0027-arm-dts-add-the-m.2-support.patch
@@ -1,7 +1,7 @@
-From 6e2210aebf96e0278d98cc3383c5fd1b1c8ae288 Mon Sep 17 00:00:00 2001
+From ac356fe052006b5bd9abfe1e95d03f2820082da7 Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Fri, 7 Jan 2022 10:18:07 +0800
-Subject: [PATCH 27/28] arm: dts: add the m.2 support
+Subject: [PATCH 27/31] arm: dts: add the m.2 support
 
 Add the support for the m.2 board based on the iot2050 advanced board
 The board has two m.2 connector,one is B-KEY,the other is E-KEY.
@@ -170,5 +170,5 @@ index cb49a0e36b..3475aee482 100644
  
  Flashing
 -- 
-2.34.1
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0028-board-siemens-iot2050-add-the-support-for-m2-variant.patch
+++ b/recipes-bsp/u-boot/files/0028-board-siemens-iot2050-add-the-support-for-m2-variant.patch
@@ -1,7 +1,7 @@
-From 80304e691a662efd1015134141582fa92de5f2d6 Mon Sep 17 00:00:00 2001
+From 36f67ae7d6029319bcf8e56fa565b0e6c9fde6bc Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Thu, 30 Jun 2022 10:53:05 +0800
-Subject: [PATCH 28/28] board: siemens: iot2050: add the support for m2 variant
+Subject: [PATCH 28/31] board: siemens: iot2050: add the support for m2 variant
 
 For normal boot, load and configure m.2 device through boot.scr
 For securey boot enable, go through UEFI, fixup the compatible
@@ -350,5 +350,5 @@ index be30b9c4d1..18d606ff31 100644
  }
  #endif
 -- 
-2.34.1
+2.30.2
 

--- a/recipes-bsp/u-boot/files/0029-lib-crypto-add-mscode_parser.patch
+++ b/recipes-bsp/u-boot/files/0029-lib-crypto-add-mscode_parser.patch
@@ -1,0 +1,295 @@
+From 65ef2c27edb8c2d37d0f92bbed68fa9ed34397d5 Mon Sep 17 00:00:00 2001
+From: AKASHI Takahiro <takahiro.akashi@linaro.org>
+Date: Tue, 5 Jul 2022 14:48:11 +0900
+Subject: [PATCH 29/31] lib: crypto: add mscode_parser
+
+In MS authenticode, pkcs7 should have data in its contentInfo field.
+This data is tagged with SpcIndirectData type and, for a signed PE image,
+provides a image's message digest as SpcPeImageData.
+
+This parser is used in image authentication to parse the field and
+retrieve a message digest.
+
+Imported from linux v5.19-rc, crypto/asymmetric_keys/mscode*.
+Checkpatch.pl generates tones of warnings, but those are not fixed
+for the sake of maintainability (importing from another source).
+
+Signed-off-by: AKASHI Takahiro <takahiro.akashi@linaro.org>
+(Backported 20220705054815.30318-2-takahiro.akashi@linaro.org to v2022.01)
+Signed-off-by: Baocheng Su <baocheng.su@siemens.com>
+---
+ include/crypto/mscode.h    |  43 ++++++++++++
+ lib/crypto/Kconfig         |   9 +++
+ lib/crypto/Makefile        |  12 ++++
+ lib/crypto/mscode.asn1     |  28 ++++++++
+ lib/crypto/mscode_parser.c | 135 +++++++++++++++++++++++++++++++++++++
+ 5 files changed, 227 insertions(+)
+ create mode 100644 include/crypto/mscode.h
+ create mode 100644 lib/crypto/mscode.asn1
+ create mode 100644 lib/crypto/mscode_parser.c
+
+diff --git a/include/crypto/mscode.h b/include/crypto/mscode.h
+new file mode 100644
+index 0000000000..551058b96e
+--- /dev/null
++++ b/include/crypto/mscode.h
+@@ -0,0 +1,43 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++/* PE Binary parser bits
++ *
++ * Copyright (C) 2014 Red Hat, Inc. All Rights Reserved.
++ * Written by David Howells (dhowells@redhat.com)
++ */
++
++#include <crypto/pkcs7.h>
++#ifndef __UBOOT__
++#include <crypto/hash_info.h>
++#endif
++
++struct pefile_context {
++#ifndef __UBOOT__
++	unsigned	header_size;
++	unsigned	image_checksum_offset;
++	unsigned	cert_dirent_offset;
++	unsigned	n_data_dirents;
++	unsigned	n_sections;
++	unsigned	certs_size;
++	unsigned	sig_offset;
++	unsigned	sig_len;
++	const struct section_header *secs;
++#endif
++
++	/* PKCS#7 MS Individual Code Signing content */
++	const void	*digest;		/* Digest */
++	unsigned	digest_len;		/* Digest length */
++	const char	*digest_algo;		/* Digest algorithm */
++};
++
++#ifndef __UBOOT__
++#define kenter(FMT, ...)					\
++	pr_devel("==> %s("FMT")\n", __func__, ##__VA_ARGS__)
++#define kleave(FMT, ...) \
++	pr_devel("<== %s()"FMT"\n", __func__, ##__VA_ARGS__)
++#endif
++
++/*
++ * mscode_parser.c
++ */
++extern int mscode_parse(void *_ctx, const void *content_data, size_t data_len,
++			size_t asn1hdrlen);
+diff --git a/lib/crypto/Kconfig b/lib/crypto/Kconfig
+index 6369bafac0..92fe5cd0b0 100644
+--- a/lib/crypto/Kconfig
++++ b/lib/crypto/Kconfig
+@@ -52,4 +52,13 @@ config PKCS7_MESSAGE_PARSER
+ config PKCS7_VERIFY
+ 	bool
+ 
++config MSCODE_PARSER
++	bool "MS authenticode parser"
++	select ASN1_DECODER
++	select ASN1_COMPILER
++	select OID_REGISTRY
++	help
++	  This option provides support for parsing MicroSoft's Authenticode
++	  in pkcs7 message.
++
+ endif # ASYMMETRIC_KEY_TYPE
+diff --git a/lib/crypto/Makefile b/lib/crypto/Makefile
+index f3a414525d..b86529da5e 100644
+--- a/lib/crypto/Makefile
++++ b/lib/crypto/Makefile
+@@ -48,3 +48,15 @@ obj-$(CONFIG_PKCS7_VERIFY) += pkcs7_verify.o
+ 
+ $(obj)/pkcs7_parser.o: $(obj)/pkcs7.asn1.h
+ $(obj)/pkcs7.asn1.o: $(obj)/pkcs7.asn1.c $(obj)/pkcs7.asn1.h
++
++#
++# Signed PE binary-wrapped key handling
++#
++obj-$(CONFIG_$(SPL_)MSCODE_PARSER) += mscode.o
++
++mscode-y := \
++	mscode_parser.o \
++	mscode.asn1.o
++
++$(obj)/mscode_parser.o: $(obj)/mscode.asn1.h $(obj)/mscode.asn1.h
++$(obj)/mscode.asn1.o: $(obj)/mscode.asn1.c $(obj)/mscode.asn1.h
+diff --git a/lib/crypto/mscode.asn1 b/lib/crypto/mscode.asn1
+new file mode 100644
+index 0000000000..6d09ba48c4
+--- /dev/null
++++ b/lib/crypto/mscode.asn1
+@@ -0,0 +1,28 @@
++--- Microsoft individual code signing data blob parser
++---
++--- Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
++--- Written by David Howells (dhowells@redhat.com)
++---
++--- This program is free software; you can redistribute it and/or
++--- modify it under the terms of the GNU General Public Licence
++--- as published by the Free Software Foundation; either version
++--- 2 of the Licence, or (at your option) any later version.
++---
++
++MSCode ::= SEQUENCE {
++	type			SEQUENCE {
++		contentType	ContentType,
++		parameters	ANY
++	},
++	content			SEQUENCE {
++		digestAlgorithm	DigestAlgorithmIdentifier,
++		digest		OCTET STRING ({ mscode_note_digest })
++	}
++}
++
++ContentType ::= OBJECT IDENTIFIER ({ mscode_note_content_type })
++
++DigestAlgorithmIdentifier ::= SEQUENCE {
++	algorithm   OBJECT IDENTIFIER ({ mscode_note_digest_algo }),
++	parameters  ANY OPTIONAL
++}
+diff --git a/lib/crypto/mscode_parser.c b/lib/crypto/mscode_parser.c
+new file mode 100644
+index 0000000000..90d5b37a6c
+--- /dev/null
++++ b/lib/crypto/mscode_parser.c
+@@ -0,0 +1,135 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/* Parse a Microsoft Individual Code Signing blob
++ *
++ * Copyright (C) 2014 Red Hat, Inc. All Rights Reserved.
++ * Written by David Howells (dhowells@redhat.com)
++ */
++
++#define pr_fmt(fmt) "MSCODE: "fmt
++#include <linux/kernel.h>
++#ifndef __UBOOT__
++#include <linux/slab.h>
++#endif
++#include <linux/err.h>
++#include <linux/oid_registry.h>
++#include <crypto/pkcs7.h>
++#ifdef __UBOOT__
++#include <crypto/mscode.h>
++#else
++#include "verify_pefile.h"
++#endif
++#include "mscode.asn1.h"
++
++/*
++ * Parse a Microsoft Individual Code Signing blob
++ */
++int mscode_parse(void *_ctx, const void *content_data, size_t data_len,
++		 size_t asn1hdrlen)
++{
++	struct pefile_context *ctx = _ctx;
++
++	content_data -= asn1hdrlen;
++	data_len += asn1hdrlen;
++	pr_devel("Data: %zu [%*ph]\n", data_len, (unsigned)(data_len),
++		 content_data);
++
++	return asn1_ber_decoder(&mscode_decoder, ctx, content_data, data_len);
++}
++
++/*
++ * Check the content type OID
++ */
++int mscode_note_content_type(void *context, size_t hdrlen,
++			     unsigned char tag,
++			     const void *value, size_t vlen)
++{
++	enum OID oid;
++
++	oid = look_up_OID(value, vlen);
++	if (oid == OID__NR) {
++		char buffer[50];
++
++		sprint_oid(value, vlen, buffer, sizeof(buffer));
++		pr_err("Unknown OID: %s\n", buffer);
++		return -EBADMSG;
++	}
++
++	/*
++	 * pesign utility had a bug where it was putting
++	 * OID_msIndividualSPKeyPurpose instead of OID_msPeImageDataObjId
++	 * So allow both OIDs.
++	 */
++	if (oid != OID_msPeImageDataObjId &&
++	    oid != OID_msIndividualSPKeyPurpose) {
++		pr_err("Unexpected content type OID %u\n", oid);
++		return -EBADMSG;
++	}
++
++	return 0;
++}
++
++/*
++ * Note the digest algorithm OID
++ */
++int mscode_note_digest_algo(void *context, size_t hdrlen,
++			    unsigned char tag,
++			    const void *value, size_t vlen)
++{
++	struct pefile_context *ctx = context;
++	char buffer[50];
++	enum OID oid;
++
++	oid = look_up_OID(value, vlen);
++	switch (oid) {
++	case OID_md4:
++		ctx->digest_algo = "md4";
++		break;
++	case OID_md5:
++		ctx->digest_algo = "md5";
++		break;
++	case OID_sha1:
++		ctx->digest_algo = "sha1";
++		break;
++	case OID_sha256:
++		ctx->digest_algo = "sha256";
++		break;
++	case OID_sha384:
++		ctx->digest_algo = "sha384";
++		break;
++	case OID_sha512:
++		ctx->digest_algo = "sha512";
++		break;
++	case OID_sha224:
++		ctx->digest_algo = "sha224";
++		break;
++
++	case OID__NR:
++		sprint_oid(value, vlen, buffer, sizeof(buffer));
++		pr_err("Unknown OID: %s\n", buffer);
++		return -EBADMSG;
++
++	default:
++		pr_err("Unsupported content type: %u\n", oid);
++		return -ENOPKG;
++	}
++
++	return 0;
++}
++
++/*
++ * Note the digest we're guaranteeing with this certificate
++ */
++int mscode_note_digest(void *context, size_t hdrlen,
++		       unsigned char tag,
++		       const void *value, size_t vlen)
++{
++	struct pefile_context *ctx = context;
++
++	ctx->digest = kmemdup(value, vlen, GFP_KERNEL);
++	if (!ctx->digest)
++		return -ENOMEM;
++
++	ctx->digest_len = vlen;
++
++	return 0;
++}
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/files/0030-efi_loader-signature-export-efi_hash_regions.patch
+++ b/recipes-bsp/u-boot/files/0030-efi_loader-signature-export-efi_hash_regions.patch
@@ -1,0 +1,45 @@
+From 2539ab52e25b9be783bef68f91118a9fdcb2e283 Mon Sep 17 00:00:00 2001
+From: AKASHI Takahiro <takahiro.akashi@linaro.org>
+Date: Tue, 5 Jul 2022 14:48:12 +0900
+Subject: [PATCH 30/31] efi_loader: signature: export efi_hash_regions()
+
+This function is used to calculate a message digest as part of
+authentication process in a later patch.
+
+Signed-off-by: AKASHI Takahiro <takahiro.akashi@linaro.org>
+(Backported 20220705054815.30318-3-takahiro.akashi@linaro.org to v2022.01)
+Signed-off-by: Baocheng Su <baocheng.su@siemens.com>
+---
+ include/efi_loader.h           | 2 ++
+ lib/efi_loader/efi_signature.c | 2 +-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/include/efi_loader.h b/include/efi_loader.h
+index 2c73fe3781..c46f6c8878 100644
+--- a/include/efi_loader.h
++++ b/include/efi_loader.h
+@@ -907,6 +907,8 @@ struct efi_signature_store {
+ struct x509_certificate;
+ struct pkcs7_message;
+ 
++bool efi_hash_regions(struct image_region *regs, int count,
++		      void **hash, size_t *size);
+ bool efi_signature_lookup_digest(struct efi_image_regions *regs,
+ 				 struct efi_signature_store *db,
+ 				 bool dbx);
+diff --git a/lib/efi_loader/efi_signature.c b/lib/efi_loader/efi_signature.c
+index eb6886cdcc..04820b811f 100644
+--- a/lib/efi_loader/efi_signature.c
++++ b/lib/efi_loader/efi_signature.c
+@@ -123,7 +123,7 @@ struct pkcs7_message *efi_parse_pkcs7_header(const void *buf,
+  *
+  * Return:	true on success, false on error
+  */
+-static bool efi_hash_regions(struct image_region *regs, int count,
++bool efi_hash_regions(struct image_region *regs, int count,
+ 			     void **hash, size_t *size)
+ {
+ 	if (!*hash) {
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/files/0031-efi_loader-image_loader-add-a-missing-digest-verific.patch
+++ b/recipes-bsp/u-boot/files/0031-efi_loader-image_loader-add-a-missing-digest-verific.patch
@@ -1,0 +1,133 @@
+From d5ab85366136770b55fda9e4db6db18b48a92e4d Mon Sep 17 00:00:00 2001
+From: AKASHI Takahiro <takahiro.akashi@linaro.org>
+Date: Tue, 5 Jul 2022 14:48:14 +0900
+Subject: [PATCH 31/31] efi_loader: image_loader: add a missing digest
+ verification for signed PE image
+
+At the last step of PE image authentication, an image's hash value must be
+compared with a message digest stored as the content (of SpcPeImageData type)
+of pkcs7's contentInfo.
+
+Fixes: commit 4540dabdcaca ("efi_loader: image_loader: support image authentication")
+Signed-off-by: AKASHI Takahiro <takahiro.akashi@linaro.org>
+(Backported 20220705054815.30318-5-takahiro.akashi@linaro.org to v2022.01)
+Signed-off-by: Baocheng Su <baocheng.su@siemens.com>
+---
+ lib/efi_loader/Kconfig            |  1 +
+ lib/efi_loader/efi_image_loader.c | 64 +++++++++++++++++++++++++++++--
+ 2 files changed, 62 insertions(+), 3 deletions(-)
+
+diff --git a/lib/efi_loader/Kconfig b/lib/efi_loader/Kconfig
+index 24f9a2bb75..4013044f47 100644
+--- a/lib/efi_loader/Kconfig
++++ b/lib/efi_loader/Kconfig
+@@ -352,6 +352,7 @@ config EFI_SECURE_BOOT
+ 	select X509_CERTIFICATE_PARSER
+ 	select PKCS7_MESSAGE_PARSER
+ 	select PKCS7_VERIFY
++	select MSCODE_PARSER
+ 	select EFI_SIGNATURE_SUPPORT
+ 	help
+ 	  Select this option to enable EFI secure boot support.
+diff --git a/lib/efi_loader/efi_image_loader.c b/lib/efi_loader/efi_image_loader.c
+index f43dfb3d57..1a8a7744b6 100644
+--- a/lib/efi_loader/efi_image_loader.c
++++ b/lib/efi_loader/efi_image_loader.c
+@@ -16,6 +16,7 @@
+ #include <malloc.h>
+ #include <pe.h>
+ #include <sort.h>
++#include <crypto/mscode.h>
+ #include <crypto/pkcs7_parser.h>
+ #include <linux/err.h>
+ 
+@@ -516,6 +517,51 @@ err:
+ }
+ 
+ #ifdef CONFIG_EFI_SECURE_BOOT
++/**
++ * efi_image_verify_digest - verify image's message digest
++ * @regs:	Array of memory regions to digest
++ * @msg:	Signature in pkcs7 structure
++ *
++ * @regs contains all the data in a PE image to digest. Calculate
++ * a hash value based on @regs and compare it with a messaged digest
++ * in the content (SpcPeImageData) of @msg's contentInfo.
++ *
++ * Return:	true if verified, false if not
++ */
++static bool efi_image_verify_digest(struct efi_image_regions *regs,
++				    struct pkcs7_message *msg)
++{
++	struct pefile_context ctx;
++	void *hash;
++	size_t hash_len;
++	int ret;
++
++	const void *data;
++	size_t data_len;
++	size_t asn1hdrlen;
++
++	/* get pkcs7's contentInfo */
++	ret = pkcs7_get_content_data(msg, &data, &data_len, &asn1hdrlen);
++	if (ret < 0 || !data)
++		return false;
++
++	/* parse data and retrieve a message digest into ctx */
++	ret = mscode_parse(&ctx, data, data_len, asn1hdrlen);
++	if (ret < 0)
++		return false;
++
++	/* calculate a hash value of PE image */
++	hash = NULL;
++	if (!efi_hash_regions(regs->reg, regs->num, &hash, &hash_len))
++		return false;
++
++	/* match the digest */
++	if (ctx.digest_len != hash_len || memcmp(ctx.digest, hash, hash_len))
++		return false;
++
++	return true;
++}
++
+ /**
+  * efi_image_unsigned_authenticate() - authenticate unsigned image with
+  * SHA256 hash
+@@ -697,6 +743,9 @@ static bool efi_image_authenticate(void *efi, size_t efi_size)
+ 		}
+ 
+ 		/*
++		 * verify signatures in pkcs7's signedInfos which are
++		 * to authenticate the integrity of pkcs7's contentInfo.
++		 *
+ 		 * NOTE:
+ 		 * UEFI specification defines two signature types possible
+ 		 * in signature database:
+@@ -727,12 +776,21 @@ static bool efi_image_authenticate(void *efi, size_t efi_size)
+ 		}
+ 
+ 		/* try white-list */
+-		if (efi_signature_verify(regs, msg, db, dbx)) {
++		if (!efi_signature_verify(regs, msg, db, dbx)) {
++			EFI_PRINT("Signature was not verified by \"db\"\n");
++			continue;
++		}
++
++		/*
++		 * now calculate an image's hash value and compare it with
++		 * a messaged digest embedded in pkcs7's contentInfo
++		 */
++		if (efi_image_verify_digest(regs, msg)) {
+ 			ret = true;
+-			break;
++			continue;
+ 		}
+ 
+-		EFI_PRINT("Signature was not verified by \"db\"\n");
++		EFI_PRINT("Message digest doesn't match\n");
+ 
+ 		if (efi_signature_lookup_digest(regs, db, false)) {
+ 			ret = true;
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/files/secure-boot.cfg
+++ b/recipes-bsp/u-boot/files/secure-boot.cfg
@@ -4,7 +4,7 @@ CONFIG_ENV_VARS_UBOOT_CONFIG=y
 CONFIG_SPL_FIT_SIGNATURE=y
 CONFIG_BOOTDELAY=-2
 CONFIG_USE_BOOTCOMMAND=y
-CONFIG_BOOTCOMMAND="setenv scan_dev_for_boot 'if test -e ${devtype} ${devnum}:${distro_bootpart} efi/boot/bootaa64.efi; then load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} efi/boot/bootaa64.efi; bootefi ${kernel_addr_r} ${fdtcontroladdr}; fi'; run start_watchdog; run distro_bootcmd; echo 'EFI Boot failed!'; sleep 1000; reset"
+CONFIG_BOOTCOMMAND="setenv scan_dev_for_boot 'if test -e ${devtype} ${devnum}:${distro_bootpart} efi/boot/bootaa64.efi; then load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} efi/boot/bootaa64.efi; bootefi ${kernel_addr_r} ${fdtcontroladdr}; fi'; run start_watchdog; run distro_bootcmd; echo 'EFI Boot failed!'; led status-led-green off; led status-led-red on; sleep 1000; reset"
 CONFIG_HUSH_PARSER=y
 # CONFIG_CMD_BOOTD is not set
 # CONFIG_CMD_BOOTI is not set

--- a/recipes-bsp/u-boot/u-boot-iot2050_2022.01.inc
+++ b/recipes-bsp/u-boot/u-boot-iot2050_2022.01.inc
@@ -41,6 +41,9 @@ SRC_URI += " \
     file://0026-board-siemens-iot2050-use-the-named-gpio-to-control-.patch \
     file://0027-arm-dts-add-the-m.2-support.patch \
     file://0028-board-siemens-iot2050-add-the-support-for-m2-variant.patch \
+    file://0029-lib-crypto-add-mscode_parser.patch \
+    file://0030-efi_loader-signature-export-efi_hash_regions.patch \
+    file://0031-efi_loader-image_loader-add-a-missing-digest-verific.patch \
     "
 
 SRC_URI[sha256sum] = "81b4543227db228c03f8a1bf5ddbc813b0bb8f6555ce46064ef721a6fc680413"


### PR DESCRIPTION
1. Backport the upstream fix of the PE image validation issue of UEFI secure
boot:

https://patchwork.ozlabs.org/project/uboot/cover/20220705054815.30318-1-
takahiro.akashi@linaro.org/

2. Upgrade efibootguard to v0.12 to pick up the `bg_gen_unified_kernel` change to drop the symbol  table from the PE Image so that u-Boot can calculate the correct hash value.

3. the fix to turn on the RED stat LED once boot failed in secure boot mode.