### PR TITLE
fix: auto-resolve native deps of npm modules

### DIFF
--- a/classes/npm.bbclass
+++ b/classes/npm.bbclass
@@ -39,6 +39,7 @@ NPM_EXTRA_DEPS = "${@'python-is-python3' if d.getVar('NPM_REBUILD') == '1' else 
 
 DEBIAN_BUILD_DEPENDS =. "${@'python, libnode72,' if d.getVar('NPM_REBUILD') == '1' else ''}"
 DEBIAN_BUILD_DEPENDS =. "${NPM_CLASS_PACKAGE},"
+DEBIAN_DEPENDS =. "\${shlibs:Depends}, \${misc:Depends},"
 
 python() {
     src_uri = (d.getVar('SRC_URI', True) or "").split()


### PR DESCRIPTION
The patch adds the common shlibs:Depends pattern to the npm class. This is required, as we use dpkg-raw as a base which does not add these as default. By adding it, all native dependencies of a package providing an NPM module are added automatically. This helps to avoid missing runtime dependencies and in general makes the dependency graph more precise.

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>