### PR TITLE
u-boot: Report fdt error for loading u-boot from SPL

### DIFF
--- a/recipes-bsp/u-boot/files/0001-iot2050-binman-add-missing-msg-for-blobs.patch
+++ b/recipes-bsp/u-boot/files/0001-iot2050-binman-add-missing-msg-for-blobs.patch
@@ -1,7 +1,7 @@
-From a790bc99d6599716e14c94ec20882b62e7a5f384 Mon Sep 17 00:00:00 2001
+From e562668176b133e0530a5e2b6bd94a2319b79e28 Mon Sep 17 00:00:00 2001
 From: Ivan Mikhaylov <ivan.mikhaylov@siemens.com>
 Date: Thu, 9 Dec 2021 16:10:53 +0000
-Subject: [PATCH 01/31] iot2050: binman: add missing-msg for blobs
+Subject: [PATCH 01/32] iot2050: binman: add missing-msg for blobs
 
 Add the 'missing-msg' for blobs for more detailed output on missing system
 firmware and SEBoot blobs.

--- a/recipes-bsp/u-boot/files/0002-watchdog-rti_wdt-Add-10-safety-margin-to-clock-frequ.patch
+++ b/recipes-bsp/u-boot/files/0002-watchdog-rti_wdt-Add-10-safety-margin-to-clock-frequ.patch
@@ -1,7 +1,7 @@
-From fed1c8f377322c69519538267d6687ee611518f9 Mon Sep 17 00:00:00 2001
+From 91afd37f3c1c664d3542dffeeda55c5d05c021f8 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 21 Feb 2022 17:09:08 +0100
-Subject: [PATCH 02/31] watchdog: rti_wdt: Add 10% safety margin to clock
+Subject: [PATCH 02/32] watchdog: rti_wdt: Add 10% safety margin to clock
  frequency
 
 When running against RC_OSC_32k, the watchdog may suffer from running

--- a/recipes-bsp/u-boot/files/0003-mtd-spi-Convert-is_locked-callback-to-is_unlocked.patch
+++ b/recipes-bsp/u-boot/files/0003-mtd-spi-Convert-is_locked-callback-to-is_unlocked.patch
@@ -1,7 +1,7 @@
-From 9134939b843f567dc99bb5fedaba8cb913d518cc Mon Sep 17 00:00:00 2001
+From f971a28c22c955f95db2f7dfe80f0c3b1dfa0cd1 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 23 Feb 2022 10:26:16 +0100
-Subject: [PATCH 03/31] mtd: spi: Convert is_locked callback to is_unlocked
+Subject: [PATCH 03/32] mtd: spi: Convert is_locked callback to is_unlocked
 
 There was no user of this callback after 5b66fdb29dc3 anymore, and its
 semantic as now inconsistent between stm and sst26. What we need for the

--- a/recipes-bsp/u-boot/files/0004-sf-Query-write-protection-status-before-operating-th.patch
+++ b/recipes-bsp/u-boot/files/0004-sf-Query-write-protection-status-before-operating-th.patch
@@ -1,7 +1,7 @@
-From c34265562774cefab994bae793e9a08d914ee7e6 Mon Sep 17 00:00:00 2001
+From f92785a0964a6ac750b6608878ec71b536ce8c1b Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 2 Feb 2022 07:20:43 +0100
-Subject: [PATCH 04/31] sf: Query write-protection status before operating the
+Subject: [PATCH 04/32] sf: Query write-protection status before operating the
  flash
 
 Do not suggest successful operation if a flash area to be changed is

--- a/recipes-bsp/u-boot/files/0005-arm-dts-iot2050-Add-cfg-register-space-for-ringacc-a.patch
+++ b/recipes-bsp/u-boot/files/0005-arm-dts-iot2050-Add-cfg-register-space-for-ringacc-a.patch
@@ -1,7 +1,7 @@
-From 1fa4f3489d94829b3aec1e2641f3550553ab837c Mon Sep 17 00:00:00 2001
+From f6dc3a3db9ee2db36ca1e553713ee8367e67274f Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 15 Feb 2022 22:15:40 +0100
-Subject: [PATCH 05/31] arm: dts: iot2050: Add cfg register space for ringacc
+Subject: [PATCH 05/32] arm: dts: iot2050: Add cfg register space for ringacc
  and udmap
 
 Recent unrelated fixes (9876ae7db6da) revealed that we were missing bits

