### PR TITLE
Bump the meta-coral version to latest main

### DIFF
--- a/kas/iot2050.yml
+++ b/kas/iot2050.yml
@@ -41,7 +41,7 @@ repos:
 
   meta-coral:
     url: https://github.com/siemens/meta-coral
-    refspec: 3b269218df570b02c213a4840575c0b79b96538a
+    refspec: 3fc1c86726e72f693f5b7e1791eabc156015459d
 
   cip-core:
     url: https://gitlab.com/cip-project/cip-core/isar-cip-core.git


### PR DESCRIPTION
Upstream repo https://salsa.debian.org/python-team/packages/python-absl integrated by meta-coral has just removed the `debian/0.15.0-1` tag which is picked up by the meta-coral, this caused the building failed for both the master and the V1.3.1 tag.

The latest main of meta-coral has bump the python-absl to `debian/0.15.0-2`.

Signed-off-by: Baocheng Su <baocheng.su@siemens.com>

This fix #351 for the master branch