### PR TITLE
fix: add missing deps to shared libraries used by mraa

### DIFF
--- a/recipes-app/mraa/mraa_2.2.0+git.bb
+++ b/recipes-app/mraa/mraa_2.2.0+git.bb
@@ -28,7 +28,7 @@ DEBIAN_BUILD_DEPENDS = " \
     libjson-c-dev, \
     default-jdk:native"
 
-DEBIAN_DEPENDS = "python3, nodejs"
+DEBIAN_DEPENDS = "python3, nodejs, \${shlibs:Depends}"
 
 do_prepare_build[cleandirs] += "${S}/debian"
 


### PR DESCRIPTION
fix: add missing deps to shared libraries used by mraa
    
This patch adds the shlibs:Depends variable to the DEBIAN_DEPENS
variable. By that, automatically resolved runtime dependencies
are automatically added in their correct version.
    
This also fixes the bug that the libjson-c was missing.
    
Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>