--- a/recipes-bsp/u-boot/files/0006-board-siemens-iot2050-Split-the-build-for-PG1-and-PG.patch
+++ b/recipes-bsp/u-boot/files/0006-board-siemens-iot2050-Split-the-build-for-PG1-and-PG.patch
@@ -1,7 +1,7 @@
-From ab47d13039310308341cc3ed42052641d6cf3901 Mon Sep 17 00:00:00 2001
+From 6ea8352936055e8427d866fb6f081417c4a27c36 Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Wed, 12 Jan 2022 15:05:27 +0800
-Subject: [PATCH 06/31] board: siemens: iot2050: Split the build for PG1 and
+Subject: [PATCH 06/32] board: siemens: iot2050: Split the build for PG1 and
  PG2
 
 Due to different signature keys, the PG1 and the PG2 boards can no

--- a/recipes-bsp/u-boot/files/0007-arm-dts-iot2050-Use-the-auto-generator-nodes-for-fdt.patch
+++ b/recipes-bsp/u-boot/files/0007-arm-dts-iot2050-Use-the-auto-generator-nodes-for-fdt.patch
@@ -1,7 +1,7 @@
-From 6b0c3ea196cc2da8782ebc1217951b053fb7438a Mon Sep 17 00:00:00 2001
+From 95b2aeed092e8fe83806a8894fb11dc60822f6d2 Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Wed, 12 Jan 2022 14:52:01 +0800
-Subject: [PATCH 07/31] arm: dts: iot2050: Use the auto generator nodes for fdt
+Subject: [PATCH 07/32] arm: dts: iot2050: Use the auto generator nodes for fdt
 
 Refactor according to the entry `fit: Entry containing a FIT` of
 document tools/binman/README.entries.

--- a/recipes-bsp/u-boot/files/0008-iot2050-Update-firmware-layout.patch
+++ b/recipes-bsp/u-boot/files/0008-iot2050-Update-firmware-layout.patch
@@ -1,7 +1,7 @@
-From 2ad9139bce1ee3eb695c43a74f4289c53ea8b3fd Mon Sep 17 00:00:00 2001
+From ae781381e0aeb4f632b8d2d4cfaffc21a8b32327 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 14 Jan 2022 18:52:06 +0100
-Subject: [PATCH 08/31] iot2050: Update firmware layout
+Subject: [PATCH 08/32] iot2050: Update firmware layout
 
 The latest version of the binary-only firmware parts come in a combined
 form of FSBL and sysfw containers. This implies some layout changes to

--- a/recipes-bsp/u-boot/files/0009-lib-crypto-Enable-more-algorithms-in-cert-verificati.patch
+++ b/recipes-bsp/u-boot/files/0009-lib-crypto-Enable-more-algorithms-in-cert-verificati.patch
@@ -1,7 +1,7 @@
-From 5a6b96af7088860782866921325bce83c0e1483f Mon Sep 17 00:00:00 2001
+From cce9007ff8e1dcd93d64e11ae395447f1a7402e9 Mon Sep 17 00:00:00 2001
 From: Ilias Apalodimas <ilias.apalodimas@linaro.org>
 Date: Wed, 19 Jan 2022 13:54:41 +0200
-Subject: [PATCH 09/31] lib/crypto: Enable more algorithms in cert verification
+Subject: [PATCH 09/32] lib/crypto: Enable more algorithms in cert verification
 
 Right now the code explicitly limits us to sha1,256 hashes with RSA2048
 encryption.  But the limitation is artificial since U-Boot supports

--- a/recipes-bsp/u-boot/files/0010-efi_loader-use-pUs-for-printing-GUIDs.patch
+++ b/recipes-bsp/u-boot/files/0010-efi_loader-use-pUs-for-printing-GUIDs.patch
@@ -1,7 +1,7 @@
-From fd38aeb5caa5fbb67e52e0f956a0803f0df73dc7 Mon Sep 17 00:00:00 2001
+From ab9e191ab2dad428647c688a6d1b3f5a43fc51b3 Mon Sep 17 00:00:00 2001
 From: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>
 Date: Sun, 16 Jan 2022 14:15:31 +0100
