### PR TITLE
linux-iot2050: Fix rs485 rts polarity change

### DIFF
--- a/recipes-kernel/linux/files/patches-5.10/0001-dmaengine-ti-k3-udma-glue-Add-function-to-get-device.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0001-dmaengine-ti-k3-udma-glue-Add-function-to-get-device.patch
@@ -1,7 +1,7 @@
-From 603a9590dcc71ba70e069324b881ac41df1a4a25 Mon Sep 17 00:00:00 2001
+From 455cbe79cac9ec192cc44427cfa0782ee64753f5 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Tue, 8 Dec 2020 11:04:24 +0200
-Subject: [PATCH 001/120] dmaengine: ti: k3-udma-glue: Add function to get
+Subject: [PATCH 001/121] dmaengine: ti: k3-udma-glue: Add function to get
  device pointer for DMA API
 
 Glue layer users should use the device of the DMA for DMA mapping and

--- a/recipes-kernel/linux/files/patches-5.10/0002-arm64-dts-ti-k3-am65-ringacc-drop-ti-dma-ring-reset-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0002-arm64-dts-ti-k3-am65-ringacc-drop-ti-dma-ring-reset-.patch
@@ -1,7 +1,7 @@
-From 9bd9615279d9aefdfa3cd275a351579509d8e1ff Mon Sep 17 00:00:00 2001
+From 528ac4460a5338f5725d8b1d035b27631d0f90b6 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Sat, 29 Aug 2020 21:41:39 +0300
-Subject: [PATCH 002/120] arm64: dts: ti: k3-am65: ringacc: drop ti,
+Subject: [PATCH 002/121] arm64: dts: ti: k3-am65: ringacc: drop ti,
  dma-ring-reset-quirk
 
 Remove obsolete "ti,dma-ring-reset-quirk" Ringacc DT property.

--- a/recipes-kernel/linux/files/patches-5.10/0003-arm64-dts-ti-k3-am65-mcu-Add-MCU-domain-R5F-cluster-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0003-arm64-dts-ti-k3-am65-mcu-Add-MCU-domain-R5F-cluster-.patch
@@ -1,7 +1,7 @@
-From e888895d9dcbca5f18714a1d2efc305f08cb9504 Mon Sep 17 00:00:00 2001
+From a9bc9bf62d5a2a411e76769cb0c52a03782a6ea9 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 28 Oct 2020 22:37:55 -0500
-Subject: [PATCH 003/120] arm64: dts: ti: k3-am65-mcu: Add MCU domain R5F
+Subject: [PATCH 003/121] arm64: dts: ti: k3-am65-mcu: Add MCU domain R5F
  cluster node
 
 The AM65x SoCs have a single dual-core Arm Cortex-R5F processor (R5FSS)

--- a/recipes-kernel/linux/files/patches-5.10/0004-arm64-dts-ti-k3-am65-Cleanup-disabled-nodes-at-SoC-d.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0004-arm64-dts-ti-k3-am65-Cleanup-disabled-nodes-at-SoC-d.patch
@@ -1,7 +1,7 @@
-From f84eba93a39502a055ec53345bd8f56191eaaa00 Mon Sep 17 00:00:00 2001
+From 16b48d3fc38696b09fba4cc2e36b0e16789d8e32 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Fri, 13 Nov 2020 15:18:22 -0600
-Subject: [PATCH 004/120] arm64: dts: ti: k3-am65*: Cleanup disabled nodes at
+Subject: [PATCH 004/121] arm64: dts: ti: k3-am65*: Cleanup disabled nodes at
  SoC dtsi level
 
 The device tree standard states that when the status property is

--- a/recipes-kernel/linux/files/patches-5.10/0005-arm64-dts-ti-am65-j721e-Fix-up-un-necessary-status-s.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0005-arm64-dts-ti-am65-j721e-Fix-up-un-necessary-status-s.patch
@@ -1,7 +1,7 @@
-From 0182a5ecf717a6c4848f93a72100f37e2f1bbf2d Mon Sep 17 00:00:00 2001
+From d6869bb201f6529133b58d025d9ef2bc98e8e5bd Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Fri, 13 Nov 2020 15:18:24 -0600
-Subject: [PATCH 005/120] arm64: dts: ti: am65/j721e: Fix up un-necessary
+Subject: [PATCH 005/121] arm64: dts: ti: am65/j721e: Fix up un-necessary
  status set to "okay" for crypto
 
 The default state of a device tree node is "okay". There is no specific

--- a/recipes-kernel/linux/files/patches-5.10/0006-arm64-dts-ti-k3-mmc-fix-dtbs_check-warnings.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0006-arm64-dts-ti-k3-mmc-fix-dtbs_check-warnings.patch
@@ -1,7 +1,7 @@
-From ab940579d4b7bb7a68ff983ece9861588d91b04e Mon Sep 17 00:00:00 2001
+From dedc9fa8aeccd46a7d99a5054d220202e5a67606 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 15 Jan 2021 21:30:16 +0200
-Subject: [PATCH 006/120] arm64: dts: ti: k3: mmc: fix dtbs_check warnings
+Subject: [PATCH 006/121] arm64: dts: ti: k3: mmc: fix dtbs_check warnings
 
 Now the dtbs_check produces below warnings
  sdhci@4f80000: clock-names:0: 'clk_ahb' was expected

--- a/recipes-kernel/linux/files/patches-5.10/0007-arm64-dts-ti-k3-am65-main-Add-device_type-to-pcie-_r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0007-arm64-dts-ti-k3-am65-main-Add-device_type-to-pcie-_r.patch
@@ -1,7 +1,7 @@
-From 692a4ad2beab3e0b9b5318070fea0701dd0d7e6c Mon Sep 17 00:00:00 2001
+From 4510c08d9f4062957276526dfe1817b1591f9b76 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Feb 2021 20:32:56 +0100
-Subject: [PATCH 007/120] arm64: dts: ti: k3-am65-main: Add device_type to
+Subject: [PATCH 007/121] arm64: dts: ti: k3-am65-main: Add device_type to
  pcie*_rc nodes
 
 This is demanded by the parent binding of ti,am654-pcie-rc, see

--- a/recipes-kernel/linux/files/patches-5.10/0008-arm64-dts-ti-k3-am65-main-Add-ICSSG-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0008-arm64-dts-ti-k3-am65-main-Add-ICSSG-nodes.patch
@@ -1,7 +1,7 @@
-From 22c20901c00c71c11dd8dc7928b304b309dc7142 Mon Sep 17 00:00:00 2001
+From 54a05a25803666ff573d827468cee0498a977066 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Thu, 4 Mar 2021 10:07:11 -0600
-Subject: [PATCH 008/120] arm64: dts: ti: k3-am65-main: Add ICSSG nodes
+Subject: [PATCH 008/121] arm64: dts: ti: k3-am65-main: Add ICSSG nodes
 
 Add the DT nodes for the ICSSG0, ICSSG1 and ICSSG2 processor subsystems
 that are present on the K3 AM65x SoCs. The three ICSSGs are identical

--- a/recipes-kernel/linux/files/patches-5.10/0009-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0009-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
@@ -1,7 +1,7 @@
-From 1d0ae381e540236c6fc80ffa56120fc18305c24f Mon Sep 17 00:00:00 2001
+From 9cf6671a367bf9db7a1237bbf7854eaa7a57ff28 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 20 Feb 2021 13:49:51 +0100
-Subject: [PATCH 009/120] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
+Subject: [PATCH 009/121] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
 
 Add the DT entry for a watchdog based on RTI1.
 

--- a/recipes-kernel/linux/files/patches-5.10/0010-arm64-dts-ti-Add-support-for-Siemens-IOT2050-boards.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0010-arm64-dts-ti-Add-support-for-Siemens-IOT2050-boards.patch
@@ -1,7 +1,7 @@
-From c40cf142b0f120920ac65757eeb659bfa09a7ccf Mon Sep 17 00:00:00 2001
+From 6c54fd572471e2010967c2c7cc78be1493c9bc24 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Mar 2021 15:33:43 +0100
-Subject: [PATCH 010/120] arm64: dts: ti: Add support for Siemens IOT2050
+Subject: [PATCH 010/121] arm64: dts: ti: Add support for Siemens IOT2050
  boards
 
 Add support for two Siemens SIMATIC IOT2050 variants, Basic and

--- a/recipes-kernel/linux/files/patches-5.10/0011-arm64-dts-ti-k3-am65-j721e-am64-Map-the-dma-navigato.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0011-arm64-dts-ti-k3-am65-j721e-am64-Map-the-dma-navigato.patch
@@ -1,7 +1,7 @@
-From 681d10e48b1e655fff6930ef1dd642c581781f27 Mon Sep 17 00:00:00 2001
+From f650f7254c236d96d0363db826e3f6b40d6aa68c Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Mon, 10 May 2021 09:54:29 -0500
-Subject: [PATCH 011/120] arm64: dts: ti: k3-am65|j721e|am64: Map the dma /
+Subject: [PATCH 011/121] arm64: dts: ti: k3-am65|j721e|am64: Map the dma /
  navigator subsystem via explicit ranges
 
 Instead of using empty ranges property, lets map explicitly the address

--- a/recipes-kernel/linux/files/patches-5.10/0012-arm64-dts-ti-k3-Introduce-reg-definition-for-interru.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0012-arm64-dts-ti-k3-Introduce-reg-definition-for-interru.patch
@@ -1,7 +1,7 @@
-From 30a9d560bc9b43633e8e5979213326fa7d161ea5 Mon Sep 17 00:00:00 2001
+From 59f999b6bbd4f8f8ef1530db703ad8aefc71ff70 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Tue, 11 May 2021 14:48:21 -0500
-Subject: [PATCH 012/120] arm64: dts: ti: k3*: Introduce reg definition for
+Subject: [PATCH 012/121] arm64: dts: ti: k3*: Introduce reg definition for
  interrupt routers
 
 Interrupt routers are memory mapped peripherals, that are organized

--- a/recipes-kernel/linux/files/patches-5.10/0013-mmc-sdhci_am654-Use-pm_runtime_resume_and_get-to-rep.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0013-mmc-sdhci_am654-Use-pm_runtime_resume_and_get-to-rep.patch
@@ -1,7 +1,7 @@
-From ebd262e5f9909e424234bb82bdc7258e7cbb5b24 Mon Sep 17 00:00:00 2001
+From 3ff1a0be5ef2d85696ee537152dd95d8409381fe Mon Sep 17 00:00:00 2001
 From: Tian Tao <tiantao6@hisilicon.com>
 Date: Fri, 21 May 2021 08:59:35 +0800
-Subject: [PATCH 013/120] mmc: sdhci_am654: Use pm_runtime_resume_and_get() to
+Subject: [PATCH 013/121] mmc: sdhci_am654: Use pm_runtime_resume_and_get() to
  replace open coding
 
 use pm_runtime_resume_and_get() to replace pm_runtime_get_sync and

--- a/recipes-kernel/linux/files/patches-5.10/0014-arm64-dts-ti-k3-am65-iot2050-common-Disable-mailbox-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0014-arm64-dts-ti-k3-am65-iot2050-common-Disable-mailbox-.patch
@@ -1,7 +1,7 @@
-From 2b9282571fdabbf39df08c3c4dbbd407340a37b1 Mon Sep 17 00:00:00 2001
+From 08864e3c97878d2b535797795bb7bf815049370a Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 14 May 2021 16:20:16 -0500
-Subject: [PATCH 014/120] arm64: dts: ti: k3-am65-iot2050-common: Disable
+Subject: [PATCH 014/121] arm64: dts: ti: k3-am65-iot2050-common: Disable
  mailbox nodes
 
 There are no sub-mailbox devices defined currently for both the

