### PR TITLE
iot2050-firmware-update: Add integrity check

### DIFF
--- a/recipes-app/iot2050-firmware-update/files/iot2050-firmware-update
+++ b/recipes-app/iot2050-firmware-update/files/iot2050-firmware-update
@@ -112,6 +112,15 @@ import tempfile
 import hashlib
 
 
+class UpgradeError(Exception):
+    def __init__(self, ErrorInfo):
+        super().__init__(self)
+        self.erroinfo = ErrorInfo
+
+    def __str__(self):
+        return self.erroinfo
+
+
 class FirmwareUpdate(object):
     def __init__(self, firmware):
         self.firmware = firmware
@@ -122,8 +131,7 @@ class FirmwareUpdate(object):
             with open(path, "r") as f:
                 return f.read()
         except IOError as e:
-            print("Reading {} failed: {}".format(path, e.strerror))
-            sys.exit(1)
+            raise UpgradeError("Reading {} failed: {}".format(path, e.strerror))
 
     @staticmethod
     def flash_erase(dev, start, nbytes):
@@ -139,8 +147,7 @@ class FirmwareUpdate(object):
         try:
             fcntl.ioctl(dev, MEMERASE, ioctl_data)
         except IOError:
-            print("ioctl failed")
-            sys.exit(1)
+            raise UpgradeError("Flash erasing failed")
 
     def get_mtd_info(self, mtd_num):
         ospi_dev_path = "/sys/bus/platform/devices/47040000.spi"
@@ -170,8 +177,7 @@ class FirmwareUpdate(object):
         try:
             mtd_dev = os.open(mtd_dev_path, os.O_SYNC | os.O_RDWR)
         except IOError as e:
-            print("Opening {} failed: {}".format(mtd_dev_path, e.strerror))
-            sys.exit(1)
+            raise UpgradeError("Opening {} failed: {}".format(mtd_dev_path, e.strerror))
 
         while mtd_pos < mtd_size and file_size > 0:
             mtd_content = os.read(mtd_dev, mtd_erasesize)
@@ -236,8 +242,7 @@ class FirmwareUpdate(object):
             try:
                 mtd_dev = os.open(mtd_dev_path, os.O_SYNC | os.O_RDWR)
             except IOError as e:
-                print("Opening {} failed: {}".format(mtd_dev_path, e.strerror))
-                sys.exit(1)
+                raise UpgradeError("Opening {} failed: {}".format(mtd_dev_path, e.strerror))
 
             while mtd_pos < mtd_size and firmware_len > 0:
                 mtd_content = os.read(mtd_dev, mtd_erasesize)
@@ -266,7 +271,7 @@ class FirmwareUpdate(object):
         firmware_flash_md5_digest = self.flash_md5_digest(self.firmware_len)
 
         if firmware_md5_digest != firmware_flash_md5_digest:
-            raise Exception('Upgrade Failed! Please do not reboot. Please try updating firmware again!\n')
+            raise UpgradeError("Firmware digest verification failed")
 
 
 class BoardInformation(object):
@@ -309,8 +314,11 @@ class BoardInformation(object):
 class UpdateConfiguration(object):
     def __init__(self, json_fileobj):
         # Deserialize the json file to an object so that we can use dot operator to access the fields.
-        self._jsonobj = json.load(
-            json_fileobj, object_hook=lambda d: Namespace(**d))
+        try:
+            self._jsonobj = json.load(
+                json_fileobj, object_hook=lambda d: Namespace(**d))
+        except ValueError:
+            raise UpgradeError("Decoding JSON has failed")
 
     def _check_os(self, target_os, os_info) -> bool:
         for tos in target_os:
@@ -350,8 +358,8 @@ class UpdateConfiguration(object):
     def preserved_uboot_env(self):
         try:
             return self._jsonobj.suggest_preserved_uboot_env
-        except Exception as e:
-            return None
+        except Exception:
+            raise UpgradeError("Get suggested preserved uboot env failed")
 
 
 class ManagedFirmwareUpdate(FirmwareUpdate):