-Subject: [PATCH 10/31] efi_loader: use %pUs for printing GUIDs
+Subject: [PATCH 10/32] efi_loader: use %pUs for printing GUIDs
 
 For printing GUIDs with macro EFI_ENTRY use %pUs instead of %pUl to provide
 readable debug output.

--- a/recipes-bsp/u-boot/files/0011-efi_loader-correctly-handle-mixed-hashes-and-signatu.patch
+++ b/recipes-bsp/u-boot/files/0011-efi_loader-correctly-handle-mixed-hashes-and-signatu.patch
@@ -1,7 +1,7 @@
-From df674ede84b14db3367eb38f8fd4674b7b725eb8 Mon Sep 17 00:00:00 2001
+From 13f3fccd5b269c17c6918609beb588b3978988a3 Mon Sep 17 00:00:00 2001
 From: Ilias Apalodimas <ilias.apalodimas@linaro.org>
 Date: Sat, 29 Jan 2022 00:20:31 +0200
-Subject: [PATCH 11/31] efi_loader: correctly handle mixed hashes and
+Subject: [PATCH 11/32] efi_loader: correctly handle mixed hashes and
  signatures in db
 
 A mix of signatures and hashes in db doesn't always work as intended.

--- a/recipes-bsp/u-boot/files/0012-efi_loader-Improve-console-screen-clearing-and-reset.patch
+++ b/recipes-bsp/u-boot/files/0012-efi_loader-Improve-console-screen-clearing-and-reset.patch
@@ -1,7 +1,7 @@
-From e550c609227c52b05c3993f96c56c4b24fceb5ed Mon Sep 17 00:00:00 2001
+From 2b2b35a240e7c5da668a972d4b936553d4f399d9 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 25 Apr 2022 10:33:15 +0200
-Subject: [PATCH 12/31] efi_loader: Improve console screen clearing and reset
+Subject: [PATCH 12/32] efi_loader: Improve console screen clearing and reset
 
 Ensure that the default colors are set when clearing the screen so that
 the background is properly filled and succeeding colored outputs will

--- a/recipes-bsp/u-boot/files/0013-env-Complete-generic-support-for-writable-list.patch
+++ b/recipes-bsp/u-boot/files/0013-env-Complete-generic-support-for-writable-list.patch
@@ -1,7 +1,7 @@
-From 4fa300bcd9313b1c0b334667e9f4f363e4bbc843 Mon Sep 17 00:00:00 2001
+From 6fb1fba4438c6f8b767431a07c35918229dd0a57 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 28 Feb 2022 12:00:14 +0100
-Subject: [PATCH 13/31] env: Complete generic support for writable list
+Subject: [PATCH 13/32] env: Complete generic support for writable list
 
 This completes what 890feecaab72 started by selecting ENV_APPEND and
 ENV_IS_NOWHERE and by moving this driver to top if the list. This

--- a/recipes-bsp/u-boot/files/0014-env-Couple-networking-related-variable-flags-to-CONF.patch
+++ b/recipes-bsp/u-boot/files/0014-env-Couple-networking-related-variable-flags-to-CONF.patch
@@ -1,7 +1,7 @@
-From 9585d3ae8b9618265cdaf94a56aa540b7a060fc1 Mon Sep 17 00:00:00 2001
+From 2638e768ec3a0ec2c060c513591be4265034c9b8 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 25 Apr 2022 11:15:36 +0200
-Subject: [PATCH 14/31] env: Couple networking-related variable flags to
+Subject: [PATCH 14/32] env: Couple networking-related variable flags to
  CONFIG_NET
 
 Boards may set networking variables programmatically, thus may have

--- a/recipes-bsp/u-boot/files/0015-introduce-CONFIG_DEVICE_TREE_INCLUDES.patch
+++ b/recipes-bsp/u-boot/files/0015-introduce-CONFIG_DEVICE_TREE_INCLUDES.patch
@@ -1,7 +1,7 @@
-From c6cfb9ed1ddd251f2efd771368757e6a7c9c8a3e Mon Sep 17 00:00:00 2001
+From 89b0f20bd924d298f9b98583356c3d88e4160878 Mon Sep 17 00:00:00 2001
 From: Rasmus Villemoes <rasmus.villemoes@prevas.dk>
 Date: Sun, 21 Nov 2021 14:52:51 +0100