--- a/recipes-kernel/linux/files/patches-5.10/0015-arm64-dts-ti-k3-am65-Add-support-for-UHS-I-modes-in-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0015-arm64-dts-ti-k3-am65-Add-support-for-UHS-I-modes-in-.patch
@@ -1,7 +1,7 @@
-From a4c7264973471080e5132480c0104e0c3d0adc5b Mon Sep 17 00:00:00 2001
+From 0251cfc9e84090cfd8d84a3acbe54053d2722168 Mon Sep 17 00:00:00 2001
 From: Aswath Govindraju <a-govindraju@ti.com>
 Date: Sat, 29 May 2021 09:07:49 +0530
-Subject: [PATCH 015/120] arm64: dts: ti: k3-am65: Add support for UHS-I modes
+Subject: [PATCH 015/121] arm64: dts: ti: k3-am65: Add support for UHS-I modes
  in MMCSD1 subsystem
 
 UHS-I speed modes are supported in AM65 S.R. 2.0 SoC[1].

--- a/recipes-kernel/linux/files/patches-5.10/0016-arm64-dts-ti-k3-am65-main-Add-ICSSG-MDIO-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0016-arm64-dts-ti-k3-am65-main-Add-ICSSG-MDIO-nodes.patch
@@ -1,7 +1,7 @@
-From 892cf819d45e0a184f054b18c3f86110886cfdd3 Mon Sep 17 00:00:00 2001
+From d85c7251b2730bdafdb6c4653f190aedca411d31 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 1 Jun 2021 10:00:31 -0500
-Subject: [PATCH 016/120] arm64: dts: ti: k3-am65-main: Add ICSSG MDIO nodes
+Subject: [PATCH 016/121] arm64: dts: ti: k3-am65-main: Add ICSSG MDIO nodes
 
 The ICSSGs on K3 AM65x SoCs contain an MDIO controller that can
 be used to control external PHYs associated with the Industrial

--- a/recipes-kernel/linux/files/patches-5.10/0017-arm64-dts-ti-iot2050-Configure-r5f-cluster-on-basic-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0017-arm64-dts-ti-iot2050-Configure-r5f-cluster-on-basic-.patch
@@ -1,7 +1,7 @@
-From 9163cc27e4819cff6342d44fc928130e44a561be Mon Sep 17 00:00:00 2001
+From be3dabd7cee4b051bbf6bdbaf2d2b92083b01448 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 2 Jun 2021 08:56:15 +0200
-Subject: [PATCH 017/120] arm64: dts: ti: iot2050: Configure r5f cluster on
+Subject: [PATCH 017/121] arm64: dts: ti: iot2050: Configure r5f cluster on
  basic variant in split mode
 
 Lockstep mode is not supported here. So turn it off to avoid warnings

--- a/recipes-kernel/linux/files/patches-5.10/0018-arm64-dts-ti-am65-align-ti-pindir-d0-out-d1-in-prope.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0018-arm64-dts-ti-am65-align-ti-pindir-d0-out-d1-in-prope.patch
@@ -1,7 +1,7 @@
-From 3ae0f11d36c617ddae74ad30fffa36580cf02890 Mon Sep 17 00:00:00 2001
+From 70c6f2b1452bcc39261a80327d938959ed636074 Mon Sep 17 00:00:00 2001
 From: Aswath Govindraju <a-govindraju@ti.com>
 Date: Tue, 8 Jun 2021 10:44:13 +0530
-Subject: [PATCH 018/120] arm64: dts: ti: am65: align ti,pindir-d0-out-d1-in
+Subject: [PATCH 018/121] arm64: dts: ti: am65: align ti,pindir-d0-out-d1-in
  property with dt-shema
 
 ti,pindir-d0-out-d1-in property is expected to be of type boolean.

--- a/recipes-kernel/linux/files/patches-5.10/0019-firmware-ti_sci-rm-Add-support-for-tx_tdtype-paramet.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0019-firmware-ti_sci-rm-Add-support-for-tx_tdtype-paramet.patch
@@ -1,7 +1,7 @@
-From 7894461b3425e65e18f0d036d50cc40697309099 Mon Sep 17 00:00:00 2001
+From d6e7ebb390f4afdc8616df002c4d9aa42eb661eb Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:02 -0700
-Subject: [PATCH 019/120] firmware: ti_sci: rm: Add support for tx_tdtype
+Subject: [PATCH 019/121] firmware: ti_sci: rm: Add support for tx_tdtype
  parameter for tx channel
 
 The system controller's resource manager have support for configuring the

--- a/recipes-kernel/linux/files/patches-5.10/0020-firmware-ti_sci-Use-struct-ti_sci_resource_desc-in-g.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0020-firmware-ti_sci-Use-struct-ti_sci_resource_desc-in-g.patch
@@ -1,7 +1,7 @@
-From 3af58e828355f930e90e5a6c77f14f2e39c37108 Mon Sep 17 00:00:00 2001
+From 696196b932dcbdfc1db351e6e813941b01604c86 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:03 -0700
-Subject: [PATCH 020/120] firmware: ti_sci: Use struct ti_sci_resource_desc in
+Subject: [PATCH 020/121] firmware: ti_sci: Use struct ti_sci_resource_desc in
  get_range ops
 
 Use the ti_sci_resource_desc directly and update it's start and num members

--- a/recipes-kernel/linux/files/patches-5.10/0021-firmware-ti_sci-rm-Add-support-for-second-resource-r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0021-firmware-ti_sci-rm-Add-support-for-second-resource-r.patch
@@ -1,7 +1,7 @@
-From 3030d8dec1974e9161f9105d58d223897c535851 Mon Sep 17 00:00:00 2001
+From d01c147a0a9efb951ff42db2da9b72c222ad4515 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:03 -0700
-Subject: [PATCH 021/120] firmware: ti_sci: rm: Add support for second resource
+Subject: [PATCH 021/121] firmware: ti_sci: rm: Add support for second resource
  range
 
 Sysfw added support for a second range in the resource range API to be able

--- a/recipes-kernel/linux/files/patches-5.10/0022-soc-ti-ti_sci_inta_msi-Add-support-for-second-range-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0022-soc-ti-ti_sci_inta_msi-Add-support-for-second-range-.patch
@@ -1,7 +1,7 @@
-From b3bba6eb2bbcab8f5e9a3b193277d8e3c2b1eef6 Mon Sep 17 00:00:00 2001
+From 4eaa952062acfcf9a2b0479e53007a0958bf1540 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:04 -0700
-Subject: [PATCH 022/120] soc: ti: ti_sci_inta_msi: Add support for second
+Subject: [PATCH 022/121] soc: ti: ti_sci_inta_msi: Add support for second
  range in resource ranges
 
 Allocate MSI entries for both first and second range if they are valid

--- a/recipes-kernel/linux/files/patches-5.10/0023-firmware-ti_sci-rm-Add-support-for-extended_ch_type-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0023-firmware-ti_sci-rm-Add-support-for-extended_ch_type-.patch
@@ -1,7 +1,7 @@
-From eb58c70c90bf3e3e711c4bc0732b020aa2dfe27b Mon Sep 17 00:00:00 2001
+From 5e28a749e163f94987471ec9a7c6189c626697f1 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:05 -0700
-Subject: [PATCH 023/120] firmware: ti_sci: rm: Add support for
+Subject: [PATCH 023/121] firmware: ti_sci: rm: Add support for
  extended_ch_type for tx channel
 
 Sysfw added 'extended_ch_type' to the tx_ch_cfg_req message which should be

--- a/recipes-kernel/linux/files/patches-5.10/0024-firmware-ti_sci-rm-Remove-ring_get_config-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0024-firmware-ti_sci-rm-Remove-ring_get_config-support.patch
@@ -1,7 +1,7 @@
-From a348bb6695e788f2f06784f4b97f015f050eda3a Mon Sep 17 00:00:00 2001
+From a38450e4d899c7cf4c0a98918bde50db57c28a26 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:05 -0700
-Subject: [PATCH 024/120] firmware: ti_sci: rm: Remove ring_get_config support
+Subject: [PATCH 024/121] firmware: ti_sci: rm: Remove ring_get_config support
 
 The ring_get_cfg (0x1111 message) is not used and it is not supported by
 sysfw for a long time.

--- a/recipes-kernel/linux/files/patches-5.10/0025-firmware-ti_sci-rm-Add-new-ops-for-ring-configuratio.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0025-firmware-ti_sci-rm-Add-new-ops-for-ring-configuratio.patch
@@ -1,7 +1,7 @@
-From b5728271a22c97457f55bf90ad6fb410ef4b0ec7 Mon Sep 17 00:00:00 2001
+From 587d372250ced3a2171ff14ca134bcaa54920276 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:06 -0700
-Subject: [PATCH 025/120] firmware: ti_sci: rm: Add new ops for ring
+Subject: [PATCH 025/121] firmware: ti_sci: rm: Add new ops for ring
  configuration
 
 The sysfw ring configuration message has been extended to include virtid

--- a/recipes-kernel/linux/files/patches-5.10/0026-soc-ti-k3-ringacc-Use-the-ti_sci-set_cfg-callback-fo.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0026-soc-ti-k3-ringacc-Use-the-ti_sci-set_cfg-callback-fo.patch
@@ -1,7 +1,7 @@
-From 6391078b61507461c5f076c89697beffadc5f83a Mon Sep 17 00:00:00 2001
+From 34efa3d75d9aecea1c623bb4f4422df5ef64ca14 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:07 -0700
-Subject: [PATCH 026/120] soc: ti: k3-ringacc: Use the ti_sci set_cfg callback
+Subject: [PATCH 026/121] soc: ti: k3-ringacc: Use the ti_sci set_cfg callback
  for ring configuration
 
 Switch to the new set_cfg to configure the ring.

--- a/recipes-kernel/linux/files/patches-5.10/0027-firmware-ti_sci-rm-Remove-unused-config-from-ti_sci_.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0027-firmware-ti_sci-rm-Remove-unused-config-from-ti_sci_.patch
@@ -1,7 +1,7 @@
-From 31b7461058d9834886d242ee84f1be238235cdaf Mon Sep 17 00:00:00 2001
+From 90236c2a532f4e4371ba6df29f7296c96ce3ddb3 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:07 -0700
-Subject: [PATCH 027/120] firmware: ti_sci: rm: Remove unused config() from
+Subject: [PATCH 027/121] firmware: ti_sci: rm: Remove unused config() from
  ti_sci_rm_ringacc_ops
 
 The ringacc driver has been converted to use the new set_cfg function to

--- a/recipes-kernel/linux/files/patches-5.10/0028-soc-ti-k3-ringacc-Use-correct-device-for-allocation-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0028-soc-ti-k3-ringacc-Use-correct-device-for-allocation-.patch
@@ -1,7 +1,7 @@
-From b4c6d0a92df9bb5671ab8d86b369b5836719c146 Mon Sep 17 00:00:00 2001
+From cf765faa5937d159d9dd671858dc1787eb0ba847 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:22 -0700
-Subject: [PATCH 028/120] soc: ti: k3-ringacc: Use correct device for
+Subject: [PATCH 028/121] soc: ti: k3-ringacc: Use correct device for
  allocation in RING mode
 
 In RING mode the ringacc does not access the ring memory. In this access

