### PR TITLE
Bump meta-coral version

### DIFF
--- a/kas/iot2050.yml
+++ b/kas/iot2050.yml
@@ -41,7 +41,7 @@ repos:
 
   meta-coral:
     url: https://github.com/siemens/meta-coral
-    refspec: 3fc1c86726e72f693f5b7e1791eabc156015459d
+    refspec: 3df2710e9f577860d44c1430aaea321a35ca6f77
 
   cip-core:
     url: https://gitlab.com/cip-project/cip-core/isar-cip-core.git


### PR DESCRIPTION
Our build system has broken cause the bazel-bootstrap upstream changes.

the commit:
https://github.com/siemens/meta-coral/commit/914ab3abf6cc4460148964b832c4276e09cc071f
has fixed this issue.

The latest main branch needs the feature supported by the newer ISAR version.
the ISAR version we are using is v0.9, meta-coral would maintain an isar-v0.9
to compat isar version.

For long-term solution we need upgrade isar version.
Bump to the latest commit of meata-coral/isar-v0.9 branch to solve this problem

Signed-off-by: chao zeng <chao.zeng@siemens.com>