-Subject: [PATCH 15/31] introduce CONFIG_DEVICE_TREE_INCLUDES
+Subject: [PATCH 15/32] introduce CONFIG_DEVICE_TREE_INCLUDES
 
 The build system already automatically looks for and includes an
 in-tree *-u-boot.dtsi when building the control .dtb. However, there

--- a/recipes-bsp/u-boot/files/0016-tools-Add-script-for-converting-public-key-into-devi.patch
+++ b/recipes-bsp/u-boot/files/0016-tools-Add-script-for-converting-public-key-into-devi.patch
@@ -1,7 +1,7 @@
-From f2b7490138359861626f2682fe6f1ed32e1783e3 Mon Sep 17 00:00:00 2001
+From 1f90f8cb1c28a1f4867c9cf0596e5fab94b8f59a Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 14 Feb 2022 07:05:15 +0100
-Subject: [PATCH 16/31] tools: Add script for converting public key into device
+Subject: [PATCH 16/32] tools: Add script for converting public key into device
  tree include
 
 Allows to create a public key device tree dtsi for inclusion into U-Boot

--- a/recipes-bsp/u-boot/files/0017-binman-Include-also-subnodes-in-generator-nodes.patch
+++ b/recipes-bsp/u-boot/files/0017-binman-Include-also-subnodes-in-generator-nodes.patch
@@ -1,7 +1,7 @@
-From 52edaeb22e5979dcd867ef1da3fa7b60a462c178 Mon Sep 17 00:00:00 2001
+From 5e72c565d98c738f1c14880bcf760d32c1d8b64a Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 28 Feb 2022 17:06:20 +0100
-Subject: [PATCH 17/31] binman: Include also subnodes in generator nodes
+Subject: [PATCH 17/32] binman: Include also subnodes in generator nodes
 
 This allows to prefill fdt and config nodes with hash and signature
 subnodes. It's just important to place the child nodes last so that

--- a/recipes-bsp/u-boot/files/0018-image-fit-Make-string-of-algo-parameter-constant.patch
+++ b/recipes-bsp/u-boot/files/0018-image-fit-Make-string-of-algo-parameter-constant.patch
@@ -1,7 +1,7 @@
-From 5a0239c41af9a4fa342950784ba8c8e6ca924a95 Mon Sep 17 00:00:00 2001
+From 008ca4348dce2ba508f9ab91aa727e23e3bc97fb Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 14 Jan 2022 10:21:17 +0100
-Subject: [PATCH 18/31] image-fit: Make string of algo parameter constant
+Subject: [PATCH 18/32] image-fit: Make string of algo parameter constant
 
 Modifications would be invalid.
 

--- a/recipes-bsp/u-boot/files/0019-mkimage-Allow-to-specify-the-signature-algorithm-on-.patch
+++ b/recipes-bsp/u-boot/files/0019-mkimage-Allow-to-specify-the-signature-algorithm-on-.patch
@@ -1,7 +1,7 @@
-From 99ca3b1e9dee719832691eaed7c9df16f88b97c8 Mon Sep 17 00:00:00 2001
+From 29277dc9c8d7bbb5c1ea8de6a684e749a5c6477c Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 14 Jan 2022 10:21:19 +0100
-Subject: [PATCH 19/31] mkimage: Allow to specify the signature algorithm on
+Subject: [PATCH 19/32] mkimage: Allow to specify the signature algorithm on
  the command line
 
 This permits to prepare FIT image description that do not hard-code the

--- a/recipes-bsp/u-boot/files/0020-iot2050-Add-watchdog-start-to-bootcmd.patch
+++ b/recipes-bsp/u-boot/files/0020-iot2050-Add-watchdog-start-to-bootcmd.patch
@@ -1,7 +1,7 @@
-From a54d0925b0a151e17bd3c889ab219224ec0a1188 Mon Sep 17 00:00:00 2001
+From 85e7b5221acf9851dfd0b0a75ae49add36c6c164 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 20 Mar 2022 15:00:34 +0100
-Subject: [PATCH 20/31] iot2050: Add watchdog start to bootcmd
+Subject: [PATCH 20/32] iot2050: Add watchdog start to bootcmd
 
 Allows run-time control over watchdog auto-start and the timeout via
 setting the environment variable watchdog_timeout_ms. A value of zero