--- a/recipes-kernel/linux/files/patches-5.10/0029-soc-ti-pruss-Remove-wrong-check-against-get_match_da.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0029-soc-ti-pruss-Remove-wrong-check-against-get_match_da.patch
@@ -1,7 +1,7 @@
-From 3f8ac072a3d17ec42c4c09cca4222896e2da5a84 Mon Sep 17 00:00:00 2001
+From 6667dce845ffb1503ea39ec81a3b03dad60c8f2c Mon Sep 17 00:00:00 2001
 From: Grzegorz Jaszczyk <grzegorz.jaszczyk@linaro.org>
 Date: Sat, 21 Nov 2020 19:22:25 -0800
-Subject: [PATCH 029/120] soc: ti: pruss: Remove wrong check against
+Subject: [PATCH 029/121] soc: ti: pruss: Remove wrong check against
  *get_match_data return value
 
 Since the of_device_get_match_data() doesn't return error code, remove

--- a/recipes-kernel/linux/files/patches-5.10/0030-soc-ti-pruss-Correct-the-pruss_clk_init-error-trace-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0030-soc-ti-pruss-Correct-the-pruss_clk_init-error-trace-.patch
@@ -1,7 +1,7 @@
-From cc9dece207075ebb763f90c944170010f7c9a114 Mon Sep 17 00:00:00 2001
+From 79ca7fffa17c25af90d0e4d8dcba2b00aadf7d05 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 24 Jan 2021 20:51:37 -0800
-Subject: [PATCH 030/120] soc: ti: pruss: Correct the pruss_clk_init error
+Subject: [PATCH 030/121] soc: ti: pruss: Correct the pruss_clk_init error
  trace text
 
 The pruss_clk_init() function can register more than one clock.

--- a/recipes-kernel/linux/files/patches-5.10/0031-soc-ti-pruss-Refactor-the-CFG-sub-module-init.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0031-soc-ti-pruss-Refactor-the-CFG-sub-module-init.patch
@@ -1,7 +1,7 @@
-From 5596289c30e144726dca2767f11c43e67523cd9e Mon Sep 17 00:00:00 2001
+From 4e6f555502f1dda2a0a43a32fe004bdbad9c2e07 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 31 Jan 2021 20:53:43 -0800
-Subject: [PATCH 031/120] soc: ti: pruss: Refactor the CFG sub-module init
+Subject: [PATCH 031/121] soc: ti: pruss: Refactor the CFG sub-module init
 
 The CFG sub-module is not present on some earlier SoCs like the
 DA850/OMAPL-138 in the TI Davinci family. Refactor out the CFG

--- a/recipes-kernel/linux/files/patches-5.10/0032-soc-ti-k3-ringacc-Use-of_device_get_match_data.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0032-soc-ti-k3-ringacc-Use-of_device_get_match_data.patch
@@ -1,7 +1,7 @@
-From 926bc1281c118145223d98eff10db1381b69508a Mon Sep 17 00:00:00 2001
+From 7b4e72b02c27621e00f3eab2ad929ded3626629a Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 31 Jan 2021 20:58:49 -0800
-Subject: [PATCH 032/120] soc: ti: k3-ringacc: Use of_device_get_match_data()
+Subject: [PATCH 032/121] soc: ti: k3-ringacc: Use of_device_get_match_data()
 
 Simplify the retrieval of getting the match data in the probe
 function by directly using of_device_get_match_data() instead

--- a/recipes-kernel/linux/files/patches-5.10/0033-remoteproc-ti_k3-fix-Wcast-function-type-warning.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0033-remoteproc-ti_k3-fix-Wcast-function-type-warning.patch
@@ -1,7 +1,7 @@
-From ef102966ed880b4c35a4d53b277546773bcd2062 Mon Sep 17 00:00:00 2001
+From 895ac8abba2a9fe5ed8c8c1646fc7c9d1e3b3f10 Mon Sep 17 00:00:00 2001
 From: Arnd Bergmann <arnd@arndb.de>
 Date: Mon, 26 Oct 2020 17:05:23 +0100
-Subject: [PATCH 033/120] remoteproc: ti_k3: fix -Wcast-function-type warning
+Subject: [PATCH 033/121] remoteproc: ti_k3: fix -Wcast-function-type warning
 
 The function cast causes a warning with "make W=1"
 

--- a/recipes-kernel/linux/files/patches-5.10/0034-remoteproc-Add-a-rproc_set_firmware-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0034-remoteproc-Add-a-rproc_set_firmware-API.patch
@@ -1,7 +1,7 @@
-From fde9bbbddad98db86c84c1bfd2a29ad4067c5a43 Mon Sep 17 00:00:00 2001
+From 62a436dba0866b0cc5804135cc4d650a229d227e Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 20 Nov 2020 21:20:42 -0600
-Subject: [PATCH 034/120] remoteproc: Add a rproc_set_firmware() API
+Subject: [PATCH 034/121] remoteproc: Add a rproc_set_firmware() API
 
 A new API, rproc_set_firmware() is added to allow the remoteproc platform
 drivers and remoteproc client drivers to be able to configure a custom

--- a/recipes-kernel/linux/files/patches-5.10/0035-remoteproc-pru-Add-a-PRU-remoteproc-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0035-remoteproc-pru-Add-a-PRU-remoteproc-driver.patch
@@ -1,7 +1,7 @@
-From 47be87d5c32ba318ba854b190299600e98608888 Mon Sep 17 00:00:00 2001
+From a131f49389bf4921bf25546db7d788c99aab83df Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:09:58 +0100
-Subject: [PATCH 035/120] remoteproc: pru: Add a PRU remoteproc driver
+Subject: [PATCH 035/121] remoteproc: pru: Add a PRU remoteproc driver
 
 The Programmable Real-Time Unit Subsystem (PRUSS) consists of
 dual 32-bit RISC cores (Programmable Real-Time Units, or PRUs)

--- a/recipes-kernel/linux/files/patches-5.10/0036-remoteproc-pru-Add-support-for-PRU-specific-interrup.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0036-remoteproc-pru-Add-support-for-PRU-specific-interrup.patch
@@ -1,7 +1,7 @@
-From d2e36e027ccac7d2719d32da64b2453cdb60fb03 Mon Sep 17 00:00:00 2001
+From 5035c7ac27c75557efbf6bbd84313f4d14ac6abb Mon Sep 17 00:00:00 2001
 From: Grzegorz Jaszczyk <grzegorz.jaszczyk@linaro.org>
 Date: Tue, 8 Dec 2020 15:09:59 +0100
-Subject: [PATCH 036/120] remoteproc: pru: Add support for PRU specific
+Subject: [PATCH 036/121] remoteproc: pru: Add support for PRU specific
  interrupt configuration
 
 The firmware blob can contain optional ELF sections: .resource_table

--- a/recipes-kernel/linux/files/patches-5.10/0037-remoteproc-pru-Add-pru-specific-debugfs-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0037-remoteproc-pru-Add-pru-specific-debugfs-support.patch
@@ -1,7 +1,7 @@
-From 4b6622f97350d566e5a24d4890fe6f1f8d5274de Mon Sep 17 00:00:00 2001
+From ffdbcf16f75e051261a365c8381eab9ba069cd6c Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:10:00 +0100
-Subject: [PATCH 037/120] remoteproc: pru: Add pru-specific debugfs support
+Subject: [PATCH 037/121] remoteproc: pru: Add pru-specific debugfs support
 
 The remoteproc core creates certain standard debugfs entries,
 that does not give a whole lot of useful information for the

--- a/recipes-kernel/linux/files/patches-5.10/0038-remoteproc-pru-Add-support-for-various-PRU-cores-on-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0038-remoteproc-pru-Add-support-for-various-PRU-cores-on-.patch
@@ -1,7 +1,7 @@
-From ee0fe7555beb8390db6225f9242580a38d1914a0 Mon Sep 17 00:00:00 2001
+From a5f08f84de79933decee3988ccba05a9eeabee0f Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:10:01 +0100
-Subject: [PATCH 038/120] remoteproc: pru: Add support for various PRU cores on
+Subject: [PATCH 038/121] remoteproc: pru: Add support for various PRU cores on
  K3 AM65x SoCs
 
 The K3 AM65x family of SoCs have the next generation of the PRU-ICSS

--- a/recipes-kernel/linux/files/patches-5.10/0039-remoteproc-pru-Fix-loading-of-GNU-Binutils-ELF.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0039-remoteproc-pru-Fix-loading-of-GNU-Binutils-ELF.patch
@@ -1,7 +1,7 @@
-From 0bc789829207f02e2a6478d505273adbf0c20d74 Mon Sep 17 00:00:00 2001
+From 6358f0ee0a99229adfa76764472806c373a66587 Mon Sep 17 00:00:00 2001
 From: Dimitar Dimitrov <dimitar@dinux.eu>
 Date: Wed, 30 Dec 2020 12:50:05 +0200
-Subject: [PATCH 039/120] remoteproc: pru: Fix loading of GNU Binutils ELF
+Subject: [PATCH 039/121] remoteproc: pru: Fix loading of GNU Binutils ELF
 
 PRU port of GNU Binutils lacks support for separate address spaces.
 PRU IRAM addresses are marked with artificial offset to differentiate

--- a/recipes-kernel/linux/files/patches-5.10/0040-remoteproc-pru-Fix-firmware-loading-crashes-on-K3-So.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0040-remoteproc-pru-Fix-firmware-loading-crashes-on-K3-So.patch
@@ -1,7 +1,7 @@
-From bde207622280eeaa96c7e470e8299e61ad637b4e Mon Sep 17 00:00:00 2001
+From a4c54ea813b95c7494638b9d7a5c130a40f8e5e9 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Mon, 15 Mar 2021 15:58:59 -0500
-Subject: [PATCH 040/120] remoteproc: pru: Fix firmware loading crashes on K3
+Subject: [PATCH 040/121] remoteproc: pru: Fix firmware loading crashes on K3
  SoCs
 
 The K3 PRUs are 32-bit processors and in general have some limitations

--- a/recipes-kernel/linux/files/patches-5.10/0041-remoteproc-pru-Fixup-interrupt-parent-logic-for-fw-e.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0041-remoteproc-pru-Fixup-interrupt-parent-logic-for-fw-e.patch
@@ -1,7 +1,7 @@
-From 4c25a6a61bb98bc0e2cb9e66a122456378348f7b Mon Sep 17 00:00:00 2001
+From a50f1a6d16f6f80888d2b7f243aa7af20f4c33f4 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:39 -0500
-Subject: [PATCH 041/120] remoteproc: pru: Fixup interrupt-parent logic for fw
+Subject: [PATCH 041/121] remoteproc: pru: Fixup interrupt-parent logic for fw
  events
 
 The PRU firmware interrupt mapping logic in pru_handle_intrmap() uses

--- a/recipes-kernel/linux/files/patches-5.10/0042-remoteproc-pru-Fix-wrong-success-return-value-for-fw.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0042-remoteproc-pru-Fix-wrong-success-return-value-for-fw.patch
@@ -1,7 +1,7 @@
-From cdcb0123e65f866ddb0ed74654965f4139ecc6b4 Mon Sep 17 00:00:00 2001
+From 11387634688afc712d3ddd3c06d6f27692aa003d Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:40 -0500
-Subject: [PATCH 042/120] remoteproc: pru: Fix wrong success return value for
+Subject: [PATCH 042/121] remoteproc: pru: Fix wrong success return value for
  fw events
 
 The irq_create_fwspec_mapping() returns a proper virq value on success

--- a/recipes-kernel/linux/files/patches-5.10/0043-remoteproc-pru-Fix-and-cleanup-firmware-interrupt-ma.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0043-remoteproc-pru-Fix-and-cleanup-firmware-interrupt-ma.patch
@@ -1,7 +1,7 @@
-From 35b51d64545bdaa7d9f610cecef666c934926f0e Mon Sep 17 00:00:00 2001
+From ffe4258b7d3c2c587ec4f338bbbf466e36225bae Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:41 -0500
-Subject: [PATCH 043/120] remoteproc: pru: Fix and cleanup firmware interrupt
+Subject: [PATCH 043/121] remoteproc: pru: Fix and cleanup firmware interrupt
  mapping logic
 
 The PRU firmware interrupt mappings are configured and unconfigured in

