### PR TITLE
customizations-example: create a symbolic link for serial port

### DIFF
--- a/recipes-core/customizations-example/customizations-example_0.1-iot2050-debian.bb
+++ b/recipes-core/customizations-example/customizations-example_0.1-iot2050-debian.bb
@@ -25,7 +25,8 @@ SRC_URI = " \
     file://10-globally-managed-devices.conf \
     file://cellular-4g \
     file://eno1-default \
-    file://20-assign-ethernet-names.rules"
+    file://20-assign-ethernet-names.rules \
+    file://20-create-symbolic-link-for-serial-port.rules"
 
 do_install() {
     # add board status led service
@@ -53,4 +54,6 @@ do_install() {
     # swap ethernet port
     install -v -d  ${D}/etc/udev/rules.d/
     install -v -m 644 ${WORKDIR}/20-assign-ethernet-names.rules ${D}/etc/udev/rules.d/
+    # create a symbolic link for serial port
+    install -v -m 644 ${WORKDIR}/20-create-symbolic-link-for-serial-port.rules ${D}/etc/udev/rules.d/
 }

--- a/recipes-core/customizations-example/files/20-create-symbolic-link-for-serial-port.rules
+++ b/recipes-core/customizations-example/files/20-create-symbolic-link-for-serial-port.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="tty", SUBSYSTEMS=="usb", KERNELS=="3-1.4:1.0", DRIVERS=="cp210x", SYMLINK+="ttyX30"
+SUBSYSTEM=="tty", KERNEL=="ttyS2", DRIVERS=="omap8250", SYMLINK+="ttyX30"


### PR DESCRIPTION
For advanced board and basic board, serial port have different names For advanced board serial port named ttyUSB0, whereas for basic board, serial port named ttyS2

Another problem is when using 4G or 5G card go through USB signal, according to the probe sequence, ttyUSB0 may not represent serial port for advanced board.

So create a dev symbolic link ttyX30 represent serial port.

Signed-off-by: chao zeng <chao.zeng@siemens.com>