--- a/recipes-bsp/u-boot/files/0021-iot2050-Add-CONFIG_ENV_FLAGS_LIST_STATIC.patch
+++ b/recipes-bsp/u-boot/files/0021-iot2050-Add-CONFIG_ENV_FLAGS_LIST_STATIC.patch
@@ -1,7 +1,7 @@
-From 685f0dbedc0d371a26317752a3dda3e45964f203 Mon Sep 17 00:00:00 2001
+From 4ec42ef5b6446571d0f7ab59336fa4ee6ad05878 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 25 Apr 2022 10:42:25 +0200
-Subject: [PATCH 21/31] iot2050: Add CONFIG_ENV_FLAGS_LIST_STATIC
+Subject: [PATCH 21/32] iot2050: Add CONFIG_ENV_FLAGS_LIST_STATIC
 
 Will be needed when CONFIG_ENV_WRITEABLE_LIST is enabled. The listed
 variables shall remain writable, for informational purposes - they have

--- a/recipes-bsp/u-boot/files/0022-arm-dts-iot2050-Allow-verifying-U-Boot-proper-by-SPL.patch
+++ b/recipes-bsp/u-boot/files/0022-arm-dts-iot2050-Allow-verifying-U-Boot-proper-by-SPL.patch
@@ -1,7 +1,7 @@
-From d3425f5110617dbb6df58a85098febcf9402ee35 Mon Sep 17 00:00:00 2001
+From 8b531450e86a316e5d1d47c2cbf04120d675cf72 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 7 Nov 2021 17:59:17 +0100
-Subject: [PATCH 22/31] arm: dts: iot2050: Allow verifying U-Boot proper by SPL
+Subject: [PATCH 22/32] arm: dts: iot2050: Allow verifying U-Boot proper by SPL
 
 Add hashes and configuration signature stubs to prepare verified boot
 of main U-Boot by SPL.

--- a/recipes-bsp/u-boot/files/0023-iot2050-Add-script-for-signing-artifacts.patch
+++ b/recipes-bsp/u-boot/files/0023-iot2050-Add-script-for-signing-artifacts.patch
@@ -1,7 +1,7 @@
-From 68da91ce946282c3ca78435fc892e99a4cc9ef99 Mon Sep 17 00:00:00 2001
+From 3d2699d74e7980d20f2a3f825ce558ad974e1dbe Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 18 Nov 2021 10:56:22 +0100
-Subject: [PATCH 23/31] iot2050: Add script for signing artifacts
+Subject: [PATCH 23/32] iot2050: Add script for signing artifacts
 
 There are many ways to get a signed firmware for the IOT2050 devices,
 namely for the parts under user-control. This script documents one way

--- a/recipes-bsp/u-boot/files/0024-arm-dts-iot2050-Optionally-embed-OTP-programming-dat.patch
+++ b/recipes-bsp/u-boot/files/0024-arm-dts-iot2050-Optionally-embed-OTP-programming-dat.patch
@@ -1,7 +1,7 @@
-From b6443db6e7a9a9e090b958362ec080d0827d129d Mon Sep 17 00:00:00 2001
+From 649aa315969d9dbc903fe97c3cc60aaaffdbfe10 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Fri, 27 May 2022 11:29:20 +0200
-Subject: [PATCH 24/31] arm: dts: iot2050: Optionally embed OTP programming
+Subject: [PATCH 24/32] arm: dts: iot2050: Optionally embed OTP programming
  data into image
 
 Use external blob otpcmd.bin to replace the 0xff filled OTP programming

--- a/recipes-bsp/u-boot/files/0025-gpio-da8xx_gpio-Fix-gpio-name-with-address.patch
+++ b/recipes-bsp/u-boot/files/0025-gpio-da8xx_gpio-Fix-gpio-name-with-address.patch
@@ -1,7 +1,7 @@
-From 960874d0986851e090df2828e746326b4c8f722b Mon Sep 17 00:00:00 2001
+From d36f6167cf7579502ee7562c91d347610261af82 Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Fri, 7 Jan 2022 11:26:24 +0800
-Subject: [PATCH 25/31] gpio: da8xx_gpio: Fix gpio name with address
+Subject: [PATCH 25/32] gpio: da8xx_gpio: Fix gpio name with address
 
 The GPIO bank numbers do not appear in the device tree,
 so make the gpio name based on the address