--- a/recipes-kernel/linux/files/patches-5.10/0044-watchdog-rti_wdt-Fix-calculation-and-evaluation-of-p.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0044-watchdog-rti_wdt-Fix-calculation-and-evaluation-of-p.patch
@@ -1,7 +1,7 @@
-From 281ffbd56ef83c021fe0c6ba9e33386f114cc3d4 Mon Sep 17 00:00:00 2001
+From 4cb23c8e4864bc89e48049c158f7fd1d33201a05 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 21 Feb 2022 15:33:54 +0100
-Subject: [PATCH 044/120] watchdog: rti_wdt: Fix calculation and evaluation of
+Subject: [PATCH 044/121] watchdog: rti_wdt: Fix calculation and evaluation of
  preset heartbeat
 
 This ensures that the same value is read back as was eventually

--- a/recipes-kernel/linux/files/patches-5.10/0045-arm64-dts-ti-iot2050-Flip-mmc-device-ordering-on-Adv.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0045-arm64-dts-ti-iot2050-Flip-mmc-device-ordering-on-Adv.patch
@@ -1,7 +1,7 @@
-From 939383d082daf8ba87a0f503f88c23dc82916ce4 Mon Sep 17 00:00:00 2001
+From b9ba7d0572b81aefa7a4308ce12b6005630cf8f0 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 1 Sep 2021 21:52:11 +0200
-Subject: [PATCH 045/120] arm64: dts: ti: iot2050: Flip mmc device ordering on
+Subject: [PATCH 045/121] arm64: dts: ti: iot2050: Flip mmc device ordering on
  Advanced devices
 
 This ensures that the SD card will remain mmc0 across Basic and Advanced

--- a/recipes-kernel/linux/files/patches-5.10/0046-arm64-dts-ti-iot2050-Disable-SR2.0-only-PRUs.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0046-arm64-dts-ti-iot2050-Disable-SR2.0-only-PRUs.patch
@@ -1,7 +1,7 @@
-From cf3459038c0e0452275b4e69d1ad0a4a8e0d6222 Mon Sep 17 00:00:00 2001
+From f3f7aa831a67c4eabc9e21cb60df8dc16b7210e4 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 1 Sep 2021 19:58:30 +0200
-Subject: [PATCH 046/120] arm64: dts: ti: iot2050: Disable SR2.0-only PRUs
+Subject: [PATCH 046/121] arm64: dts: ti: iot2050: Disable SR2.0-only PRUs
 
 The IOT2050 devices described so far are using SR1.0 silicon, thus do
 not have the additional PRUs of the ICSSG of the SR2.0. Disable them.

--- a/recipes-kernel/linux/files/patches-5.10/0047-arm64-dts-ti-iot2050-Add-enabled-mailboxes-and-carve.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0047-arm64-dts-ti-iot2050-Add-enabled-mailboxes-and-carve.patch
@@ -1,7 +1,7 @@
-From c396252e832e36a97afc96955680881a450ef247 Mon Sep 17 00:00:00 2001
+From cc05777e02c07648f40dd6f95a2abd55db505b8d Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 9 Sep 2021 08:01:16 +0200
-Subject: [PATCH 047/120] arm64: dts: ti: iot2050: Add/enabled mailboxes and
+Subject: [PATCH 047/121] arm64: dts: ti: iot2050: Add/enabled mailboxes and
  carve-outs for R5F cores
 
 Analogously to the am654-base-board, configure the mailboxes for the the

--- a/recipes-kernel/linux/files/patches-5.10/0048-arm64-dts-ti-iot2050-Prepare-for-adding-2nd-generati.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0048-arm64-dts-ti-iot2050-Prepare-for-adding-2nd-generati.patch
@@ -1,7 +1,7 @@
-From 5f795c7d4c1ff053b1179f1786eb532bd2dafa3f Mon Sep 17 00:00:00 2001
+From 6e605f236b4d487b274eac613c0dbf12c777c54b Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 7 Sep 2021 17:49:55 +0200
-Subject: [PATCH 048/120] arm64: dts: ti: iot2050: Prepare for adding
+Subject: [PATCH 048/121] arm64: dts: ti: iot2050: Prepare for adding
  2nd-generation boards
 
 The current IOT2050 devices are Product Generation 1 (PG1), using SR1.0

--- a/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
@@ -1,7 +1,7 @@
-From d647bf08669b4dc4c20a0ef9256714a5000332a6 Mon Sep 17 00:00:00 2001
+From 9e0ba1d36f2c42893d255c84ec193596efb59b49 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 21 Jun 2021 11:04:56 +0200
-Subject: [PATCH 049/120] arm64: dts: ti: iot2050: Add support for product
+Subject: [PATCH 049/121] arm64: dts: ti: iot2050: Add support for product
  generation 2 boards
 
 This adds the devices trees for IOT2050 Product Generation 2 (PG2)

--- a/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-iot2050-Add-layout-of-OSPI-flash.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-iot2050-Add-layout-of-OSPI-flash.patch
@@ -1,7 +1,7 @@
-From 546008a453a2ccdc50a6724ba1ac1ee66696bbef Mon Sep 17 00:00:00 2001
+From fc3636187addb87f4e7a3da127d83688c847cf9c Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 21 Mar 2022 15:53:15 +0100
-Subject: [PATCH 050/120] arm64: dts: ti: iot2050: Add layout of OSPI flash
+Subject: [PATCH 050/121] arm64: dts: ti: iot2050: Add layout of OSPI flash
 
 Describe the layout of the OSPI flash as the latest firmware uses it.
 Specifically the location of the U-Boot envs is important for userspace

--- a/recipes-kernel/linux/files/patches-5.10/0051-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0051-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
@@ -1,7 +1,7 @@
-From 00aa7e803b8ff3937fbcf95287b42980db3246b7 Mon Sep 17 00:00:00 2001
+From 8423a01c6810d4547751d0bacc291fd820c217be Mon Sep 17 00:00:00 2001
 From: Tomi Valkeinen <tomi.valkeinen@ti.com>
 Date: Mon, 31 May 2021 16:31:35 +0530
-Subject: [PATCH 051/120] arm64: dts: ti: k3-am65-main: fix DSS irq trigger
+Subject: [PATCH 051/121] arm64: dts: ti: k3-am65-main: fix DSS irq trigger
  type
 
 DSS irq trigger type is set to IRQ_TYPE_EDGE_RISING. For some reason this

--- a/recipes-kernel/linux/files/patches-5.10/0052-irqdomain-Export-of_phandle_args_to_fwspec.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0052-irqdomain-Export-of_phandle_args_to_fwspec.patch
@@ -1,7 +1,7 @@
-From 7afed2f4aa6937c909a60929dd6cdaacd2bc1c3e Mon Sep 17 00:00:00 2001
+From 1e726c74da9d7de2ae74e25838f5106128f22f50 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:46 +0530
-Subject: [PATCH 052/120] irqdomain: Export of_phandle_args_to_fwspec()
+Subject: [PATCH 052/121] irqdomain: Export of_phandle_args_to_fwspec()
 
 Export of_phandle_args_to_fwspec() to be used by drivers.
 of_phandle_args_to_fwspec() can be used by drivers to get irq specifier

--- a/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
@@ -1,7 +1,7 @@
-From 24bb9ebb768357311f1d1ae2ed8aed1aedc021f0 Mon Sep 17 00:00:00 2001
+From cc768e66ee5d1c4d53f74cb06c84f7e8765f4c82 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:47 +0530
-Subject: [PATCH 053/120] PCI: keystone: Convert to using hierarchy domain for
+Subject: [PATCH 053/121] PCI: keystone: Convert to using hierarchy domain for
  legacy interrupts
 
 K2G provides separate IRQ lines for each of the four legacy interrupts.

--- a/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
@@ -1,7 +1,7 @@
-From 987af9d0eef1d3a55dc0bb2c1f000ce1951d2acf Mon Sep 17 00:00:00 2001
+From 3ada9322cdbdd9567f245453ec89abfbd7638d10 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:48 +0530
-Subject: [PATCH 054/120] PCI: keystone: Add PCI legacy interrupt support for
+Subject: [PATCH 054/121] PCI: keystone: Add PCI legacy interrupt support for
  AM654
 
 Add PCI legacy interrupt support for AM654. AM654 has a single HW

--- a/recipes-kernel/linux/files/patches-5.10/0055-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0055-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
@@ -1,7 +1,7 @@
-From a93dff5f75843d0fc9b307254d3da9afdfde76f9 Mon Sep 17 00:00:00 2001
+From 2e65dee01b098b9b62ae2785cf471612079a6043 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:49 +0530
-Subject: [PATCH 055/120] PCI: keystone: Add workaround for Errata #i2037
+Subject: [PATCH 055/121] PCI: keystone: Add workaround for Errata #i2037
  (AM65x SR 1.0)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/recipes-kernel/linux/files/patches-5.10/0056-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0056-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
@@ -1,7 +1,7 @@
-From 5bd99f9dee8c791147c70ea7b687d8c85165afb2 Mon Sep 17 00:00:00 2001
+From eb0a0a832cbb0795affbb1b6f5d9807343485006 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:38:07 +0530
-Subject: [PATCH 056/120] arm64: dts: ti: k3-am65-main: Add properties to
+Subject: [PATCH 056/121] arm64: dts: ti: k3-am65-main: Add properties to
  support legacy interrupts
 
 Add DT properties in PCIe DT node to support legacy interrupts.

--- a/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
@@ -1,7 +1,7 @@
-From 3ac83d0ccfd7b3ea7ecb0b89157cb5a67b38a6de Mon Sep 17 00:00:00 2001
+From 3f6223d332b80482c26abef7349cda7d3eb14a09 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 20 Nov 2020 21:01:54 -0600
-Subject: [PATCH 057/120] remoteproc: Fix unbalanced boot with sysfs for no
+Subject: [PATCH 057/121] remoteproc: Fix unbalanced boot with sysfs for no
  auto-boot rprocs
 
 The remoteproc core performs automatic boot and shutdown of a remote

--- a/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-Introduce-deny_sysfs_ops-flag.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-Introduce-deny_sysfs_ops-flag.patch
@@ -1,7 +1,7 @@
-From ed04ff94e0d7c79635c178f8407daeed4ba6b85c Mon Sep 17 00:00:00 2001
+From 8204eb623b539a33a11611ca2ba3f8363cdb3390 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 13:05:28 -0500
-Subject: [PATCH 058/120] remoteproc: Introduce deny_sysfs_ops flag
+Subject: [PATCH 058/121] remoteproc: Introduce deny_sysfs_ops flag
 
 The remoteproc framework provides sysfs interfaces for changing the
 firmware name and for starting/stopping a remote processor through

--- a/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
@@ -1,7 +1,7 @@
-From d5c80641ccacbbf9cb4274147ae5444b7296d486 Mon Sep 17 00:00:00 2001
+From d528180b848ee9d75394c56143ec1a7403e90ce2 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:32:29 -0500
-Subject: [PATCH 059/120] remoteproc: pru: Add APIs to get and put the PRU
+Subject: [PATCH 059/121] remoteproc: pru: Add APIs to get and put the PRU
  cores
 
 Add two new APIs, pru_rproc_get() and pru_rproc_put(), to the PRU