@@ -382,8 +390,7 @@ class ManagedFirmwareUpdate(FirmwareUpdate):
             self._board_info.board_name, self._board_info.os_info)
 
         if len(firmware_names) <= 0:
-            print("No firmware image could be updated on this board")
-            exit(1)
+            raise UpgradeError("No firmware image could be updated on this board")
 
         if len(firmware_names) == 1:
             firmware_name = firmware_names[0]
@@ -441,7 +448,7 @@ class ManagedFirmwareUpdate(FirmwareUpdate):
                                 env_default_binary.name, uboot_env_assemble_file), check=True, shell=True)
                 except subprocess.CalledProcessError as error:
                     print(error.stdout)
-                    sys.exit(1)
+                    raise UpgradeError("Run mkenvimage failed")
 
                 firmware_size = os.path.getsize(env_default_binary.name)
 
@@ -465,7 +472,7 @@ class ManagedFirmwareUpdate(FirmwareUpdate):
         env_flash_md5_digest = self.flash_md5_digest(env_file_size, mtd_num=3)
 
         if env_file_md5_digest != env_flash_md5_digest:
-            raise Exception('Upgrade Failed! Please do not reboot. Please try updating firmware again!\n')
+            raise UpgradeError("Env digest verification failed")
 
     def get_preserved_uboot_env(self, preserve_list):
         if preserve_list:
@@ -487,11 +494,13 @@ class ManagedFirmwareUpdate(FirmwareUpdate):
                 preserved_uboot_env_value.append(env_value)
             except subprocess.CalledProcessError as error:
                 print(error.stdout)
-                sys.exit(1)
+                raise UpgradeError("Run fw_printenv failed")
 
         return preserved_uboot_env_value
 
+
 __version__ = "0.2"
