### PR TITLE
customizations-example: Resizing a terminal

### DIFF
--- a/recipes-core/customizations-example/customizations-example_0.1-iot2050-debian.bb
+++ b/recipes-core/customizations-example/customizations-example_0.1-iot2050-debian.bb
@@ -26,7 +26,8 @@ SRC_URI = " \
     file://cellular-4g \
     file://eno1-default \
     file://20-assign-ethernet-names.rules \
-    file://20-create-symbolic-link-for-serial-port.rules"
+    file://20-create-symbolic-link-for-serial-port.rules \
+    file://terminal_resize.sh"
 
 do_install() {
     # add board status led service
@@ -56,4 +57,8 @@ do_install() {
     install -v -m 644 ${WORKDIR}/20-assign-ethernet-names.rules ${D}/etc/udev/rules.d/
     # create a symbolic link for serial port
     install -v -m 644 ${WORKDIR}/20-create-symbolic-link-for-serial-port.rules ${D}/etc/udev/rules.d/
+
+    # resizing a terminal
+    install -v -d ${D}/etc/profile.d/
+    install -v -m 755 ${WORKDIR}/terminal_resize.sh ${D}/etc/profile.d
 }

--- a/recipes-core/customizations-example/files/terminal_resize.sh
+++ b/recipes-core/customizations-example/files/terminal_resize.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Copyright (c) Siemens AG, 2022
+#
+# Authors:
+#  Chao Zeng <chao.zeng@siemens.com>
+#
+# SPDX-License-Identifier: MIT
+
+terminal_resize() {
+    local IFS='[;' escape screen_size cols rows
+    # detect the size of the screen
+    echo -ne '\e7\e[r\e[999;999H\e[6n\e8'
+    read -t 5 -sd R escape screen_size || {
+        echo Unable to detect the size of the current terminal emulator. >&2
+        return 0
+    }
+
+    cols="${screen_size##*;}" rows="${screen_size%%;*}"
+    if [[ "${cols}" -gt 0 && "${rows}" -gt 0 ]];then
+        stty cols "${cols}" rows "${rows}"
+    else
+        echo Unable to change the size of the current terminal emulator. >&2
+        return 0
+    fi
+}
+
+case $(/usr/bin/tty) in
+        /dev/ttyS3)
+        terminal_resize
+        ;;
+esac


### PR DESCRIPTION
Console window has fixed columns and rows, there is no method to pass the window columns and rows to console terminal.
So it can not adjust the window size automatically.

This change would make adjust the console terminal column and row according to the actual terminal window size.

The most important benefit is that we can see the whole output when using journalctl systemctl and so on to output the debug info if the debug information is too long.

Autosize-console origin from iot2050setup tool.

Signed-off-by: chao zeng <chao.zeng@siemens.com>