--- a/recipes-bsp/u-boot/files/0026-board-siemens-iot2050-use-the-named-gpio-to-control-.patch
+++ b/recipes-bsp/u-boot/files/0026-board-siemens-iot2050-use-the-named-gpio-to-control-.patch
@@ -1,7 +1,7 @@
-From 5611ee6f3052c523a76d2befacea9a717049b198 Mon Sep 17 00:00:00 2001
+From 55ba97f1af9e44092a29dfbb5ef5582bb8cacb58 Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Wed, 12 Jan 2022 10:34:18 +0800
-Subject: [PATCH 26/31] board: siemens: iot2050: use the named gpio to control
+Subject: [PATCH 26/32] board: siemens: iot2050: use the named gpio to control
  the user-button
 
 User-button is controlled by the mcu domain gpio number 25.

--- a/recipes-bsp/u-boot/files/0027-arm-dts-add-the-m.2-support.patch
+++ b/recipes-bsp/u-boot/files/0027-arm-dts-add-the-m.2-support.patch
@@ -1,7 +1,7 @@
-From ac356fe052006b5bd9abfe1e95d03f2820082da7 Mon Sep 17 00:00:00 2001
+From 1a81b0e841547bfde3b6d7febecb20d3a3c7f558 Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Fri, 7 Jan 2022 10:18:07 +0800
-Subject: [PATCH 27/31] arm: dts: add the m.2 support
+Subject: [PATCH 27/32] arm: dts: add the m.2 support
 
 Add the support for the m.2 board based on the iot2050 advanced board
 The board has two m.2 connector,one is B-KEY,the other is E-KEY.

--- a/recipes-bsp/u-boot/files/0028-board-siemens-iot2050-add-the-support-for-m2-variant.patch
+++ b/recipes-bsp/u-boot/files/0028-board-siemens-iot2050-add-the-support-for-m2-variant.patch
@@ -1,7 +1,7 @@
-From 36f67ae7d6029319bcf8e56fa565b0e6c9fde6bc Mon Sep 17 00:00:00 2001
+From e07f2283e716a1fb3946e8d3892378fb4192dcbd Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Thu, 30 Jun 2022 10:53:05 +0800
-Subject: [PATCH 28/31] board: siemens: iot2050: add the support for m2 variant
+Subject: [PATCH 28/32] board: siemens: iot2050: add the support for m2 variant
 
 For normal boot, load and configure m.2 device through boot.scr
 For securey boot enable, go through UEFI, fixup the compatible

--- a/recipes-bsp/u-boot/files/0029-lib-crypto-add-mscode_parser.patch
+++ b/recipes-bsp/u-boot/files/0029-lib-crypto-add-mscode_parser.patch
@@ -1,7 +1,7 @@
-From 65ef2c27edb8c2d37d0f92bbed68fa9ed34397d5 Mon Sep 17 00:00:00 2001
+From d9ca309d31f9bfc98bde5a5f7503fc57dc76fd37 Mon Sep 17 00:00:00 2001
 From: AKASHI Takahiro <takahiro.akashi@linaro.org>
 Date: Tue, 5 Jul 2022 14:48:11 +0900
-Subject: [PATCH 29/31] lib: crypto: add mscode_parser
+Subject: [PATCH 29/32] lib: crypto: add mscode_parser
 
 In MS authenticode, pkcs7 should have data in its contentInfo field.
 This data is tagged with SpcIndirectData type and, for a signed PE image,

--- a/recipes-bsp/u-boot/files/0030-efi_loader-signature-export-efi_hash_regions.patch
+++ b/recipes-bsp/u-boot/files/0030-efi_loader-signature-export-efi_hash_regions.patch
@@ -1,7 +1,7 @@
-From 2539ab52e25b9be783bef68f91118a9fdcb2e283 Mon Sep 17 00:00:00 2001
+From 1e9ae380a44aa71c69cc3938e6f96f7c320cb30f Mon Sep 17 00:00:00 2001
 From: AKASHI Takahiro <takahiro.akashi@linaro.org>
 Date: Tue, 5 Jul 2022 14:48:12 +0900
-Subject: [PATCH 30/31] efi_loader: signature: export efi_hash_regions()
+Subject: [PATCH 30/32] efi_loader: signature: export efi_hash_regions()
 
 This function is used to calculate a message digest as part of
 authentication process in a later patch.

