### PR TITLE
Align bitbake and debian dependencies

### DIFF
--- a/classes/npm.bbclass
+++ b/classes/npm.bbclass
@@ -239,7 +239,8 @@ do_install() {
 
 do_prepare_build_append() {
     INSTALL_FLAGS="--offline --only=production --no-package-lock --verbose \
-                   --arch=${NPM_ARCH} --target_arch=${NPM_ARCH}"
+                   --arch=${NPM_ARCH} --target_arch=${NPM_ARCH} \
+                   --no-audit"
 
     if [ -n "${NPM_LOCAL_INSTALL_DIR}" ]; then
         CHDIR=${PP}/image/${NPM_LOCAL_INSTALL_DIR}

--- a/recipes-app/node-red-preinstalled-nodes/node-red-preinstalled-nodes_0.1.bb
+++ b/recipes-app/node-red-preinstalled-nodes/node-red-preinstalled-nodes_0.1.bb
@@ -9,6 +9,7 @@
 #
 
 inherit dpkg-raw
+DPKG_ARCH = "all"
 
 REGULAR_NODE_RED_PACKAGES = " \
     node-red-dashboard \

--- a/recipes-app/node-red-preinstalled-nodes/node-red-preinstalled-nodes_0.1.bb
+++ b/recipes-app/node-red-preinstalled-nodes/node-red-preinstalled-nodes_0.1.bb
@@ -23,7 +23,7 @@ NODE_RED_PACKAGES = " \
     ${REGULAR_NODE_RED_PACKAGES} \
     @mindconnect/node-red-contrib-mindconnect"
 
-DEPENDS = " \
+RDEPENDS = " \
     ${REGULAR_NODE_RED_PACKAGES} \
     mindconnect-node-red-contrib-mindconnect"
 

--- a/recipes-app/node-red/node-red_2.2.3.bb
+++ b/recipes-app/node-red/node-red_2.2.3.bb
@@ -14,6 +14,7 @@ inherit npm
 DESCRIPTION = "A visual tool for wiring the Internet of Things"
 
 PRESERVE_PERMS = "usr/lib/node_modules/node-red/red.js"
+DEBIAN_DEPENDS = "nodejs"
 
 SRC_URI += "file://node-red.service"
 

--- a/recipes-bsp/u-boot/u-boot-iot2050.inc
+++ b/recipes-bsp/u-boot/u-boot-iot2050.inc
@@ -32,9 +32,6 @@ U_BOOT_ENV = "u-boot-initial-env"
 SPI_FLASH_IMG = "${U_BOOT_BIN}"
 SPI_FLASH_DEPLOY_IMG ??= "iot2050-image-boot.bin"
 
-# Needed to resolve races as long as the layer has to rebuild swig
-DEPENDS += "swig"
-
 # Build environment
 DEPENDS += "trusted-firmware-a-iot2050 optee-os-iot2050 k3-rti-wdt"
 DEBIAN_BUILD_DEPENDS =. "openssl, libssl-dev:native, libssl-dev:arm64, \

--- a/recipes-core/install-on-emmc/install-on-emmc_1.0.bb
+++ b/recipes-core/install-on-emmc/install-on-emmc_1.0.bb
@@ -10,7 +10,7 @@ inherit dpkg-raw
 
 DESCRIPTION = "This service provides the option to install on eMMC during first boot"
 
-DEPENDS = "regen-rootfs-uuid"
+RDEPENDS = "regen-rootfs-uuid"
 DEBIAN_DEPENDS = "systemd, fdisk, util-linux, regen-rootfs-uuid, parted"
 
 SRC_URI = " \

--- a/recipes-core/iot2050-firmware/iot2050-firmware_0.1.bb
+++ b/recipes-core/iot2050-firmware/iot2050-firmware_0.1.bb
@@ -11,7 +11,7 @@
 inherit dpkg-raw
 
 DEBIAN_DEPENDS = "k3-rti-wdt, ti-pruss-firmware"
-DEPENDS = "k3-rti-wdt ti-pruss-firmware"
+RDEPENDS = "k3-rti-wdt ti-pruss-firmware"
 
 do_prepare_build_append() {
     echo "/lib/firmware/k3-rti-wdt.fw /lib/firmware/am65x-mcu-r5f0_0-fw" > ${S}/debian/links

--- a/recipes-core/regen-rootfs-uuid/regen-rootfs-uuid_1.0.bb
+++ b/recipes-core/regen-rootfs-uuid/regen-rootfs-uuid_1.0.bb
@@ -10,6 +10,7 @@ inherit dpkg-raw
 
 DESCRIPTION = "This service generates an individual UUID for the rootfs during first boot"
 
+RDEPENDS = "u-boot-script"
 DEBIAN_DEPENDS = "systemd, u-boot-script, fdisk, util-linux, uuid-runtime"
 
 SRC_URI = " \

--- a/recipes-core/watchdog/iot2050-watchdog.bb
+++ b/recipes-core/watchdog/iot2050-watchdog.bb
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: MIT
 inherit dpkg-raw
 
-DEPENDS += "patch-u-boot-env"
+RDEPENDS += "patch-u-boot-env"
 DEBIAN_DEPENDS += "patch-u-boot-env"
 
 SRC_URI += "file://99-watchdog.conf"


### PR DESCRIPTION
This patch aligns the bitbake and the debian dependencies to improve partial builds. This also helps to reduce the dependency graph in general, which in turn allows for more concurrency in the build.

In addition, npm auditing is disabled at install time to significantly speed up the build.