### PR TITLE
improve caching of build on gitlab-runners

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -20,5 +20,6 @@ BBFILE_PRIORITY_meta-iot2050 = "6"
 LAYERSERIES_COMPAT_meta-iot2050 = "next"
 
 LAYERDIR_meta-iot2050 = "${LAYERDIR}"
+LAYERDIR_meta-iot2050[vardepvalue] = "meta-iot2050"
 
 ISAR_RELEASE_CMD = "git -C ${LAYERDIR_meta-iot2050} describe --long --tags --dirty --always || echo unknown"


### PR DESCRIPTION
This patch removes an absolute path pointing into the build host that also ends up in the sstate cache. By that, the target rootfs can be cached across multiple builds executed from different build directories. This is mainly important for gitlab-cloud-ci, as the build directory is mounted from the host and contains some random parts. For meta-iot2050 it might not be relevant, but this caching issue is inerhited by downstream users of this layer.

The general issue already has been discussed on the ISAR and KAS ML, leading to improvements in isar-sstate lint (for detection) and KAS for making the LAYERDIR variable relative to the TOPDIR. The last remaining bit is to fix the vardepvalue in the layers, as the LAYERDIR variable is immediately expanded, hence always contains an absolute path.

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>