### PR TITLE
kconfig: Secure boot for m.2 variant

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -139,7 +139,7 @@ config SECURE_BOOT
 
 config OTP_PROVISIONING
 	bool "OTP Provisioning"
-	depends on IMAGE_BOOT_PG2
+	depends on IMAGE_BOOT_PG2 || IMAGE_BOOT_M2
 	help
 	  Integrate OTP provisioning data into the firmware artifacts. Various
 	  options are avaiable. By default, this will integrate the OTP command
@@ -211,7 +211,7 @@ config KAS_INCLUDE_DEBIAN_MIRROR
 config FIRMWARE_SECURE_VER
 	string "Use specific firmware secure version"
 	default "0"
-	depends on SECURE_BOOT && IMAGE_BOOT_PG2
+	depends on SECURE_BOOT && (IMAGE_BOOT_PG2 || IMAGE_BOOT_M2)
 	help
 	  Use specific anti-rollback secure version rather than the default 0.
 	  Range 0 - 127.


### PR DESCRIPTION
Fix the Kconfig for the secure boot on m.2 variant, so that
`kas-container menu` could show the secure boot options when the m.2
firmware target is chosen, especially the OTP provisioning options and
the firmware secure version.