--- a/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
@@ -1,7 +1,7 @@
-From 4645091838590d8fac3e42417b9fa25d24b7b360 Mon Sep 17 00:00:00 2001
+From 2e1f8ad2bdae2ce7c34e34fefdf149563b63f1e4 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 16 Dec 2020 17:52:37 +0100
-Subject: [PATCH 060/120] remoteproc: pru: Deny rproc sysfs ops for PRU client
+Subject: [PATCH 060/121] remoteproc: pru: Deny rproc sysfs ops for PRU client
  driven boots
 
 The PRU remoteproc driver is not configured for 'auto-boot' by default,

--- a/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
@@ -1,7 +1,7 @@
-From ebb16e8abaf40c21179b3ab6969b5018b932f959 Mon Sep 17 00:00:00 2001
+From ef97e82013588f7de5c978a7fec6ad194501ea07 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Fri, 26 Mar 2021 15:43:53 -0500
-Subject: [PATCH 061/120] remoteproc: pru: Add pru_rproc_set_ctable() function
+Subject: [PATCH 061/121] remoteproc: pru: Add pru_rproc_set_ctable() function
 
 Some firmwares expect the OS drivers to configure the CTABLE
 entries publishing dynamically allocated memory regions. For

--- a/recipes-kernel/linux/files/patches-5.10/0062-remoteproc-pru-Configure-firmware-based-on-client-se.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0062-remoteproc-pru-Configure-firmware-based-on-client-se.patch
@@ -1,7 +1,7 @@
-From 2937f1ca61474a1c81ebba364a328eff56c79e2b Mon Sep 17 00:00:00 2001
+From 045cec81b55064cebdfb5a39c78d651e2d7ac86c Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:50:14 -0500
-Subject: [PATCH 062/120] remoteproc: pru: Configure firmware based on client
+Subject: [PATCH 062/121] remoteproc: pru: Configure firmware based on client
  setup
 
 Client device node property firmware-name is now used to configure

--- a/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_get-put-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_get-put-API.patch
@@ -1,7 +1,7 @@
-From fb2d979c0c48962e249777043195f1618f0d558a Mon Sep 17 00:00:00 2001
+From aa40bc397be613aa77e6c2b3e4d91546e4a49982 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:58:00 -0500
-Subject: [PATCH 063/120] soc: ti: pruss: Add pruss_get()/put() API
+Subject: [PATCH 063/121] soc: ti: pruss: Add pruss_get()/put() API
 
 Add two new get and put API, pruss_get() and pruss_put() to the
 PRUSS platform driver to allow client drivers to request a handle

--- a/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
@@ -1,7 +1,7 @@
-From 6feb16491fdf3169aae9dbb905b7b213e625ed0e Mon Sep 17 00:00:00 2001
+From 975f5ab786bb9129d153fda8965b29b22de2edef Mon Sep 17 00:00:00 2001
 From: "Andrew F. Davis" <afd@ti.com>
 Date: Fri, 26 Mar 2021 16:11:42 -0500
-Subject: [PATCH 064/120] soc: ti: pruss: Add
+Subject: [PATCH 064/121] soc: ti: pruss: Add
  pruss_{request,release}_mem_region() API
 
 Add two new API - pruss_request_mem_region() & pruss_release_mem_region(),

--- a/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
@@ -1,7 +1,7 @@
-From eb334f496e5ecc68275fc98b590f694258142fce Mon Sep 17 00:00:00 2001
+From e7e405361e5bbd29bd572cf903c6092ee8e677f2 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:27:34 -0500
-Subject: [PATCH 065/120] soc: ti: pruss: Add pruss_cfg_read()/update() API
+Subject: [PATCH 065/121] soc: ti: pruss: Add pruss_cfg_read()/update() API
 
 Add two new generic API pruss_cfg_read() and pruss_cfg_update() to
 the PRUSS platform driver to allow other drivers to read and program

--- a/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
@@ -1,7 +1,7 @@
-From 02acf31d06b1fcd7457c4955aaa77734ad55865f Mon Sep 17 00:00:00 2001
+From 07f33e4c2129a2d447cd34f436cbedd62058432b Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 11 Dec 2020 19:48:09 +0100
-Subject: [PATCH 066/120] soc: ti: pruss: Add helper functions to set GPI mode,
+Subject: [PATCH 066/121] soc: ti: pruss: Add helper functions to set GPI mode,
  MII_RT_event and XFR
 
 The PRUSS CFG module is represented as a syscon node and is currently

