### PR TITLE
iot2050-image-example: Add systemd-timesyncd

### DIFF
--- a/recipes-core/images/iot2050-image-example.bb
+++ b/recipes-core/images/iot2050-image-example.bb
@@ -61,6 +61,7 @@ IOT2050_DEBIAN_DEBUG_PACKAGES = " \
     i2c-tools \
     sudo \
     usb-modeswitch \
+    systemd-timesyncd \
     "
 
 # wifi support


### PR DESCRIPTION
Currently,there is no ntp service by default,so can not
sync time automatic.

Using systemd-timesyncd daemon to do the time sync.

Signed-off-by: chao zeng <chao.zeng@siemens.com>