### PR TITLE
re-add NPM_INSTALL_FLAGS lost in sbuild transition

### DIFF
--- a/classes/npm.bbclass
+++ b/classes/npm.bbclass
@@ -242,7 +242,7 @@ override_dh_clean:
 	rm -rf $(npm_config_cache)
 
 override_dh_auto_build:
-	cd ${CHDIR} && npm install ${INSTALL_FLAGS} /downloads/${@get_npm_bundled_tgz(d)}
+	cd ${CHDIR} && npm install ${INSTALL_FLAGS} ${NPM_INSTALL_FLAGS} /downloads/${@get_npm_bundled_tgz(d)}
 	if [ -n "${NPM_LOCAL_INSTALL_DIR}" ]; then \
 	    rm -f ${CHDIR}/node_modules/.package-lock.json; \
 	fi


### PR DESCRIPTION
This patch re-adds the NPM_INSTALL_FLAGS support that has been added in f9e004 and got lost when integrating the sbuild support in f810b9.

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>