--- a/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
@@ -1,7 +1,7 @@
-From 61b974c00c96df9ee4f7b3144e536cd91e339058 Mon Sep 17 00:00:00 2001
+From 093ce877740371d0a5e0d0c990da634661c8832f Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:38:11 -0500
-Subject: [PATCH 067/120] soc: ti: pruss: Add helper function to enable OCP
+Subject: [PATCH 067/121] soc: ti: pruss: Add helper function to enable OCP
  master ports
 
 The PRU-ICSS subsystem on OMAP-architecture based SoCS (AM33xx, AM437x

--- a/recipes-kernel/linux/files/patches-5.10/0068-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0068-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
@@ -1,7 +1,7 @@
-From ea1472ab14b8815b98e5ec7f040113f7f15588f5 Mon Sep 17 00:00:00 2001
+From e7ce009697d0716f15abcd4b215a1f07bcb93481 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 09:24:51 -0500
-Subject: [PATCH 068/120] soc: ti: pruss: Add helper functions to get/set
+Subject: [PATCH 068/121] soc: ti: pruss: Add helper functions to get/set
  PRUSS_CFG_GPMUX
 
 Add two new helper functions pruss_cfg_get_gpmux() & pruss_cfg_set_gpmux()

--- a/recipes-kernel/linux/files/patches-5.10/0069-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0069-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
@@ -1,7 +1,7 @@
-From 6e3a004dfcab9f6cfb5d6c808c91b6faf5f6aef1 Mon Sep 17 00:00:00 2001
+From 927c789327f9fa067d12fbf40679c34975737085 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 10:11:42 -0500
-Subject: [PATCH 069/120] remoteproc/pru: add support for configuring GPMUX
+Subject: [PATCH 069/121] remoteproc/pru: add support for configuring GPMUX
  based on client setup
 
 Client device node property ti,pruss-gp-mux-sel can now be used to

--- a/recipes-kernel/linux/files/patches-5.10/0070-net-ethernet-ti-prueth-Add-IEP-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0070-net-ethernet-ti-prueth-Add-IEP-driver.patch
@@ -1,7 +1,7 @@
-From d1fd33d049a3571c10a1a942a490dfffebf685c2 Mon Sep 17 00:00:00 2001
+From 6c7b3c94beb904d5ecdeb570f6e9375cc9d50ad8 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 20 Apr 2021 13:17:30 +0530
-Subject: [PATCH 070/120] net: ethernet: ti: prueth: Add IEP driver
+Subject: [PATCH 070/121] net: ethernet: ti: prueth: Add IEP driver
 
 Add a driver for Industrial Ethernet Peripheral (IEP) block of PRUSS to
 support timestamping of ethernet packets and thus support PTP and PPS

--- a/recipes-kernel/linux/files/patches-5.10/0071-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0071-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
@@ -1,7 +1,7 @@
-From 373c33c52cf7f21c9164bed7ce7d511c480d1485 Mon Sep 17 00:00:00 2001
+From c4373ea5cf0033ac9c62f161adeb700853cfbce4 Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Tue, 20 Apr 2021 13:17:31 +0530
-Subject: [PATCH 071/120] HACK: net: ethernet: ti: icss-iep: Fix sync0
+Subject: [PATCH 071/121] HACK: net: ethernet: ti: icss-iep: Fix sync0
  generation on a compare event
 
 commit 41e5c46849b5 ("net: ethernet: ti: icss-iep: Add support for generating

--- a/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
@@ -1,7 +1,7 @@
-From 6c9c3fee8c3b9d92c61d84fa1fe6294cd05dfd60 Mon Sep 17 00:00:00 2001
+From 3b2dd27600c5dad46d0ed788ec133c9d42118a01 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:28 +0300
-Subject: [PATCH 072/120] net: ethernet: ti: icss_iep: drop
+Subject: [PATCH 072/121] net: ethernet: ti: icss_iep: drop
  ICSS_IEP_CAPx_FALL_REGy
 
 ICSS_IEP_CAPx_FALL_REGy are not used, but cause indexation issues in

--- a/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
@@ -1,7 +1,7 @@
-From 4750041204aec587d3ad1fb9264206ad34ba06b2 Mon Sep 17 00:00:00 2001
+From dfb173913d735a2f7c689df44ab63ca8058d1f5b Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:29 +0300
-Subject: [PATCH 073/120] net: ethernet: ti: icss_iep: fix access to x_REG1 in
+Subject: [PATCH 073/121] net: ethernet: ti: icss_iep: fix access to x_REG1 in
  non 64bit mode
 
 Do not access x_REG1 registers in non 64bit mode.

--- a/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
@@ -1,7 +1,7 @@
-From 0d5ca1752fddd39cb76c6bc3d22322cc2525696e Mon Sep 17 00:00:00 2001
+From 22515366acf8dcca2088d73e4428313191d11be0 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:30 +0300
-Subject: [PATCH 074/120] net: ethernet: ti: icss_iep: disable extts and pps if
+Subject: [PATCH 074/121] net: ethernet: ti: icss_iep: disable extts and pps if
  no slow compensation or non 64bit mode
 
 Disable extts and pps if no slow compensation support or non 64bit mode.

--- a/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
@@ -1,7 +1,7 @@
-From 47a2e0d13d44734203ca6e85b1606f4b3607c9b9 Mon Sep 17 00:00:00 2001
+From 18d72e522b8626b8c01b3e233cc5e0bdc077088a Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:31 +0300
-Subject: [PATCH 075/120] net: ethernet: ti: icss_iep: fix pps irq race vs pps
+Subject: [PATCH 075/121] net: ethernet: ti: icss_iep: fix pps irq race vs pps
  disable
 
 When PPS is disabled the PPS IRQ can be running and PPS timer started which

--- a/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
@@ -1,7 +1,7 @@
-From 74538d726083dbd4e45ebaa33e9df0540aa0bc95 Mon Sep 17 00:00:00 2001
+From 84c3e3a5e11a9c3bfb3f0a843fffa71ae4f10dc5 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:32 +0300
-Subject: [PATCH 076/120] net: ethernet: ti: icss_iep: improve icss_iep_gettime
+Subject: [PATCH 076/121] net: ethernet: ti: icss_iep: improve icss_iep_gettime
 
 There are few issues with icss_iep_gettime():
 - it has to be very fast, but it's not protected from interruption

--- a/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
@@ -1,7 +1,7 @@
-From 18e1c3e5a573f03fe598086070cb0d7158b7469c Mon Sep 17 00:00:00 2001
+From 19ce671d769e7a7db91f0dd2c0d722000c17a3a8 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:33 +0300
-Subject: [PATCH 077/120] net: ethernet: ti: icss_iep: simplify peroutput
+Subject: [PATCH 077/121] net: ethernet: ti: icss_iep: simplify peroutput
  processing
 
 simplify peroutput processing

--- a/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
@@ -1,7 +1,7 @@
-From d7937c9e894bfaae60a73d31b59303ec5c53102d Mon Sep 17 00:00:00 2001
+From 2e39350ca987939f627dcd7b1e3fbd3599b00f93 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:34 +0300
-Subject: [PATCH 078/120] net: ethernet: ti: icss_iep: use readl/writel in
+Subject: [PATCH 078/121] net: ethernet: ti: icss_iep: use readl/writel in
  cap_cmp_handler
 
 Use readl/writel in cap_cmp_handler and timer handler instead of regmap

--- a/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
@@ -1,7 +1,7 @@
-From 85c34272e43564f480edd9d651d2a8cb6244946f Mon Sep 17 00:00:00 2001
+From b0511b1177e977a65b774cf4fabb98b7e8454853 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:35 +0300
-Subject: [PATCH 079/120] net: ethernet: ti: icss_iep: switch to .gettimex64()
+Subject: [PATCH 079/121] net: ethernet: ti: icss_iep: switch to .gettimex64()
 
 The .gettime64() is deprecated by commit 916444df305e ("ptp: deprecate
 gettime64() in favor of gettimex64()").

--- a/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
@@ -1,7 +1,7 @@
-From 5356c6b4df58ce8316479dc1916973816ccc378b Mon Sep 17 00:00:00 2001
+From 5e6367f88ff64a0fcd5d49bbfc54fbec75d116fd Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Thu, 29 Apr 2021 18:13:36 +0300
-Subject: [PATCH 080/120] net: ethernet: ti: icss_iep: Update compare registers
+Subject: [PATCH 080/121] net: ethernet: ti: icss_iep: Update compare registers
  after changing ptp clock time
 
 Consider the scenario where PPS is enabled, then iep set_time or adjust_time is

--- a/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
@@ -1,7 +1,7 @@
-From 653c3b3227ec3108cbe14ab86704eefa2161f214 Mon Sep 17 00:00:00 2001
+From f45bde520758b2bc5e09dce559bea6764e5d428d Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:37 +0300
-Subject: [PATCH 081/120] net: ethernet: ti: icss_iep: request cmp_cap irq from
+Subject: [PATCH 081/121] net: ethernet: ti: icss_iep: request cmp_cap irq from
  probe
 
 The current INTC design allows to define IEP cmp_cap IRQ explicitly for IEP

--- a/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
@@ -1,7 +1,7 @@
-From df6c68af180a394c8b35e44f56b953198a90b22f Mon Sep 17 00:00:00 2001
+From 02c1acbee44e22fe1f3295e5d5eabce4e8bbd516 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:38 +0300
-Subject: [PATCH 082/120] net: ethernet: ti: icss_iep: set phc time to system
+Subject: [PATCH 082/121] net: ethernet: ti: icss_iep: set phc time to system
  time on init
 
 Following customer feedback IEP PHC time has to be set to system time on

--- a/recipes-kernel/linux/files/patches-5.10/0083-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0083-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
@@ -1,7 +1,7 @@
-From 141a42040921d551d50fe7b8a658153d4e8f9cd3 Mon Sep 17 00:00:00 2001
+From 3c6c473d2f70ecc6b4c0cbf262d8e397ac1984d5 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:39 +0300
-Subject: [PATCH 083/120] net: ethernet: ti: icss_iep: use
+Subject: [PATCH 083/121] net: ethernet: ti: icss_iep: use
  devm_platform_ioremap_resource
 
 Use devm_platform_ioremap_resource() in probe to simplify code.

--- a/recipes-kernel/linux/files/patches-5.10/0084-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0084-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
@@ -1,7 +1,7 @@
-From b2b9f69bc2f36466bbabe6704c319b427e1a0292 Mon Sep 17 00:00:00 2001
+From 8e6e36ba88addadcb0c29b24863e42dd1d0ee32c Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 16 Mar 2021 18:00:25 -0500
-Subject: [PATCH 084/120] arm64: dts: ti: k3-am65-main: Add ICSSG IEP nodes
+Subject: [PATCH 084/121] arm64: dts: ti: k3-am65-main: Add ICSSG IEP nodes
 
 The ICSSG IP on AM65x SoCs have two Industrial Ethernet Peripherals (IEPs)
 to manage/generate Industrial Ethernet functions such as time stamping.

--- a/recipes-kernel/linux/files/patches-5.10/0085-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0085-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
@@ -1,7 +1,7 @@
-From f07a153ee88fd1ea97b9e5e7ef63c70f51412c9d Mon Sep 17 00:00:00 2001
+From 30de3e23de06b6c5aa83e8f7b6b01434b44501f0 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:22 +0300
-Subject: [PATCH 085/120] dt-bindings: net: Add binding for ti,icssg-prueth
+Subject: [PATCH 085/121] dt-bindings: net: Add binding for ti,icssg-prueth
  device
 
 This is the DT binding document for the ICSSG Dual-EMAC Ethernet

--- a/recipes-kernel/linux/files/patches-5.10/0086-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0086-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
@@ -1,7 +1,7 @@
-From bcaf1a9e02f4970dccfd1833a5a804a714f89cf5 Mon Sep 17 00:00:00 2001
+From 76a358ff08588fec5e178ea308fadd818d1c2220 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:23 +0300
-Subject: [PATCH 086/120] net: ti: icssg-prueth: Add ICSSG ethernet driver
+Subject: [PATCH 086/121] net: ti: icssg-prueth: Add ICSSG ethernet driver
 
 This is the Ethernet driver for TI SoCs with the
 ICSSG PRU Sub-system running dual-EMAC firmware.

--- a/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
@@ -1,7 +1,7 @@
-From 6f4cd608a33e1220d75d0cf40ab203ef82bcf4b5 Mon Sep 17 00:00:00 2001
+From 3d3c480a062c24ed0c15f7796da864f2811339d0 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:24 +0300
-Subject: [PATCH 087/120] net: ethernet: ti: icssg_prueth: add 10M full duplex
+Subject: [PATCH 087/121] net: ethernet: ti: icssg_prueth: add 10M full duplex
  support
 
 For 10M support RGMII need to be configured in inband mode and FW has to be

--- a/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
@@ -1,7 +1,7 @@
-From 73e89fe42ce14e3783073a7787af1d273a2fd67d Mon Sep 17 00:00:00 2001
+From c5da533a85b4af4d38407c4d31d66dfa252e5178 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:25 +0300
-Subject: [PATCH 088/120] net: ethernet: ti: icssg_prueth: Use DMA device for
+Subject: [PATCH 088/121] net: ethernet: ti: icssg_prueth: Use DMA device for
  DMA API
 
 For DMA API the DMA device should be used as cpsw does not accesses to

--- a/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
@@ -1,7 +1,7 @@
-From c2718cf85291c7faa04da5786d88655ee56ddb58 Mon Sep 17 00:00:00 2001
+From 022908d646f60a13dc0e9cc8d44d4b368ad2a7c2 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:26 +0300
-Subject: [PATCH 089/120] net: ethernet: ti: icss_iep: add icss_iep_get_idx()
+Subject: [PATCH 089/121] net: ethernet: ti: icss_iep: add icss_iep_get_idx()
  api
 
 Add icss_iep_get_idx() API to allow retrieve IEP from phandle list in DT.

--- a/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
@@ -1,7 +1,7 @@
-From 798b174c00996be26a907c239f2e23c9184b75e6 Mon Sep 17 00:00:00 2001
+From db33d8a44e576935be489f401d71169cd0bab93e Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:27 +0300
-Subject: [PATCH 090/120] net: ethernet: ti: icss_iep: use readl() in
+Subject: [PATCH 090/121] net: ethernet: ti: icss_iep: use readl() in
  icss_iep_get_count_low/hi()
 
 Use readl() in icss_iep_get_count_low/hi() to speed up hot path.

--- a/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
@@ -1,7 +1,7 @@
-From 81db856ddc528b1282d0eeaedd4d0c61824abe4a Mon Sep 17 00:00:00 2001
+From ad23473d97a88b053d0926f8027f79548323c8c6 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:28 +0300
-Subject: [PATCH 091/120] net: ethernet: ti: icss_iep: fix init for sr2.0
+Subject: [PATCH 091/121] net: ethernet: ti: icss_iep: fix init for sr2.0
 
 There are two issues with IEP initialization for ICSSG SR2.0 where only one
 IEP0 is used in shadow mode:

--- a/recipes-kernel/linux/files/patches-5.10/0092-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0092-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
@@ -1,7 +1,7 @@
-From 0f6577a8396f322eb0ba6526680e7277a962cb1f Mon Sep 17 00:00:00 2001
+From 5237ef8070b0f716d54508ddab5135971a154afd Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:29 +0300
-Subject: [PATCH 092/120] net: ethernet: ti: icss_iep: sr2.0 fix NULL pointer
+Subject: [PATCH 092/121] net: ethernet: ti: icss_iep: sr2.0 fix NULL pointer
  exception on pps stop
 
 The NULL pointer exception is observed on pps stop - fix it as timer is not

--- a/recipes-kernel/linux/files/patches-5.10/0093-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0093-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
@@ -1,7 +1,7 @@
-From 006cda4a237c3138144c5ed1b1ae8fc1e4114857 Mon Sep 17 00:00:00 2001
+From 30326cbb49ff8a894e1a18c7af7b55d91b2a9d70 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:30 +0300
-Subject: [PATCH 093/120] net: ti: ethernet: icssg-prueth: add packet
+Subject: [PATCH 093/121] net: ti: ethernet: icssg-prueth: add packet
  timestamping and ptp support
 
 Add packet timestamping TS and PTP PHC clock support.

--- a/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
@@ -1,7 +1,7 @@
-From 07487a132d65fe6ff15d972d917666d7cfb01d95 Mon Sep 17 00:00:00 2001
+From dbf9c30e1db8aac2cbbb64da3da11f4bd84be852 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:33 +0300
-Subject: [PATCH 094/120] net: ethernet: ti: icssg_prueth: add am64x icssg
+Subject: [PATCH 094/121] net: ethernet: ti: icssg_prueth: add am64x icssg
  support
 
 Add AM64x ICSSG support which is similar to am65x SR2.0, but required:

--- a/recipes-kernel/linux/files/patches-5.10/0095-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0095-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
@@ -1,7 +1,7 @@
-From 8e2234f3f7281cbd1464af2fa01a531ddf77b170 Mon Sep 17 00:00:00 2001
+From 141eddb2801a82aa6aa233a05a85ff232bf3232d Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 19 May 2021 19:31:36 +0300
-Subject: [PATCH 095/120] net: ethernet: ti: icssg_prueth: am65x SR2.0 add 10M
+Subject: [PATCH 095/121] net: ethernet: ti: icssg_prueth: am65x SR2.0 add 10M
  full duplex support
 
 For for AM65x SR2.0 it's required to enable IEP1 in raw 64bit mode which is

--- a/recipes-kernel/linux/files/patches-5.10/0096-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0096-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
@@ -1,7 +1,7 @@
-From a8f105abfe66d04054a886867ace652f9c494e15 Mon Sep 17 00:00:00 2001
+From d98b01974c1220bcfbd87cacab8b8083495215e7 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Mon, 21 Jun 2021 15:47:49 +0530
-Subject: [PATCH 096/120] net: ti: icssg_prueth: Free desc pool before DMA
+Subject: [PATCH 096/121] net: ti: icssg_prueth: Free desc pool before DMA
  channel release
 
 Release DMA desc pool associated with channel before releasing the

--- a/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
@@ -1,7 +1,7 @@
-From 15f907c1a473d15a500f39f0bd2964b8da57700e Mon Sep 17 00:00:00 2001
+From 43acaa3b2e222a5a8a2dec476c436d25c8bdffa5 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:47 +0300
-Subject: [PATCH 097/120] net: ethernet: icssg-prueth: fix rgmii tx delay
+Subject: [PATCH 097/121] net: ethernet: icssg-prueth: fix rgmii tx delay
  configuration
 
 The driver enables RGMII TX delay without checking specified

--- a/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
@@ -1,7 +1,7 @@
-From 4b2e063d044d9ab022cde8c8ba19d23b37cbee5e Mon Sep 17 00:00:00 2001
+From c39cf9ab7d6102f5fdf5dc4b18234f36665b613b Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:48 +0300
-Subject: [PATCH 098/120] net: ethernet: icssg-prueth: enable "fixed-link"
+Subject: [PATCH 098/121] net: ethernet: icssg-prueth: enable "fixed-link"
  connection
 
 The ICSSG has incomplete and incorrect "fixed-link" connection type

--- a/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
@@ -1,7 +1,7 @@
-From e6122f7decf324a08273c89d2ef1dd153925d470 Mon Sep 17 00:00:00 2001
+From 55089efc4502cf6bbb904e246e1a440965c69727 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:12 +0300
-Subject: [PATCH 099/120] net: ethernet: icssg-prueth: fix bug 'scheduling
+Subject: [PATCH 099/121] net: ethernet: icssg-prueth: fix bug 'scheduling
  while atomic' from emac_ndo_set_rx_mode()
 
 The .ndo_set_rx_mode() is called with BH disabled and should be atomic, but

--- a/recipes-kernel/linux/files/patches-5.10/0100-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0100-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
@@ -1,7 +1,7 @@
-From 4975005c893d95b61a1bec17e2a249f81add81a4 Mon Sep 17 00:00:00 2001
+From df9dc1595824afb0080abedaf959f80fee59fbc9 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:13 +0300
-Subject: [PATCH 100/120] net: ethernet: icssg-prueth: fix enabling/disabling
+Subject: [PATCH 100/121] net: ethernet: icssg-prueth: fix enabling/disabling
  port in emac_adjust_link()
 
 The port state is set to FORWARD in emac_ndo_open() and never changed, but

--- a/recipes-kernel/linux/files/patches-5.10/0101-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0101-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
@@ -1,7 +1,7 @@
-From 90081b529f8ceb7dce6032631c094e3d8a0c4b13 Mon Sep 17 00:00:00 2001
+From bcfc935fba633836b28d5d9067b305ae6f9b761b Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 27 Jun 2020 10:53:13 +0200
-Subject: [PATCH 101/120] arm64: dts: ti: iot2050: Add icssg-prueth nodes for
+Subject: [PATCH 101/121] arm64: dts: ti: iot2050: Add icssg-prueth nodes for
  PG1 and PG2 devices
 
 Add the required nodes to enable ICSSG SR1.0 and SR2.0 based prueth

--- a/recipes-kernel/linux/files/patches-5.10/0102-HACK-setting-the-RJ45-port-led-behavior.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0102-HACK-setting-the-RJ45-port-led-behavior.patch
@@ -1,7 +1,7 @@
-From 172ef5bd32fe5ad3691bb84a204bfb37f45f3fc8 Mon Sep 17 00:00:00 2001
+From c6db41ab52a8394d6e1a3337729bd3ea247d5403 Mon Sep 17 00:00:00 2001
 From: zengchao <chao.zeng@siemens.com>
 Date: Wed, 6 Nov 2019 11:21:49 +0800
-Subject: [PATCH 102/120] HACK: setting the RJ45 port led behavior
+Subject: [PATCH 102/121] HACK: setting the RJ45 port led behavior
 
 Temporary needed until we have a proper, likely LED-class based
 solution upstream.

--- a/recipes-kernel/linux/files/patches-5.10/0103-WIP-feat-extend-led-panic-indicator-on-and-off.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0103-WIP-feat-extend-led-panic-indicator-on-and-off.patch
@@ -1,7 +1,7 @@
-From 0ffaad35f7a24a341ebcad027abed6249a02e6c1 Mon Sep 17 00:00:00 2001
+From 29c9be7c2e732dd99d96beb7c994a0c25618b8dd Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Tue, 22 Dec 2020 15:05:56 +0800
-Subject: [PATCH 103/120] WIP: feat:extend led panic-indicator on and off
+Subject: [PATCH 103/121] WIP: feat:extend led panic-indicator on and off
 
 WIP because upstream strategy is still under discussion.
 

--- a/recipes-kernel/linux/files/patches-5.10/0104-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0104-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
@@ -1,7 +1,7 @@
-From 1eb7014af57e7d1be8588cccf80f87b897b9efa3 Mon Sep 17 00:00:00 2001
+From ab8a083846d767cfaed00c540c5055fd5381ebd5 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Mar 2021 15:28:21 +0100
-Subject: [PATCH 104/120] WIP: arm64: dts: ti: iot2050: Add node for generic
+Subject: [PATCH 104/121] WIP: arm64: dts: ti: iot2050: Add node for generic
  spidev
 
 This allows to use mcu_spi0 via userspace spidev.

--- a/recipes-kernel/linux/files/patches-5.10/0105-watchdog-rti-wdt-Provide-set_timeout-handler-to-make.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0105-watchdog-rti-wdt-Provide-set_timeout-handler-to-make.patch
@@ -1,7 +1,7 @@
-From e974f8d99bd400af15b77795ded58d0f05e3a759 Mon Sep 17 00:00:00 2001
+From 350f982c0a11b0661f637ef553bd3de880c2a80f Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 13 Sep 2021 12:27:17 +0200
-Subject: [PATCH 105/120] watchdog: rti-wdt: Provide set_timeout handler to
+Subject: [PATCH 105/121] watchdog: rti-wdt: Provide set_timeout handler to
  make existing userspace happy
 
 Prominent userspace - systemd - cannot handle watchdogs without

--- a/recipes-kernel/linux/files/patches-5.10/0106-dt-bindings-net-ti-icssg-prueth-Add-documentation-fo.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0106-dt-bindings-net-ti-icssg-prueth-Add-documentation-fo.patch
@@ -1,7 +1,7 @@
-From 79d5ebf6ae15af2433d076b6a234ddfdba010f93 Mon Sep 17 00:00:00 2001
+From a0e51403d73e4cd2ae571374f1234ded798786ed Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Tue, 12 Oct 2021 13:54:41 +0300
-Subject: [PATCH 106/120] dt-bindings: net: ti, icssg-prueth: Add documentation
+Subject: [PATCH 106/121] dt-bindings: net: ti, icssg-prueth: Add documentation
  for half duplex
 
 In order to support half-duplex operation at 10M and 100M link speeds, the

--- a/recipes-kernel/linux/files/patches-5.10/0107-net-ethernet-icssg-prueth-sr1.0-add-support-for-half.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0107-net-ethernet-icssg-prueth-sr1.0-add-support-for-half.patch
@@ -1,7 +1,7 @@
-From 8ccf558755789fe08201803fdedd8888d6e9b943 Mon Sep 17 00:00:00 2001
+From 9d3a9f94d09cc4c416bc80f50fd220b4abbc9e66 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 12 Oct 2021 13:54:42 +0300
-Subject: [PATCH 107/120] net: ethernet: icssg-prueth: sr1.0: add support for
+Subject: [PATCH 107/121] net: ethernet: icssg-prueth: sr1.0: add support for
  half duplex operation
 
 This patch adds support for half duplex operation at 10M and 100M link

--- a/recipes-kernel/linux/files/patches-5.10/0108-net-ethernet-icssg-prueth-sr2.0-add-support-for-half.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0108-net-ethernet-icssg-prueth-sr2.0-add-support-for-half.patch
@@ -1,7 +1,7 @@
-From 890e3b56a2f44dfb7080d37d26af4aac30e0f287 Mon Sep 17 00:00:00 2001
+From 8091bea4519b048777bf6a6d6755c13701c49b4c Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 12 Oct 2021 13:54:43 +0300
-Subject: [PATCH 108/120] net: ethernet: icssg-prueth: sr2.0: add support for
+Subject: [PATCH 108/121] net: ethernet: icssg-prueth: sr2.0: add support for
  half duplex operation
 
 This patch adds support for half duplex operation at 10M and 100M link

--- a/recipes-kernel/linux/files/patches-5.10/0109-arm64-dts-ti-add-the-support-for-the-half-duplex.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0109-arm64-dts-ti-add-the-support-for-the-half-duplex.patch
@@ -1,7 +1,7 @@
-From ef9e006735a1c28b6ecc8e021b2fbb1eac40e0e0 Mon Sep 17 00:00:00 2001
+From 93cf8b7c98aca76639dbc18e36055f116be56f2b Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Fri, 22 Oct 2021 13:37:22 +0800
-Subject: [PATCH 109/120] arm64: dts: ti: add the support for the half-duplex
+Subject: [PATCH 109/121] arm64: dts: ti: add the support for the half-duplex
 
 origin from TI and add the dts property to support the half-duplex for ethernet port
 

--- a/recipes-kernel/linux/files/patches-5.10/0110-USB-serial-cp210x-return-early-on-unchanged-termios.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0110-USB-serial-cp210x-return-early-on-unchanged-termios.patch
@@ -1,7 +1,7 @@
-From a8b96eef82694acffe730ea43b041ab64baa63bd Mon Sep 17 00:00:00 2001
+From 41509301679c86621d79e4d59055e7b22755e94c Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:21 +0100
-Subject: [PATCH 110/120] USB: serial: cp210x: return early on unchanged
+Subject: [PATCH 110/121] USB: serial: cp210x: return early on unchanged
  termios
 
 Return early from set_termios() in case no relevant terminal settings

--- a/recipes-kernel/linux/files/patches-5.10/0111-USB-serial-cp210x-clean-up-line-control-handling.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0111-USB-serial-cp210x-clean-up-line-control-handling.patch
@@ -1,7 +1,7 @@
-From 08fdab2b70537fa7a3eea5f14f8613464c08f948 Mon Sep 17 00:00:00 2001
+From 71856806a2f5bd2d3b13c31cf629f55b74ca0d54 Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:22 +0100
-Subject: [PATCH 111/120] USB: serial: cp210x: clean up line-control handling
+Subject: [PATCH 111/121] USB: serial: cp210x: clean up line-control handling
 
 Update the line-control settings in one request unconditionally instead
 of setting the word-length, parity and stop-bit settings separately.

--- a/recipes-kernel/linux/files/patches-5.10/0112-USB-serial-cp210x-set-terminal-settings-on-open.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0112-USB-serial-cp210x-set-terminal-settings-on-open.patch
@@ -1,7 +1,7 @@
-From 40aebffff88dca0b1acf51dce904c6533cf6a7a7 Mon Sep 17 00:00:00 2001
+From 996ee735c66cfa20b650af525e17cb8cb525670d Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:23 +0100
-Subject: [PATCH 112/120] USB: serial: cp210x: set terminal settings on open
+Subject: [PATCH 112/121] USB: serial: cp210x: set terminal settings on open
 
 Unlike other drivers cp210x have been retrieving the current terminal
 settings from the device on open and reflecting those in termios.

--- a/recipes-kernel/linux/files/patches-5.10/0113-USB-serial-cp210x-drop-flow-control-debugging.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0113-USB-serial-cp210x-drop-flow-control-debugging.patch
@@ -1,7 +1,7 @@
-From ab501f34992f045ad7da8c1e5e9a519452536966 Mon Sep 17 00:00:00 2001
+From 3a0a1ebb22e6ddbab043620bd0f2b713e838c788 Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:24 +0100
-Subject: [PATCH 113/120] USB: serial: cp210x: drop flow-control debugging
+Subject: [PATCH 113/121] USB: serial: cp210x: drop flow-control debugging
 
 Drop some unnecessary flow-control debugging.
 

--- a/recipes-kernel/linux/files/patches-5.10/0114-USB-serial-cp210x-refactor-flow-control-handling.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0114-USB-serial-cp210x-refactor-flow-control-handling.patch
@@ -1,7 +1,7 @@
-From 466b150b863113493da2e5e8e00deab9d40ee058 Mon Sep 17 00:00:00 2001
+From 0bbcb0f651f168d5130196df1aeb23db96652eb1 Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:25 +0100
-Subject: [PATCH 114/120] USB: serial: cp210x: refactor flow-control handling
+Subject: [PATCH 114/121] USB: serial: cp210x: refactor flow-control handling
 
 Add a helper function to be used to configure flow control.
 

--- a/recipes-kernel/linux/files/patches-5.10/0115-USB-serial-cp210x-clean-up-dtr_rts.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0115-USB-serial-cp210x-clean-up-dtr_rts.patch
@@ -1,7 +1,7 @@
-From 3b27a7057b12f83dde32702033cf78f6d6d91357 Mon Sep 17 00:00:00 2001
+From a8122069c50c0a557f0fc20eccb51f67d394957b Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:26 +0100
-Subject: [PATCH 115/120] USB: serial: cp210x: clean up dtr_rts()
+Subject: [PATCH 115/121] USB: serial: cp210x: clean up dtr_rts()
 
 Clean up dtr_rts() by renaming the port parameter and adding missing
 whitespace.

--- a/recipes-kernel/linux/files/patches-5.10/0116-USB-serial-cp210x-add-support-for-software-flow-cont.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0116-USB-serial-cp210x-add-support-for-software-flow-cont.patch
@@ -1,7 +1,7 @@
-From c29b3cb129e11970970f454120d4f73620ecfd53 Mon Sep 17 00:00:00 2001
+From 23599eea7f593a5478d0dba07211862233c841d1 Mon Sep 17 00:00:00 2001
 From: Wang Sheng Long <shenglong.wang.ext@siemens.com>
 Date: Mon, 18 Jan 2021 12:13:26 +0100
-Subject: [PATCH 116/120] USB: serial: cp210x: add support for software flow
+Subject: [PATCH 116/121] USB: serial: cp210x: add support for software flow
  control
 
 When data is transmitted between two serial ports, the phenomenon of

--- a/recipes-kernel/linux/files/patches-5.10/0117-USB-serial-cp210x-fix-control-characters-error-handl.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0117-USB-serial-cp210x-fix-control-characters-error-handl.patch
@@ -1,7 +1,7 @@
-From 16a55eff60ec1f282d32a3fa94f13fba7a0475ae Mon Sep 17 00:00:00 2001
+From 54574ed7b31747927e3e545e2bccf4e7c08ddeda Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 5 Jul 2021 10:20:10 +0200
-Subject: [PATCH 117/120] USB: serial: cp210x: fix control-characters error
+Subject: [PATCH 117/121] USB: serial: cp210x: fix control-characters error
  handling
 
 In the unlikely event that setting the software flow-control characters

--- a/recipes-kernel/linux/files/patches-5.10/0118-net-ethernet-icssg-prueth-Fix-release-of-iep0-on-pro.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0118-net-ethernet-icssg-prueth-Fix-release-of-iep0-on-pro.patch
@@ -1,7 +1,7 @@
-From 7047216400bc1d8146823d01c9faa3390f5d4255 Mon Sep 17 00:00:00 2001
+From 795d7831b75acbd9a5e181fec6885d3e5db850dd Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 30 Nov 2021 10:53:42 +0100
-Subject: [PATCH 118/120] net: ethernet: icssg-prueth: Fix release of iep0 on
+Subject: [PATCH 118/121] net: ethernet: icssg-prueth: Fix release of iep0 on
  probing error
 
 A typo caused crashes in case icss_iep_get_idx succeeded for iep0 but

--- a/recipes-kernel/linux/files/patches-5.10/0119-arm64-dts-ti-Indicate-the-green-light-is-off-when-pa.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0119-arm64-dts-ti-Indicate-the-green-light-is-off-when-pa.patch
@@ -1,7 +1,7 @@
-From 08189c14ee2283406137dbc36ec7133d59aac417 Mon Sep 17 00:00:00 2001
+From 49e1d669220be800c3d47f2b6b2e9c5253e8cc5e Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Thu, 16 Dec 2021 15:09:25 +0800
-Subject: [PATCH 119/120] arm64: dts: ti: Indicate the green light is off when
+Subject: [PATCH 119/121] arm64: dts: ti: Indicate the green light is off when
  panic
 
 The green light is out of control when panic occurs.

--- a/recipes-kernel/linux/files/patches-5.10/0120-arm64-dts-ti-iot2050-add-the-support-for-the-m.2-var.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0120-arm64-dts-ti-iot2050-add-the-support-for-the-m.2-var.patch
@@ -1,7 +1,7 @@
-From a464ef31ceb4e8b8f5f10cb8e17fe3c15011a4eb Mon Sep 17 00:00:00 2001
+From b3cd789f5f09e8df7c20739c37604e773cbcc665 Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Tue, 11 Jan 2022 11:28:24 +0800
-Subject: [PATCH 120/120] arm64: dts :ti: iot2050: add the support for the m.2
+Subject: [PATCH 120/121] arm64: dts :ti: iot2050: add the support for the m.2
  variant
 
 Configure the m2 board dts based on the pg2 advanced variant

--- a/recipes-kernel/linux/files/patches-5.10/0121-serial-core-Initialize-rs485-RTS-polarity-already-on.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0121-serial-core-Initialize-rs485-RTS-polarity-already-on.patch
@@ -1,0 +1,124 @@
+From 8125632dd072987934f07455f80628beb368e17e Mon Sep 17 00:00:00 2001
+From: Lukas Wunner <lukas@wunner.de>
+Date: Sun, 23 Jan 2022 05:21:14 +0100
+Subject: [PATCH 121/121] serial: core: Initialize rs485 RTS polarity already
+ on probe
+
+commit 2dd8a74fddd21b95dcc60a2d3c9eaec993419d69 upstream.
+
+RTS polarity of rs485-enabled ports is currently initialized on uart
+open via:
+
+tty_port_open()
+  tty_port_block_til_ready()
+    tty_port_raise_dtr_rts()  # if (C_BAUD(tty))
+      uart_dtr_rts()
+        uart_port_dtr_rts()
+
+There's at least three problems here:
+
+First, if no baud rate is set, RTS polarity is not initialized.
+That's the right thing to do for rs232, but not for rs485, which
+requires that RTS is deasserted unconditionally.
+
+Second, if the DeviceTree property "linux,rs485-enabled-at-boot-time" is
+present, RTS should be deasserted as early as possible, i.e. on probe.
+Otherwise it may remain asserted until first open.
+
+Third, even though RTS is deasserted on open and close, it may
+subsequently be asserted by uart_throttle(), uart_unthrottle() or
+uart_set_termios() because those functions aren't rs485-aware.
+(Only uart_tiocmset() is.)
+
+To address these issues, move RTS initialization from uart_port_dtr_rts()
+to uart_configure_port().  Prevent subsequent modification of RTS
+polarity by moving the existing rs485 check from uart_tiocmget() to
+uart_update_mctrl().
+
+That way, RTS is initialized on probe and then remains unmodified unless
+the uart transmits data.  If rs485 is enabled at runtime (instead of at
+boot) through a TIOCSRS485 ioctl(), RTS is initialized by the uart
+driver's ->rs485_config() callback and then likewise remains unmodified.
+
+The PL011 driver initializes RTS on uart open and prevents subsequent
+modification in its ->set_mctrl() callback.  That code is obsoleted by
+the present commit, so drop it.
+
+Cc: Jan Kiszka <jan.kiszka@siemens.com>
+Cc: Su Bao Cheng <baocheng.su@siemens.com>
+Signed-off-by: Lukas Wunner <lukas@wunner.de>
+Link: https://lore.kernel.org/r/2d2acaf3a69e89b7bf687c912022b11fd29dfa1e.1642909284.git.lukas@wunner.de
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/tty/serial/serial_core.c | 34 +++++++++++---------------------
+ 1 file changed, 12 insertions(+), 22 deletions(-)
+
+diff --git a/drivers/tty/serial/serial_core.c b/drivers/tty/serial/serial_core.c
+index be0d9922e320..dbd6911c32f1 100644
+--- a/drivers/tty/serial/serial_core.c
++++ b/drivers/tty/serial/serial_core.c
+@@ -144,6 +144,11 @@ uart_update_mctrl(struct uart_port *port, unsigned int set, unsigned int clear)
+ 	unsigned long flags;
+ 	unsigned int old;
+ 
++	if (port->rs485.flags & SER_RS485_ENABLED) {
++		set &= ~TIOCM_RTS;
++		clear &= ~TIOCM_RTS;
++	}
++
+ 	spin_lock_irqsave(&port->lock, flags);
+ 	old = port->mctrl;
+ 	port->mctrl = (old & ~clear) | set;
+@@ -157,23 +162,10 @@ uart_update_mctrl(struct uart_port *port, unsigned int set, unsigned int clear)
+ 
+ static void uart_port_dtr_rts(struct uart_port *uport, int raise)
+ {
+-	int rs485_on = uport->rs485_config &&
+-		(uport->rs485.flags & SER_RS485_ENABLED);
+-	int RTS_after_send = !!(uport->rs485.flags & SER_RS485_RTS_AFTER_SEND);
+-
+-	if (raise) {
+-		if (rs485_on && RTS_after_send) {
+-			uart_set_mctrl(uport, TIOCM_DTR);
+-			uart_clear_mctrl(uport, TIOCM_RTS);
+-		} else {
+-			uart_set_mctrl(uport, TIOCM_DTR | TIOCM_RTS);
+-		}
+-	} else {
+-		unsigned int clear = TIOCM_DTR;
+-
+-		clear |= (!rs485_on || RTS_after_send) ? TIOCM_RTS : 0;
+-		uart_clear_mctrl(uport, clear);
+-	}
++	if (raise)
++		uart_set_mctrl(uport, TIOCM_DTR | TIOCM_RTS);
++	else
++		uart_clear_mctrl(uport, TIOCM_DTR | TIOCM_RTS);
+ }
+ 
+ /*
+@@ -1102,11 +1094,6 @@ uart_tiocmset(struct tty_struct *tty, unsigned int set, unsigned int clear)
+ 		goto out;
+ 
+ 	if (!tty_io_error(tty)) {
+-		if (uport->rs485.flags & SER_RS485_ENABLED) {
+-			set &= ~TIOCM_RTS;
+-			clear &= ~TIOCM_RTS;
+-		}
+-
+ 		uart_update_mctrl(uport, set, clear);
+ 		ret = 0;
+ 	}
+@@ -2415,6 +2402,9 @@ uart_configure_port(struct uart_driver *drv, struct uart_state *state,
+ 		 */
+ 		spin_lock_irqsave(&port->lock, flags);
+ 		port->mctrl &= TIOCM_DTR;
++		if (port->rs485.flags & SER_RS485_ENABLED &&
++		    !(port->rs485.flags & SER_RS485_RTS_AFTER_SEND))
++			port->mctrl |= TIOCM_RTS;
+ 		port->ops->set_mctrl(port, port->mctrl);
+ 		spin_unlock_irqrestore(&port->lock, flags);
+ 
+-- 
+2.32.0
+


### PR DESCRIPTION
Issue description:
When work on rs485 mode, it can not receive data.
The root casue is the rts can not change,it always pull high.
It can send data only.

Upstream:f85e04503f369b3f2be28c83fc48b74e19936ebc has fixed this issue before.
But d3b3404df318504ec084213ab1065b73f49b0f1d has broken the fix.
Pick the commit:2dd8a74fddd21b95dcc60a2d3c9eaec993419d69 to fix it

Signed-off-by: chao zeng <chao.zeng@siemens.com>