+
 
 def main(argv):
     description=textwrap.dedent('''\
@@ -540,27 +549,39 @@ def main(argv):
         erase_env_input = input("\nWarning: All U-Boot environment variables will be reset to factory settings. Continue (y/N)? ")
         if not erase_env_input == "y":
             sys.exit(1)
+    try:
+        if args.force:
+            # When forced, ignore all the checking and call the underlying updater directly
+            updater = FirmwareUpdate(args.firmware)
+        else:
+            updater = ManagedFirmwareUpdate(args.firmware)
 
-    if args.force:
-        # When forced, ignore all the checking and call the underlying updater directly
-        updater = FirmwareUpdate(args.firmware)
-    else:
-        updater = ManagedFirmwareUpdate(args.firmware)
+        envlist = None
+        if not args.force and not args.reset:
+            envlist = updater.get_preserved_uboot_env(args.preserve_list)
 
-    envlist = None
-    if not args.force and not args.reset:
-        envlist = updater.get_preserved_uboot_env(args.preserve_list)
+        updater.update_firmware()
 
-    updater.update_firmware()
-
-    if envlist:
-        print("\n")
-        for env in envlist:
-            print(env)
-        preserved_env_input = input(
-            "\nWarning: Preserve the above env variables. Confirm(Y/n)? ")
-        if not preserved_env_input == "n":
-            updater.update_uboot_env(envlist)
+        if envlist:
+            print("\n")
+            for env in envlist:
+                print(env)
+            preserved_env_input = input(
+                "\nWarning: Preserve the above env variables. Confirm(Y/n)? ")
+            if not preserved_env_input == "n":
+                updater.update_uboot_env(envlist)
+    except UpgradeError as e:
+        print(e)
+        intput_reminder = '''
+        ====================================
+        Upgrade Failed! Please do not reboot!!
+        The Device may become brick.
+        Please try to upgrade firmware again!
+        ====================================
+Hit any Key to Exit:
+        '''
+        input(intput_reminder)
+        sys.exit(1)
 
     reboot_input = input(
         "\nWarning: Completed. Please reboot the device. Reboot now(y/N)? ")

--- a/recipes-app/iot2050-firmware-update/files/iot2050-firmware-update
+++ b/recipes-app/iot2050-firmware-update/files/iot2050-firmware-update
@@ -109,6 +109,7 @@ import textwrap
 from types import SimpleNamespace as Namespace
 import subprocess
 import tempfile
+import hashlib
 
 
 class FirmwareUpdate(object):
@@ -204,6 +205,7 @@ class FirmwareUpdate(object):
         self.firmware.seek(0)
         self.firmware.seek(0, os.SEEK_END)
         firmware_size = self.firmware.tell()
+        self.firmware_len = firmware_size
         self.firmware.seek(0)
 
         while True:
@@ -217,6 +219,54 @@ class FirmwareUpdate(object):
                 mtd_dev_path, mtd_size, mtd_erasesize, self.firmware, firmware_size)
 
             mtd_num += 1
+
+        self.firmware_integrity_check()
+
+    def flash_md5_digest(self, firmware_len, mtd_num=0):
+        flash_md5 = hashlib.md5()
+
+        while True:
+            if firmware_len <= 0:
+                break
+
+            mtd_dev_path, mtd_size, mtd_erasesize, mtd_name = self.get_mtd_info(
+                mtd_num)
+
+            mtd_pos = 0
+            try:
+                mtd_dev = os.open(mtd_dev_path, os.O_SYNC | os.O_RDWR)
+            except IOError as e:
+                print("Opening {} failed: {}".format(mtd_dev_path, e.strerror))
+                sys.exit(1)
+
+            while mtd_pos < mtd_size and firmware_len > 0:
+                mtd_content = os.read(mtd_dev, mtd_erasesize)
+                flash_md5.update(mtd_content)
+
+                mtd_pos += mtd_erasesize
+                firmware_len -= mtd_erasesize
+
+            os.close(mtd_dev)
+
+            mtd_num += 1
+
+        return flash_md5.hexdigest()
+
+    def firmware_md5_digest(self):
+        self.firmware.seek(0)
+        firmware_md5 = hashlib.md5()
+
+        for chunk in iter(lambda: self.firmware.read(4096), b""):
+            firmware_md5.update(chunk)
+
+        return firmware_md5.hexdigest()
+
+    def firmware_integrity_check(self):
+        firmware_md5_digest = self.firmware_md5_digest()
+        firmware_flash_md5_digest = self.flash_md5_digest(self.firmware_len)
+
+        if firmware_md5_digest != firmware_flash_md5_digest:
+            raise Exception('Upgrade Failed! Please do not reboot. Please try updating firmware again!\n')
 
 
 class BoardInformation(object):
@@ -401,6 +451,21 @@ class ManagedFirmwareUpdate(FirmwareUpdate):
                     print("Updating %-20s" % mtd_name, end="")
                     firmware_size = self.flash_operate(
                         mtd_dev_path, mtd_size, mtd_erasesize, env_default_binary, firmware_size)
+
+            self.uboot_env_integrify_check(env_default_binary)
+
+    def uboot_env_integrify_check(self, file_obj):
+        file_obj.seek(0)
+
+        env_md5 = hashlib.md5()
+        env_md5.update(file_obj.read())
+        env_file_md5_digest = env_md5.hexdigest()
+
+        env_file_size = os.path.getsize(file_obj.name)
+        env_flash_md5_digest = self.flash_md5_digest(env_file_size, mtd_num=3)
+
+        if env_file_md5_digest != env_flash_md5_digest:
+            raise Exception('Upgrade Failed! Please do not reboot. Please try updating firmware again!\n')
 
     def get_preserved_uboot_env(self, preserve_list):
         if preserve_list:


### PR DESCRIPTION
After the update is completed, read back the content of the flash, calculate the hash value of the content and the write value, compare the two hash value to ensure the correctness of the written value.

Signed-off-by: chao zeng <chao.zeng@siemens.com>