--- a/recipes-bsp/u-boot/files/0031-efi_loader-image_loader-add-a-missing-digest-verific.patch
+++ b/recipes-bsp/u-boot/files/0031-efi_loader-image_loader-add-a-missing-digest-verific.patch
@@ -1,7 +1,7 @@
-From d5ab85366136770b55fda9e4db6db18b48a92e4d Mon Sep 17 00:00:00 2001
+From 663d795a4376b1942ceb24622d90d7b4802a6008 Mon Sep 17 00:00:00 2001
 From: AKASHI Takahiro <takahiro.akashi@linaro.org>
 Date: Tue, 5 Jul 2022 14:48:14 +0900
-Subject: [PATCH 31/31] efi_loader: image_loader: add a missing digest
+Subject: [PATCH 31/32] efi_loader: image_loader: add a missing digest
  verification for signed PE image
 
 At the last step of PE image authentication, an image's hash value must be

--- a/recipes-bsp/u-boot/files/0032-spl-fit-Report-fdt-error-for-loading-u-boot.patch
+++ b/recipes-bsp/u-boot/files/0032-spl-fit-Report-fdt-error-for-loading-u-boot.patch
@@ -1,0 +1,40 @@
+From 8f743321ad1584ed37e197f78bf3ac56f409d1b1 Mon Sep 17 00:00:00 2001
+From: Baocheng Su <baocheng.su@siemens.com>
+Date: Sat, 30 Jul 2022 10:53:55 +0800
+Subject: [PATCH 32/32] spl: fit: Report fdt error for loading u-boot
+
+Commit 71551055cbdb ("spl: fit: Load devicetree when a Linux payload is
+found") made a change to not report the spl_fit_append_fdt error at all
+if next-stage image is u-boot.
+
+However for u-boot image without CONFIG_OF_EMBED, the error should be
+reported to uplevel caller. Otherwise, uplevel caller would think the
+fdt is already loaded which is obviously not true.
+
+Signed-off-by: Baocheng Su <baocheng.su@siemens.com>
+---
+ common/spl/spl_fit.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/common/spl/spl_fit.c b/common/spl/spl_fit.c
+index 5fe0273d66..a764a7d5d1 100644
+--- a/common/spl/spl_fit.c
++++ b/common/spl/spl_fit.c
+@@ -755,8 +755,12 @@ int spl_load_simple_fit(struct spl_image_info *spl_image,
+ 	 */
+ 	if (os_takes_devicetree(spl_image->os)) {
+ 		ret = spl_fit_append_fdt(spl_image, info, sector, &ctx);
+-		if (ret < 0 && spl_image->os != IH_OS_U_BOOT)
+-			return ret;
++		if (ret < 0) {
++			if (spl_image->os != IH_OS_U_BOOT)
++				return ret;
++			else if (!IS_ENABLED(CONFIG_OF_EMBED))
++				return ret;
++		}
+ 	}
+ 
+ 	firmware_node = node;
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/u-boot-iot2050_2022.01.inc
+++ b/recipes-bsp/u-boot/u-boot-iot2050_2022.01.inc
@@ -44,6 +44,7 @@ SRC_URI += " \
     file://0029-lib-crypto-add-mscode_parser.patch \
     file://0030-efi_loader-signature-export-efi_hash_regions.patch \
     file://0031-efi_loader-image_loader-add-a-missing-digest-verific.patch \
+    file://0032-spl-fit-Report-fdt-error-for-loading-u-boot.patch \
     "
 
 SRC_URI[sha256sum] = "81b4543227db228c03f8a1bf5ddbc813b0bb8f6555ce46064ef721a6fc680413"


### PR DESCRIPTION
u-boot commit 71551055cbdb ("spl: fit: Load devicetree when a Linux
payload is found") made a change to not report the spl_fit_append_fdt
error at all if next-stage image is u-boot.

However for u-boot image without CONFIG_OF_EMBED, the error should be
reported to up-level caller. Otherwise, up-level caller would think the
fdt is already loaded which is obviously not true.

The reported issue is that, when secure boot is enabled, by tampering
the fdt data, although the device hangs, the red LED does not light. The
reason is that when spl parsing the fdt, bad hash value error was not
reported to the up-level caller, which would light the red led if
received any error.

Signed-off-by: Baocheng Su <baocheng.su@siemens.com>