### PR TITLE
ci: Reword for bootloaders

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
             build/tmp/deploy/images/iot2050/iot2050-image-swu-example-iot2050-debian-iot2050.wic.img.bmap
 
   bootloaders:
-    name: Bootloaders for both PG1 and PG2
+    name: Bootloaders
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -67,7 +67,7 @@ jobs:
         uses: ./.github/workflows/free-disk-space
       - name: Build bootloader image for PG1
         run: ./kas-container build kas-iot2050-boot-pg1.yml
-      - name: Build bootloader image for PG2
+      - name: Build bootloader image for PG2 & m.2
         run: ./kas-container build kas-iot2050-boot-pg2.yml
       - name: Archive bootloaders
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
As now we have another m.2 variant, the old wording for bootloaders
could not stand any more.

Reword the job name to `Bootloaders` to cover all variants, including
future variants, if any. Meanwhile reword the stage names to be more
accurate.

Signed-off-by: Baocheng Su <baocheng.su@siemens.com>