### PR TITLE
install-on-emmc: Improve the robustness

### DIFF
--- a/recipes-core/install-on-emmc/install-on-emmc_1.0.bb
+++ b/recipes-core/install-on-emmc/install-on-emmc_1.0.bb
@@ -11,7 +11,7 @@ inherit dpkg-raw
 DESCRIPTION = "This service provides the option to install on eMMC during first boot"
 
 DEPENDS = "regen-rootfs-uuid"
-DEBIAN_DEPENDS = "systemd, fdisk, util-linux, regen-rootfs-uuid, parted"
+DEBIAN_DEPENDS = "systemd, fdisk, util-linux, regen-rootfs-uuid, parted, gdisk, "
 
 SRC_URI = " \
     file://install-on-emmc-on-first-boot.service \


### PR DESCRIPTION
Main change point:

1. When using Win32 Disk Imager to make the boot-able SD card or USB
   stick that bigger than the eMMC size (16GB), the `Backup LBA` of the
   GPT header is set to the end of the device, which is beyond the 16GB
   range. After copying such image to the eMMC, linux does not treat the
   GPT partition table as a correct one and some wired problems happen,
   such as the new p1 could not be informed to kernel.

   The solution is, the `Backup LBA` must be adjusted to the end of the
   eMMC after copying the image to the eMMC. `gdisk` provides an easy
   way to handle that.

2. If the eMMC has old partition data, (which is true for the Advanced
   device with Industrial OS), then better to wipe the eMMC partition
   table before copying the data to eMMC. This is because according to
   UEFI spec, there is a GPT backup header and backup partition table at
   the end of the device. When copying the new image via dd, normally
   the tail part of the device will not be touched. This is ok when
   everything goes smoothly, however, if problem happen during the
   install-on-emmc, the old backup partition data could be recovered
   during next boot.

   For example in the above problem, when `Backup LBA` is beyond the
   eMMC size, the new partition p1 could not be informed to kernel.
   however, the since there is already the old p1 before
   install-on-emmc, the script still continue to reboot the device,
   however, during next booting, the `Backup LBA` offset error is
   detected and the old backup partition table is recovered to overwrite
   the new GPT table.

   It is very hard to notice this issue especially when the old image
   and the new image have similar partition layout.

   The solution is, before install-on-emmc, wipe the old GPT
   partitioning data, including the backup LBA. `sgdisk` also provides
   an easy way to wipe it, meanwhile `sfdisk` could not do it easily.
