### PR TITLE
Integrate new tool k3conf

### DIFF
--- a/recipes-app/k3conf/files/debian/k3conf.install
+++ b/recipes-app/k3conf/files/debian/k3conf.install
@@ -1,0 +1,1 @@
+./k3conf /usr/bin

--- a/recipes-app/k3conf/k3conf_0.2.bb
+++ b/recipes-app/k3conf/k3conf_0.2.bb
@@ -1,0 +1,27 @@
+#
+# Copyright (c) Siemens AG, 2022
+#
+# Authors:
+#  Chao Zeng <chao.zeng@siemens.com>
+#
+# This file is subject to the terms and conditions of the MIT License.  See
+# COPYING.MIT file in the top-level directory.
+#
+inherit dpkg
+
+DESCRIPTION = "A Powerful Diagnostic Tool for Texas Instruments K3 based Processors"
+MAINTAINER = "chao.zeng@siemens.com"
+
+SRC_URI += "https://git.ti.com/cgit/k3conf/k3conf/snapshot/k3conf-0.2.tar.gz;protocol=https \
+            file://debian"
+SRC_URI[sha256sum] = "4e19f6fdee6d40216d786c7d9000191771fe3ff467e5b5efe659ad5acb6f610f"
+
+S = "${WORKDIR}/k3conf-${PV}"
+
+do_prepare_build[cleandirs] += "${S}/debian"
+
+do_prepare_build() {
+    cp -r ${WORKDIR}/debian ${S}/
+    deb_debianize
+}
+

--- a/recipes-core/images/iot2050-image-example.bb
+++ b/recipes-core/images/iot2050-image-example.bb
@@ -118,6 +118,7 @@ IMAGE_INSTALL += " \
     node-red \
     node-red-gpio \
     node-red-preinstalled-nodes \
+    k3conf \
     "
 
 IOT2050_CORAL_SUPPORT ?= "1"


### PR DESCRIPTION
Introduction:
K3CONF is a Linux user-space standalone application designed to provide a quick'n easy way to dynamically diagnose Texas Instruments' K3 architecture based processors link:https://git.ti.com/cgit/k3conf/k3conf/about/

It's very useful tool to get and set the clock and so on. For current usage, we can use this tool to switch cpu frequency from user-space.

Signed-off-by: chao zeng <chao.zeng@siemens.com>