### PR TITLE
linux-iot2050: dts: fix the gpio configuration of m.2

### DIFF
--- a/recipes-kernel/linux/files/patches-5.10/0001-dmaengine-ti-k3-udma-glue-Add-function-to-get-device.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0001-dmaengine-ti-k3-udma-glue-Add-function-to-get-device.patch
@@ -1,4 +1,4 @@
-From 22f5f67685ec18135a657b9c3bed267fc3bdfd14 Mon Sep 17 00:00:00 2001
+From cec1ccec871de02fdf465c3138009469b910d75b Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Tue, 8 Dec 2020 11:04:24 +0200
 Subject: [PATCH 001/120] dmaengine: ti: k3-udma-glue: Add function to get
@@ -99,5 +99,5 @@ index 5eb34ad973a7..d7c12f31377c 100644
  
  #endif /* K3_UDMA_GLUE_H_ */
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0002-arm64-dts-ti-k3-am65-ringacc-drop-ti-dma-ring-reset-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0002-arm64-dts-ti-k3-am65-ringacc-drop-ti-dma-ring-reset-.patch
@@ -1,4 +1,4 @@
-From 0fba16d2cf33faa182c1b6d54358e57b02217136 Mon Sep 17 00:00:00 2001
+From 360af753d830acb3d56ab28b6b32bfdf032776bf Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Sat, 29 Aug 2020 21:41:39 +0300
 Subject: [PATCH 002/120] arm64: dts: ti: k3-am65: ringacc: drop ti,
@@ -39,5 +39,5 @@ index 29aaf8dca6f6..044042b166d9 100644
  			ti,sci-dev-id = <195>;
  			msi-parent = <&inta_main_udmass>;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0003-arm64-dts-ti-k3-am65-mcu-Add-MCU-domain-R5F-cluster-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0003-arm64-dts-ti-k3-am65-mcu-Add-MCU-domain-R5F-cluster-.patch
@@ -1,4 +1,4 @@
-From 6f7de05a46bb41a8922d201f05f488981640e3cd Mon Sep 17 00:00:00 2001
+From 3d8cda7de595c59d0d489f4e14b05c0f6d5c9f40 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 28 Oct 2020 22:37:55 -0500
 Subject: [PATCH 003/120] arm64: dts: ti: k3-am65-mcu: Add MCU domain R5F
@@ -95,5 +95,5 @@ index 044042b166d9..7454c8cec0cc 100644
 +	};
  };
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0004-arm64-dts-ti-k3-am65-Cleanup-disabled-nodes-at-SoC-d.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0004-arm64-dts-ti-k3-am65-Cleanup-disabled-nodes-at-SoC-d.patch
@@ -1,4 +1,4 @@
-From 522552b5d98a4896546a76ca7a992d5d7cd47471 Mon Sep 17 00:00:00 2001
+From 695f7f432b18355876d89b3bef3d13d796727497 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Fri, 13 Nov 2020 15:18:22 -0600
 Subject: [PATCH 004/120] arm64: dts: ti: k3-am65*: Cleanup disabled nodes at
@@ -121,5 +121,5 @@ index 937dd7280c7a..8c082af489f5 100644
 +	status = "disabled";
 +};
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0005-arm64-dts-ti-am65-j721e-Fix-up-un-necessary-status-s.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0005-arm64-dts-ti-am65-j721e-Fix-up-un-necessary-status-s.patch
@@ -1,4 +1,4 @@
-From a22ada6783d1a22a2850572a76cca0107b86f66e Mon Sep 17 00:00:00 2001
+From 182db0fdcff3450a05c8911ea5c2626f8fbc8060 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Fri, 13 Nov 2020 15:18:24 -0600
 Subject: [PATCH 005/120] arm64: dts: ti: am65/j721e: Fix up un-necessary
@@ -44,5 +44,5 @@ index 0350ddfe2c72..b8ca6e03de36 100644
  				<&main_udmap 0x4001>;
  		dma-names = "tx", "rx1", "rx2";
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0006-arm64-dts-ti-k3-mmc-fix-dtbs_check-warnings.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0006-arm64-dts-ti-k3-mmc-fix-dtbs_check-warnings.patch
@@ -1,4 +1,4 @@
-From 47f9403b812e345194b95615bb1e9ce826e92213 Mon Sep 17 00:00:00 2001
+From 6eed039e0dbf397d7e5c46030cd3b823cdf9ab64 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 15 Jan 2021 21:30:16 +0200
 Subject: [PATCH 006/120] arm64: dts: ti: k3: mmc: fix dtbs_check warnings
@@ -129,5 +129,5 @@ index b8ca6e03de36..81fddd145b86 100644
  		assigned-clock-parents = <&k3_clks 93 1>;
  		ti,otap-del-sel = <0x2>;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0007-arm64-dts-ti-k3-am65-main-Add-device_type-to-pcie-_r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0007-arm64-dts-ti-k3-am65-main-Add-device_type-to-pcie-_r.patch
@@ -1,4 +1,4 @@
-From 0c9f3a892035f55baab39dbb30a08c65bf74694a Mon Sep 17 00:00:00 2001
+From 856344d056ebe9b5d74fd389ce8b9182a66ab914 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Feb 2021 20:32:56 +0100
 Subject: [PATCH 007/120] arm64: dts: ti: k3-am65-main: Add device_type to
@@ -36,5 +36,5 @@ index cf7656cf650e..3c36ae6d7816 100644
  
  	pcie1_ep: pcie-ep@5600000 {
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0008-arm64-dts-ti-k3-am65-main-Add-ICSSG-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0008-arm64-dts-ti-k3-am65-main-Add-ICSSG-nodes.patch
@@ -1,4 +1,4 @@
-From 687aee019ceca582f01f9e83683ddc26c129655e Mon Sep 17 00:00:00 2001
+From b2e3248c1758aa31f01ef9c1e0f741be0957df9a Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Thu, 4 Mar 2021 10:07:11 -0600
 Subject: [PATCH 008/120] arm64: dts: ti: k3-am65-main: Add ICSSG nodes
@@ -475,5 +475,5 @@ index 3c36ae6d7816..6d2662588565 100644
 +	};
  };
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0009-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0009-arm64-dts-ti-k3-am65-mcu-Add-RTI-watchdog-entry.patch
@@ -1,4 +1,4 @@
-From b8b3bb649dc158f159daf0a0bff3be5a908ec1a9 Mon Sep 17 00:00:00 2001
+From 32eb082902cd0dcb126642bedbb20e7cf7c20507 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 20 Feb 2021 13:49:51 +0100
 Subject: [PATCH 009/120] arm64: dts: ti: k3-am65-mcu: Add RTI watchdog entry
@@ -37,5 +37,5 @@ index 7454c8cec0cc..0388c02c2203 100644
 +	};
  };
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0010-arm64-dts-ti-Add-support-for-Siemens-IOT2050-boards.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0010-arm64-dts-ti-Add-support-for-Siemens-IOT2050-boards.patch
@@ -1,4 +1,4 @@
-From da977b5722628da8e2096273a61cc9e392fffb7c Mon Sep 17 00:00:00 2001
+From fe91a58ddf2259428ab5d99d5242d928466290f5 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Mar 2021 15:33:43 +0100
 Subject: [PATCH 010/120] arm64: dts: ti: Add support for Siemens IOT2050
@@ -836,5 +836,5 @@ index 000000000000..ec9617c13cdb
 +	status = "disabled";
 +};
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0011-arm64-dts-ti-k3-am65-j721e-am64-Map-the-dma-navigato.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0011-arm64-dts-ti-k3-am65-j721e-am64-Map-the-dma-navigato.patch
@@ -1,4 +1,4 @@
-From da65208e2f1373d85c6d0f9148d31a755439534d Mon Sep 17 00:00:00 2001
+From 1c57381c40dd3b34b06ee093cb38339bcbaf53d6 Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Mon, 10 May 2021 09:54:29 -0500
 Subject: [PATCH 011/120] arm64: dts: ti: k3-am65|j721e|am64: Map the dma /
@@ -102,5 +102,5 @@ index e581cb1d87ee..d766c7fe02af 100644
  		dma-ranges;
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0012-arm64-dts-ti-k3-Introduce-reg-definition-for-interru.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0012-arm64-dts-ti-k3-Introduce-reg-definition-for-interru.patch
@@ -1,4 +1,4 @@
-From 5a0359f7ef324fbf45676c9228f8ac81b0e6cca9 Mon Sep 17 00:00:00 2001
+From 1d1d98a8574c00b33bab9b1d3c65334b95a110dd Mon Sep 17 00:00:00 2001
 From: Nishanth Menon <nm@ti.com>
 Date: Tue, 11 May 2021 14:48:21 -0500
 Subject: [PATCH 012/120] arm64: dts: ti: k3*: Introduce reg definition for
@@ -162,5 +162,5 @@ index d766c7fe02af..282bbdc359ac 100644
  		interrupt-controller;
  		interrupt-parent = <&gic500>;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0013-mmc-sdhci_am654-Use-pm_runtime_resume_and_get-to-rep.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0013-mmc-sdhci_am654-Use-pm_runtime_resume_and_get-to-rep.patch
@@ -1,4 +1,4 @@
-From 00565d0cc745cb56d7fe5665e2ea8a458dcc32ae Mon Sep 17 00:00:00 2001
+From 22258f4190ace217f55f40ed9695edf5ea9f79b0 Mon Sep 17 00:00:00 2001
 From: Tian Tao <tiantao6@hisilicon.com>
 Date: Fri, 21 May 2021 08:59:35 +0800
 Subject: [PATCH 013/120] mmc: sdhci_am654: Use pm_runtime_resume_and_get() to
@@ -34,5 +34,5 @@ index 7cab9d831afb..9c3a37d94f53 100644
  	base = devm_platform_ioremap_resource(pdev, 1);
  	if (IS_ERR(base)) {
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0014-arm64-dts-ti-k3-am65-iot2050-common-Disable-mailbox-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0014-arm64-dts-ti-k3-am65-iot2050-common-Disable-mailbox-.patch
@@ -1,4 +1,4 @@
-From 18bf626137b1e09c270eb9e0f418ff004d5a7438 Mon Sep 17 00:00:00 2001
+From d2c6c9316a4e8cd4b5c1bca6521073fa2680fe62 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 14 May 2021 16:20:16 -0500
 Subject: [PATCH 014/120] arm64: dts: ti: k3-am65-iot2050-common: Disable
@@ -80,5 +80,5 @@ index de763ca9251c..f4ec9ed52939 100644
 +	status = "disabled";
 +};
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0015-arm64-dts-ti-k3-am65-Add-support-for-UHS-I-modes-in-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0015-arm64-dts-ti-k3-am65-Add-support-for-UHS-I-modes-in-.patch
@@ -1,4 +1,4 @@
-From 8a9c66f3df76743065cf740525c1448fccfc05e6 Mon Sep 17 00:00:00 2001
+From 914404a4899885320a3dfcafaace1615dd90d913 Mon Sep 17 00:00:00 2001
 From: Aswath Govindraju <a-govindraju@ti.com>
 Date: Sat, 29 May 2021 09:07:49 +0530
 Subject: [PATCH 015/120] arm64: dts: ti: k3-am65: Add support for UHS-I modes
@@ -108,5 +108,5 @@ index 8c082af489f5..fea6a8243d75 100644
  	pinctrl-0 = <&main_mmc1_pins_default>;
  	ti,driver-strength-ohm = <50>;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0016-arm64-dts-ti-k3-am65-main-Add-ICSSG-MDIO-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0016-arm64-dts-ti-k3-am65-main-Add-ICSSG-MDIO-nodes.patch
@@ -1,4 +1,4 @@
-From e63f46cb1df73aaf268e1d9d2b4467e16ad5c5fa Mon Sep 17 00:00:00 2001
+From ceb9ce91ea2a3655bc52cc2414f4f53be5bd69fa Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 1 Jun 2021 10:00:31 -0500
 Subject: [PATCH 016/120] arm64: dts: ti: k3-am65-main: Add ICSSG MDIO nodes
@@ -125,5 +125,5 @@ index fea6a8243d75..b47fc2a1e59d 100644
 +	status = "disabled";
 +};
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0017-arm64-dts-ti-iot2050-Configure-r5f-cluster-on-basic-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0017-arm64-dts-ti-iot2050-Configure-r5f-cluster-on-basic-.patch
@@ -1,4 +1,4 @@
-From 52278738c3ca3b6a7e3f6a6e26c85a244b897d72 Mon Sep 17 00:00:00 2001
+From ddb96b52d9ddddcab5b199671bd700622ecd0c5a Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Wed, 2 Jun 2021 08:56:15 +0200
 Subject: [PATCH 017/120] arm64: dts: ti: iot2050: Configure r5f cluster on
@@ -28,5 +28,5 @@ index 4f7e3f2a6265..94bb5dd39122 100644
 +	ti,cluster-mode = <0>;
 +};
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0018-arm64-dts-ti-am65-align-ti-pindir-d0-out-d1-in-prope.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0018-arm64-dts-ti-am65-align-ti-pindir-d0-out-d1-in-prope.patch
@@ -1,4 +1,4 @@
-From b27c3f0bc54e3c8cbbdd8a5095a7defbec57ec5f Mon Sep 17 00:00:00 2001
+From 247d309801b747c4e8b400699fdd0577e460a93e Mon Sep 17 00:00:00 2001
 From: Aswath Govindraju <a-govindraju@ti.com>
 Date: Tue, 8 Jun 2021 10:44:13 +0530
 Subject: [PATCH 018/120] arm64: dts: ti: am65: align ti,pindir-d0-out-d1-in
@@ -46,5 +46,5 @@ index b47fc2a1e59d..56dc855a5f13 100644
  	flash@0{
  		compatible = "jedec,spi-nor";
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0019-firmware-ti_sci-rm-Add-support-for-tx_tdtype-paramet.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0019-firmware-ti_sci-rm-Add-support-for-tx_tdtype-paramet.patch
@@ -1,4 +1,4 @@
-From 16ca136482df2a562d6935baec63d40a8221a2aa Mon Sep 17 00:00:00 2001
+From 9d27e77ad832959aaaa02eb74b3b875e08456357 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:02 -0700
 Subject: [PATCH 019/120] firmware: ti_sci: rm: Add support for tx_tdtype
@@ -86,5 +86,5 @@ index b1af87330f86..fece890e1635 100644
  
  /**
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0020-firmware-ti_sci-Use-struct-ti_sci_resource_desc-in-g.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0020-firmware-ti_sci-Use-struct-ti_sci_resource_desc-in-g.patch
@@ -1,4 +1,4 @@
-From 5c9d2975642f9a2ff42b94dbff9240f74f2ed619 Mon Sep 17 00:00:00 2001
+From 22e2e1c92f021e337bbe32736ff4624f08237f4f Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:03 -0700
 Subject: [PATCH 020/120] firmware: ti_sci: Use struct ti_sci_resource_desc in
@@ -177,5 +177,5 @@ index fece890e1635..19b90545edd8 100644
   * struct ti_sci_resource - Structure representing a resource assigned
   *			    to a device.
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0021-firmware-ti_sci-rm-Add-support-for-second-resource-r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0021-firmware-ti_sci-rm-Add-support-for-second-resource-r.patch
@@ -1,4 +1,4 @@
-From 9623554a594445b870509c796540a0c2062099ef Mon Sep 17 00:00:00 2001
+From 1310363d9f1d2ec01e396aa7bcab7fbe21b00130 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:03 -0700
 Subject: [PATCH 021/120] firmware: ti_sci: rm: Add support for second resource
@@ -174,5 +174,5 @@ index 19b90545edd8..2cd563c7328c 100644
  };
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0022-soc-ti-ti_sci_inta_msi-Add-support-for-second-range-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0022-soc-ti-ti_sci_inta_msi-Add-support-for-second-range-.patch
@@ -1,4 +1,4 @@
-From 764224bb7911351f8a897b31a86a18fb976a90d0 Mon Sep 17 00:00:00 2001
+From db06dbd7ec257eb5dac8322d734656c1989da17e Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:04 -0700
 Subject: [PATCH 022/120] soc: ti: ti_sci_inta_msi: Add support for second
@@ -36,5 +36,5 @@ index 0eb9462f609e..a1d9c027022a 100644
  
  	return count;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0023-firmware-ti_sci-rm-Add-support-for-extended_ch_type-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0023-firmware-ti_sci-rm-Add-support-for-extended_ch_type-.patch
@@ -1,4 +1,4 @@
-From b20ba6b463912ee2366dbf4eaac9e1124624af2e Mon Sep 17 00:00:00 2001
+From 098f54e864f2efab7510e019ccf2efcf5e9a3dca Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:05 -0700
 Subject: [PATCH 023/120] firmware: ti_sci: rm: Add support for
@@ -91,5 +91,5 @@ index 2cd563c7328c..a090b72a3362 100644
  
  /**
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0024-firmware-ti_sci-rm-Remove-ring_get_config-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0024-firmware-ti_sci-rm-Remove-ring_get_config-support.patch
@@ -1,4 +1,4 @@
-From ac8128a14d918854d21f73cbb47398c11cc2438d Mon Sep 17 00:00:00 2001
+From 8756621d5f4f9040ee0cfac8c22d8f0cb7363141 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:05 -0700
 Subject: [PATCH 024/120] firmware: ti_sci: rm: Remove ring_get_config support
@@ -200,5 +200,5 @@ index a090b72a3362..7727ec954f62 100644
  
  /**
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0025-firmware-ti_sci-rm-Add-new-ops-for-ring-configuratio.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0025-firmware-ti_sci-rm-Add-new-ops-for-ring-configuratio.patch
@@ -1,4 +1,4 @@
-From b2069ec9290b6b0c130751b457d5872bbbb7be9a Mon Sep 17 00:00:00 2001
+From f2ac64c36a05300c288f9b8338c941b150d9a8ea Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:06 -0700
 Subject: [PATCH 025/120] firmware: ti_sci: rm: Add new ops for ring
@@ -198,5 +198,5 @@ index 7727ec954f62..d7f0dcf98861 100644
  
  /**
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0026-soc-ti-k3-ringacc-Use-the-ti_sci-set_cfg-callback-fo.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0026-soc-ti-k3-ringacc-Use-the-ti_sci-set_cfg-callback-fo.patch
@@ -1,4 +1,4 @@
-From d561733e1942175ac52edfbaff3dfedd19c8a845 Mon Sep 17 00:00:00 2001
+From 6b6c9db27682ebbfa850dea953681a01e6d974e3 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:07 -0700
 Subject: [PATCH 026/120] soc: ti: k3-ringacc: Use the ti_sci set_cfg callback
@@ -142,5 +142,5 @@ index 1147dc4c1d59..9ddd77113c5a 100644
  	return ret;
  }
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0027-firmware-ti_sci-rm-Remove-unused-config-from-ti_sci_.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0027-firmware-ti_sci-rm-Remove-unused-config-from-ti_sci_.patch
@@ -1,4 +1,4 @@
-From 89c9f5950a23ee994ca388d853cd53b28a1baf7f Mon Sep 17 00:00:00 2001
+From 935b14caa68a4114bb15f8549ce00ee30c52cd89 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:07 -0700
 Subject: [PATCH 027/120] firmware: ti_sci: rm: Remove unused config() from
@@ -127,5 +127,5 @@ index d7f0dcf98861..bd0d11af76c5 100644
  		       const struct ti_sci_msg_rm_ring_cfg *params);
  };
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0028-soc-ti-k3-ringacc-Use-correct-device-for-allocation-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0028-soc-ti-k3-ringacc-Use-correct-device-for-allocation-.patch
@@ -1,4 +1,4 @@
-From f98c7075fc722fa8841771e34d47d1afb4cb2f0d Mon Sep 17 00:00:00 2001
+From 86b20ee783dfd444d02f707628eb966b3144bff1 Mon Sep 17 00:00:00 2001
 From: Peter Ujfalusi <peter.ujfalusi@ti.com>
 Date: Sun, 25 Oct 2020 12:10:22 -0700
 Subject: [PATCH 028/120] soc: ti: k3-ringacc: Use correct device for
@@ -126,5 +126,5 @@ index 5a472eca5ee4..658dc71d2901 100644
  
  #define K3_RINGACC_RING_ID_ANY (-1)
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0029-soc-ti-pruss-Remove-wrong-check-against-get_match_da.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0029-soc-ti-pruss-Remove-wrong-check-against-get_match_da.patch
@@ -1,4 +1,4 @@
-From 724d79219d8322d45c3ace42ff00cb2578bd64e5 Mon Sep 17 00:00:00 2001
+From a6e0ed17feb77da77a5fb615d261874a65b0b56d Mon Sep 17 00:00:00 2001
 From: Grzegorz Jaszczyk <grzegorz.jaszczyk@linaro.org>
 Date: Sat, 21 Nov 2020 19:22:25 -0800
 Subject: [PATCH 029/120] soc: ti: pruss: Remove wrong check against
@@ -43,5 +43,5 @@ index 30695172a508..aa3aba80dbc6 100644
  	ret = dma_set_coherent_mask(dev, DMA_BIT_MASK(32));
  	if (ret) {
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0030-soc-ti-pruss-Correct-the-pruss_clk_init-error-trace-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0030-soc-ti-pruss-Correct-the-pruss_clk_init-error-trace-.patch
@@ -1,4 +1,4 @@
-From 6ab2d4e9245e220c4d19629b6e09cec912ca3477 Mon Sep 17 00:00:00 2001
+From 35c1adff35660f5c1dd82d9fb135fcc396bdfc00 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 24 Jan 2021 20:51:37 -0800
 Subject: [PATCH 030/120] soc: ti: pruss: Correct the pruss_clk_init error
@@ -28,5 +28,5 @@ index aa3aba80dbc6..dc94335fc351 100644
  	}
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0031-soc-ti-pruss-Refactor-the-CFG-sub-module-init.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0031-soc-ti-pruss-Refactor-the-CFG-sub-module-init.patch
@@ -1,4 +1,4 @@
-From 7334ba89e50423220be222046d0e2c7e629145db Mon Sep 17 00:00:00 2001
+From 759a96ed263888fb4b811900b15fa88770dfed20 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 31 Jan 2021 20:53:43 -0800
 Subject: [PATCH 031/120] soc: ti: pruss: Refactor the CFG sub-module init
@@ -134,5 +134,5 @@ index dc94335fc351..afc8aae68035 100644
  	pm_runtime_put_sync(dev);
  rpm_disable:
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0032-soc-ti-k3-ringacc-Use-of_device_get_match_data.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0032-soc-ti-k3-ringacc-Use-of_device_get_match_data.patch
@@ -1,4 +1,4 @@
-From 77089c5ab6da4d3c7a083ac4f58ae28c45fa118b Mon Sep 17 00:00:00 2001
+From 020de327cbd5a881002bd503f1c949402d410415 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Sun, 31 Jan 2021 20:58:49 -0800
 Subject: [PATCH 032/120] soc: ti: k3-ringacc: Use of_device_get_match_data()
@@ -44,5 +44,5 @@ index 7fdb688452f7..db3f705da7a0 100644
  	ringacc = devm_kzalloc(dev, sizeof(*ringacc), GFP_KERNEL);
  	if (!ringacc)
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0033-remoteproc-ti_k3-fix-Wcast-function-type-warning.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0033-remoteproc-ti_k3-fix-Wcast-function-type-warning.patch
@@ -1,4 +1,4 @@
-From 4381b2c9ccecdcb07fd39508f8c1be730bcefe90 Mon Sep 17 00:00:00 2001
+From fc997f21cb8a846b01cfae68443c2621e9b86d76 Mon Sep 17 00:00:00 2001
 From: Arnd Bergmann <arnd@arndb.de>
 Date: Mon, 26 Oct 2020 17:05:23 +0100
 Subject: [PATCH 033/120] remoteproc: ti_k3: fix -Wcast-function-type warning
@@ -79,5 +79,5 @@ index f92a18c06d80..e5346251db0f 100644
  		return ret;
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0034-remoteproc-Add-a-rproc_set_firmware-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0034-remoteproc-Add-a-rproc_set_firmware-API.patch
@@ -1,4 +1,4 @@
-From 6f8e4117309e0278b4e4b6089625a54c791d02d2 Mon Sep 17 00:00:00 2001
+From 5aa09f360380301451927b277e919dc15ab53d6f Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 20 Nov 2020 21:20:42 -0600
 Subject: [PATCH 034/120] remoteproc: Add a rproc_set_firmware() API
@@ -159,5 +159,5 @@ index 3fa3ba6498e8..e8ac041c64d9 100644
  int rproc_coredump_add_segment(struct rproc *rproc, dma_addr_t da, size_t size);
  int rproc_coredump_add_custom_segment(struct rproc *rproc,
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0035-remoteproc-pru-Add-a-PRU-remoteproc-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0035-remoteproc-pru-Add-a-PRU-remoteproc-driver.patch
@@ -1,4 +1,4 @@
-From 611679084e60663843add5e78ec616d90ecb9eca Mon Sep 17 00:00:00 2001
+From a5eb683304f87c3b2e19fc95b0050949365b8663 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:09:58 +0100
 Subject: [PATCH 035/120] remoteproc: pru: Add a PRU remoteproc driver
@@ -524,5 +524,5 @@ index 000000000000..d33392bbd8af
 +MODULE_DESCRIPTION("PRU-ICSS Remote Processor Driver");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0036-remoteproc-pru-Add-support-for-PRU-specific-interrup.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0036-remoteproc-pru-Add-support-for-PRU-specific-interrup.patch
@@ -1,4 +1,4 @@
-From 880477ddcaee99594a560ac3aea075f0de9fd4fe Mon Sep 17 00:00:00 2001
+From 46a980ea4159ffe892d8c8223814f2ac57141b0a Mon Sep 17 00:00:00 2001
 From: Grzegorz Jaszczyk <grzegorz.jaszczyk@linaro.org>
 Date: Tue, 8 Dec 2020 15:09:59 +0100
 Subject: [PATCH 036/120] remoteproc: pru: Add support for PRU specific
@@ -352,5 +352,5 @@ index 000000000000..8ee9c3171610
 +
 +#endif	/* _PRU_RPROC_H_ */
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0037-remoteproc-pru-Add-pru-specific-debugfs-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0037-remoteproc-pru-Add-pru-specific-debugfs-support.patch
@@ -1,4 +1,4 @@
-From 7b7a612f0eb3ced29c9836cb8e69e9ff800542b0 Mon Sep 17 00:00:00 2001
+From 0cc88d8cc7b3a9cc37886e9385253211bc2a0a7d Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:10:00 +0100
 Subject: [PATCH 037/120] remoteproc: pru: Add pru-specific debugfs support
@@ -223,5 +223,5 @@ index 72e64d15f0dc..59240fd82f56 100644
  
  	return 0;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0038-remoteproc-pru-Add-support-for-various-PRU-cores-on-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0038-remoteproc-pru-Add-support-for-various-PRU-cores-on-.patch
@@ -1,4 +1,4 @@
-From bdfb9fff7583cc3028a64618eacf256fda746226 Mon Sep 17 00:00:00 2001
+From c3d66f629be259d8765c1dbd0348f61f56abfa60 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 8 Dec 2020 15:10:01 +0100
 Subject: [PATCH 038/120] remoteproc: pru: Add support for various PRU cores on
@@ -294,5 +294,5 @@ index 59240fd82f56..421ebbc1c02d 100644
  };
  MODULE_DEVICE_TABLE(of, pru_rproc_match);
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0039-remoteproc-pru-Fix-loading-of-GNU-Binutils-ELF.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0039-remoteproc-pru-Fix-loading-of-GNU-Binutils-ELF.patch
@@ -1,4 +1,4 @@
-From aab50e9c072fc7085dab093e7ade21fcadf2f9aa Mon Sep 17 00:00:00 2001
+From 96c407eedded4f756a4840dde5de9ef179e711bb Mon Sep 17 00:00:00 2001
 From: Dimitar Dimitrov <dimitar@dinux.eu>
 Date: Wed, 30 Dec 2020 12:50:05 +0200
 Subject: [PATCH 039/120] remoteproc: pru: Fix loading of GNU Binutils ELF
@@ -48,5 +48,5 @@ index 421ebbc1c02d..a113e150d5d5 100644
  	    da + len <= PRU_IRAM_DA + pru->mem_regions[PRU_IOMEM_IRAM].size) {
  		offset = da - PRU_IRAM_DA;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0040-remoteproc-pru-Fix-firmware-loading-crashes-on-K3-So.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0040-remoteproc-pru-Fix-firmware-loading-crashes-on-K3-So.patch
@@ -1,4 +1,4 @@
-From 75f818c9c3a78fd417dcb35f2c3e47713a9da902 Mon Sep 17 00:00:00 2001
+From c1aaaa9793a122664867c59d207d5fb06f73e60f Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Mon, 15 Mar 2021 15:58:59 -0500
 Subject: [PATCH 040/120] remoteproc: pru: Fix firmware loading crashes on K3
@@ -36,5 +36,5 @@ index a113e150d5d5..21105592a83d 100644
  					       filesz);
  			if (ret) {
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0041-remoteproc-pru-Fixup-interrupt-parent-logic-for-fw-e.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0041-remoteproc-pru-Fixup-interrupt-parent-logic-for-fw-e.patch
@@ -1,4 +1,4 @@
-From 364537f0ea1c07e91a5fd2244d5d226eaeca3119 Mon Sep 17 00:00:00 2001
+From e17e66d4ceb2b952acd646e1f25946ff1186cd2c Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:39 -0500
 Subject: [PATCH 041/120] remoteproc: pru: Fixup interrupt-parent logic for fw
@@ -74,5 +74,5 @@ index 21105592a83d..773c09d01958 100644
  	return ret;
  }
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0042-remoteproc-pru-Fix-wrong-success-return-value-for-fw.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0042-remoteproc-pru-Fix-wrong-success-return-value-for-fw.patch
@@ -1,4 +1,4 @@
-From 988b5c3b01ba7b7e904e011b9e8331a82aace8f2 Mon Sep 17 00:00:00 2001
+From 2249d812bb7fbf1653e856d4ceb4e362bc8e117d Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:40 -0500
 Subject: [PATCH 042/120] remoteproc: pru: Fix wrong success return value for
@@ -41,5 +41,5 @@ index 773c09d01958..e0c5fce8bccd 100644
  		}
  	}
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0043-remoteproc-pru-Fix-and-cleanup-firmware-interrupt-ma.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0043-remoteproc-pru-Fix-and-cleanup-firmware-interrupt-ma.patch
@@ -1,4 +1,4 @@
-From ff75b3320171183423a3e5d5328e458ba4d8a08c Mon Sep 17 00:00:00 2001
+From 904ec457c074130a9932a899240811aebd4124d8 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 7 Apr 2021 10:56:41 -0500
 Subject: [PATCH 043/120] remoteproc: pru: Fix and cleanup firmware interrupt
@@ -95,5 +95,5 @@ index e0c5fce8bccd..d8597027a93e 100644
  	return 0;
  }
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0044-watchdog-rti_wdt-Fix-calculation-and-evaluation-of-p.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0044-watchdog-rti_wdt-Fix-calculation-and-evaluation-of-p.patch
@@ -1,4 +1,4 @@
-From 846975e40e37df3e05159b2166c735bac842e032 Mon Sep 17 00:00:00 2001
+From 40cc8413bbc3161aff97ba8e1acfc7459762fe60 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 21 Feb 2022 17:22:38 +0100
 Subject: [PATCH 044/120] watchdog: rti_wdt: Fix calculation and evaluation of
@@ -50,5 +50,5 @@ index 46c2a4bd9ebe..06f9d0ee1340 100644
  		wsize = readl(wdt->base + RTIWWDSIZECTRL);
  		ret = rti_wdt_setup_hw_hb(wdd, wsize);
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0045-arm64-dts-ti-iot2050-Flip-mmc-device-ordering-on-Adv.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0045-arm64-dts-ti-iot2050-Flip-mmc-device-ordering-on-Adv.patch
@@ -1,4 +1,4 @@
-From 128c8ad26e860b0b78f5d6eaf3f9c4d2483c30ec Mon Sep 17 00:00:00 2001
+From 1794fbe87563bb900ffb6d218869f379d9c7b222 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 26 Sep 2021 14:05:12 +0200
 Subject: [PATCH 045/120] arm64: dts: ti: iot2050: Flip mmc device ordering on
@@ -30,5 +30,5 @@ index 1008e9162ba2..6261ca8ee2d8 100644
  
  	chosen {
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0046-arm64-dts-ti-iot2050-Disable-SR2.0-only-PRUs.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0046-arm64-dts-ti-iot2050-Disable-SR2.0-only-PRUs.patch
@@ -1,4 +1,4 @@
-From 657f536f1d080386c5e9c20cc7e43708ad9b0642 Mon Sep 17 00:00:00 2001
+From 7eb2a6106ba768bb1e92010b0caf79ee43479a52 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 26 Sep 2021 14:05:13 +0200
 Subject: [PATCH 046/120] arm64: dts: ti: iot2050: Disable SR2.0-only PRUs
@@ -48,5 +48,5 @@ index 6261ca8ee2d8..58c8e64d5885 100644
 +	status = "disabled";
 +};
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0047-arm64-dts-ti-iot2050-Add-enabled-mailboxes-and-carve.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0047-arm64-dts-ti-iot2050-Add-enabled-mailboxes-and-carve.patch
@@ -1,4 +1,4 @@
-From 5e8c08502e85e9e90764a30fbf45b314311cf2ad Mon Sep 17 00:00:00 2001
+From a7cba7bde8eaf60c8608e4c8435d03f842e39fb2 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 26 Sep 2021 14:05:14 +0200
 Subject: [PATCH 047/120] arm64: dts: ti: iot2050: Add/enabled mailboxes and
@@ -65,5 +65,5 @@ index 58c8e64d5885..b29537088289 100644
  	status = "disabled";
  };
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0048-arm64-dts-ti-iot2050-Prepare-for-adding-2nd-generati.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0048-arm64-dts-ti-iot2050-Prepare-for-adding-2nd-generati.patch
@@ -1,4 +1,4 @@
-From 2b10be6eb723b040c696c3922f4d1b40b213e1ec Mon Sep 17 00:00:00 2001
+From 766497acb9e2a15bb450fa3b59183c1174e66ee0 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 26 Sep 2021 14:05:16 +0200
 Subject: [PATCH 048/120] arm64: dts: ti: iot2050: Prepare for adding
@@ -359,5 +359,5 @@ index ec9617c13cdb..077f165bdc68 100644
 -	status = "disabled";
  };
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0049-arm64-dts-ti-iot2050-Add-support-for-product-generat.patch
@@ -1,4 +1,4 @@
-From 20e35f39724ecfabd62f67ec7c7560fb1d7ffbff Mon Sep 17 00:00:00 2001
+From 778812d627c0a43a908854262b425a3811f02314 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sun, 26 Sep 2021 14:05:17 +0200
 Subject: [PATCH 049/120] arm64: dts: ti: iot2050: Add support for product
@@ -160,5 +160,5 @@ index 000000000000..f00dc86d01b9
 +	ti,cluster-mode = <0>;
 +};
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-iot2050-Add-layout-of-OSPI-flash.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0050-arm64-dts-ti-iot2050-Add-layout-of-OSPI-flash.patch
@@ -1,4 +1,4 @@
-From a23ba5a394799fc132055300e994e02fbae3ef90 Mon Sep 17 00:00:00 2001
+From 104019200697ec6ab5cc9afa3be6292de6bb5489 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 21 Mar 2022 15:53:15 +0100
 Subject: [PATCH 050/120] arm64: dts: ti: iot2050: Add layout of OSPI flash
@@ -72,5 +72,5 @@ index 65da226847f4..d8661096f2de 100644
  };
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0051-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0051-arm64-dts-ti-k3-am65-main-fix-DSS-irq-trigger-type.patch
@@ -1,4 +1,4 @@
-From b1d66d6a10869b1a80eb85391fcf22523918def9 Mon Sep 17 00:00:00 2001
+From b4cc838f86fb60d5d6706f1cdd7fd1e1adb27d3e Mon Sep 17 00:00:00 2001
 From: Tomi Valkeinen <tomi.valkeinen@ti.com>
 Date: Mon, 31 May 2021 16:31:35 +0530
 Subject: [PATCH 051/120] arm64: dts: ti: k3-am65-main: fix DSS irq trigger
@@ -35,5 +35,5 @@ index a506a24bd9c2..dd1e475f2c18 100644
  		dma-coherent;
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0052-irqdomain-Export-of_phandle_args_to_fwspec.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0052-irqdomain-Export-of_phandle_args_to_fwspec.patch
@@ -1,4 +1,4 @@
-From cf1a1afb303707c2622d6ffa47cc0aae96b040dd Mon Sep 17 00:00:00 2001
+From b9fb2cb52162239f9184895885c1f07c53c29265 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:46 +0530
 Subject: [PATCH 052/120] irqdomain: Export of_phandle_args_to_fwspec()
@@ -55,5 +55,5 @@ index c6b419db68ef..a17e4ce3811d 100644
  unsigned int irq_create_fwspec_mapping(struct irq_fwspec *fwspec)
  {
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0053-PCI-keystone-Convert-to-using-hierarchy-domain-for-l.patch
@@ -1,4 +1,4 @@
-From b3064cb2296aeef46bc98597166738e9efea657c Mon Sep 17 00:00:00 2001
+From 8c6cd0581cf64c7ae1e302622a56f0839bb78d76 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:47 +0530
 Subject: [PATCH 053/120] PCI: keystone: Convert to using hierarchy domain for
@@ -318,5 +318,5 @@ index 90482d5246ff..0493e43ba416 100644
  err:
  	of_node_put(intc_np);
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0054-PCI-keystone-Add-PCI-legacy-interrupt-support-for-AM.patch
@@ -1,4 +1,4 @@
-From 669c628b875613bb3bc16afd1de573d05093c088 Mon Sep 17 00:00:00 2001
+From 5f96e603ff85862969eb15a77aab8ec14d23ca26 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:48 +0530
 Subject: [PATCH 054/120] PCI: keystone: Add PCI legacy interrupt support for
@@ -135,5 +135,5 @@ index 0493e43ba416..0460ed2a277a 100644
  		return ret;
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0055-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0055-PCI-keystone-Add-workaround-for-Errata-i2037-AM65x-S.patch
@@ -1,4 +1,4 @@
-From a79e6b84a63941c5f8622cd1eeb0e9e0926cb6a5 Mon Sep 17 00:00:00 2001
+From a73b62a2662baa935c9edca58e8d68bd4806dde3 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:24:49 +0530
 Subject: [PATCH 055/120] PCI: keystone: Add workaround for Errata #i2037
@@ -110,5 +110,5 @@ index 0460ed2a277a..bb7190400ba8 100644
  DECLARE_PCI_FIXUP_ENABLE(PCI_ANY_ID, PCI_ANY_ID, ks_pcie_quirk);
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0056-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0056-arm64-dts-ti-k3-am65-main-Add-properties-to-support-.patch
@@ -1,4 +1,4 @@
-From 1f18fb4d6dfa92f0dbb6495ffa4a628722380ecf Mon Sep 17 00:00:00 2001
+From 2299a87ecafa24f10068fdb0fefad6192c57c954 Mon Sep 17 00:00:00 2001
 From: Kishon Vijay Abraham I <kishon@ti.com>
 Date: Tue, 30 Mar 2021 17:38:07 +0530
 Subject: [PATCH 056/120] arm64: dts: ti: k3-am65-main: Add properties to
@@ -82,5 +82,5 @@ index dd1e475f2c18..2911b4286c97 100644
  
  	pcie1_ep: pcie-ep@5600000 {
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0057-remoteproc-Fix-unbalanced-boot-with-sysfs-for-no-aut.patch
@@ -1,4 +1,4 @@
-From 6073757e0dbc2bc4599326f1cc7dc0323c32e579 Mon Sep 17 00:00:00 2001
+From 70f4742e4058fbc91c7e28bb8bac2d83acb38ad9 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 20 Nov 2020 21:01:54 -0600
 Subject: [PATCH 057/120] remoteproc: Fix unbalanced boot with sysfs for no
@@ -73,5 +73,5 @@ index 1dbef895e65e..3b05230641c8 100644
  		dev_err(&rproc->dev, "Unrecognised option: %s\n", buf);
  		ret = -EINVAL;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-Introduce-deny_sysfs_ops-flag.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0058-remoteproc-Introduce-deny_sysfs_ops-flag.patch
@@ -1,4 +1,4 @@
-From 2031bb3addf4ea37244bf7b033b91bc6db36a9e5 Mon Sep 17 00:00:00 2001
+From f7d775468c076bf8a35cad9b04dff97a1323867a Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 13:05:28 -0500
 Subject: [PATCH 058/120] remoteproc: Introduce deny_sysfs_ops flag
@@ -95,5 +95,5 @@ index e8ac041c64d9..02425aac6100 100644
  	int nb_vdev;
  	u8 elf_class;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0059-remoteproc-pru-Add-APIs-to-get-and-put-the-PRU-cores.patch
@@ -1,4 +1,4 @@
-From dc142aa4e3ccf10a79adb4774d0e506668562c13 Mon Sep 17 00:00:00 2001
+From 3f6c1321ad1ddff36670a47a9f31e4a6692a59c3 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:32:29 -0500
 Subject: [PATCH 059/120] remoteproc: pru: Add APIs to get and put the PRU
@@ -279,5 +279,5 @@ index 000000000000..1a97856b463a
 +
 +#endif /* __LINUX_PRUSS_H */
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0060-remoteproc-pru-Deny-rproc-sysfs-ops-for-PRU-client-d.patch
@@ -1,4 +1,4 @@
-From 86b11f5149f813d29b084ee4f52e388c63343530 Mon Sep 17 00:00:00 2001
+From 9c2891b07597255fc8f7a49b5c9d33df7791b9ba Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Wed, 16 Dec 2020 17:52:37 +0100
 Subject: [PATCH 060/120] remoteproc: pru: Deny rproc sysfs ops for PRU client
@@ -41,5 +41,5 @@ index 0b57b3f7747f..8fac021adc52 100644
  
  	put_device(&rproc->dev);
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0061-remoteproc-pru-Add-pru_rproc_set_ctable-function.patch
@@ -1,4 +1,4 @@
-From 8b75e4d0ca24d7e4ed536184d55af9be6bab47ea Mon Sep 17 00:00:00 2001
+From c625c085089a54e3871a821c056a5e53a49ec5a0 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Fri, 26 Mar 2021 15:43:53 -0500
 Subject: [PATCH 061/120] remoteproc: pru: Add pru_rproc_set_ctable() function
@@ -182,5 +182,5 @@ index 1a97856b463a..e1740ff06962 100644
  
  static inline bool is_pru_rproc(struct device *dev)
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0062-remoteproc-pru-Configure-firmware-based-on-client-se.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0062-remoteproc-pru-Configure-firmware-based-on-client-se.patch
@@ -1,4 +1,4 @@
-From bf7b479f7984ece56d2116901c5e17577b5fc929 Mon Sep 17 00:00:00 2001
+From ec426cfe463625eaf63bafdec6fb070f9a6a809e Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:50:14 -0500
 Subject: [PATCH 062/120] remoteproc: pru: Configure firmware based on client
@@ -104,5 +104,5 @@ index 90c097ebc27e..c346899d5e3b 100644
  	pru->client_np = NULL;
  	rproc->deny_sysfs_ops = false;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_get-put-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0063-soc-ti-pruss-Add-pruss_get-put-API.patch
@@ -1,4 +1,4 @@
-From b7db5098ff878776d7f093610d2f4f07cd8bf47d Mon Sep 17 00:00:00 2001
+From fe94c46135048283d16ed18cec4bb9cf2b908930 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Fri, 26 Mar 2021 15:58:00 -0500
 Subject: [PATCH 063/120] soc: ti: pruss: Add pruss_get()/put() API
@@ -176,5 +176,5 @@ index ecfded30ed05..4d1321f0d326 100644
  
  /*
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0064-soc-ti-pruss-Add-pruss_-request-release-_mem_region-.patch
@@ -1,4 +1,4 @@
-From 2bdb7743850b7b44bb2f9a7b79680a52642137a1 Mon Sep 17 00:00:00 2001
+From 5ff6d5f128791b5a1287155b21e19a440feef486 Mon Sep 17 00:00:00 2001
 From: "Andrew F. Davis" <afd@ti.com>
 Date: Fri, 26 Mar 2021 16:11:42 -0500
 Subject: [PATCH 064/120] soc: ti: pruss: Add
@@ -236,5 +236,5 @@ index 4d1321f0d326..f1d1197fd91a 100644
  	struct clk *iep_clk_mux;
  };
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0065-soc-ti-pruss-Add-pruss_cfg_read-update-API.patch
@@ -1,4 +1,4 @@
-From cda4db756ef96e233ddae9a3c7ffc26dc5f787fb Mon Sep 17 00:00:00 2001
+From c27626e4767f5a261e75be84cff7c320e5483d93 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:27:34 -0500
 Subject: [PATCH 065/120] soc: ti: pruss: Add pruss_cfg_read()/update() API
@@ -209,5 +209,5 @@ index 40de553d4446..a4f59a46c331 100644
  
  #if IS_ENABLED(CONFIG_PRU_REMOTEPROC)
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0066-soc-ti-pruss-Add-helper-functions-to-set-GPI-mode-MI.patch
@@ -1,4 +1,4 @@
-From cd3aff778c1d48fef2d3624edbbff2b69c2437ea Mon Sep 17 00:00:00 2001
+From 3769b99de18955b27869e3cfe83f671c934b7802 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 11 Dec 2020 19:48:09 +0100
 Subject: [PATCH 066/120] soc: ti: pruss: Add helper functions to set GPI mode,
@@ -82,5 +82,5 @@ index a4f59a46c331..ba5b728d5015 100644
 +
  #endif /* __LINUX_PRUSS_H */
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0067-soc-ti-pruss-Add-helper-function-to-enable-OCP-maste.patch
@@ -1,4 +1,4 @@
-From e30534b2e260897c01eb722ef402cb002cfe73ef Mon Sep 17 00:00:00 2001
+From c82f5c73444cfbbad934d3e5c7e8532bc65db38c Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Fri, 26 Mar 2021 16:38:11 -0500
 Subject: [PATCH 067/120] soc: ti: pruss: Add helper function to enable OCP
@@ -178,5 +178,5 @@ index ba5b728d5015..5fdd6f03446d 100644
  
  #if IS_ENABLED(CONFIG_PRU_REMOTEPROC)
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0068-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0068-soc-ti-pruss-Add-helper-functions-to-get-set-PRUSS_C.patch
@@ -1,4 +1,4 @@
-From 5df804fe60ae90bbbf45db248f6c01119b984dcc Mon Sep 17 00:00:00 2001
+From 85f74a7272505d7b22eb7f2da97ea3810dbedd1c Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 09:24:51 -0500
 Subject: [PATCH 068/120] soc: ti: pruss: Add helper functions to get/set
@@ -71,5 +71,5 @@ index f1d1197fd91a..d6abfdd17631 100644
 +
  #endif	/* _PRUSS_DRIVER_H_ */
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0069-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0069-remoteproc-pru-add-support-for-configuring-GPMUX-bas.patch
@@ -1,4 +1,4 @@
-From dec2e494b1ee58b3cb03e3c4862d1034ae8663e9 Mon Sep 17 00:00:00 2001
+From aaf83c026ac126399687d983458b4bad18661430 Mon Sep 17 00:00:00 2001
 From: Tero Kristo <t-kristo@ti.com>
 Date: Sat, 27 Mar 2021 10:11:42 -0500
 Subject: [PATCH 069/120] remoteproc/pru: add support for configuring GPMUX
@@ -75,5 +75,5 @@ index c346899d5e3b..7ef176170b18 100644
  
  	mutex_lock(&pru->lock);
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0070-net-ethernet-ti-prueth-Add-IEP-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0070-net-ethernet-ti-prueth-Add-IEP-driver.patch
@@ -1,4 +1,4 @@
-From 6fe08e45746854a7d962bc415f8e86f7e87d8877 Mon Sep 17 00:00:00 2001
+From 8ccc5b9b57ffa8c0e77a70eea70ef46230d731ec Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 20 Apr 2021 13:17:30 +0530
 Subject: [PATCH 070/120] net: ethernet: ti: prueth: Add IEP driver
@@ -1146,5 +1146,5 @@ index 000000000000..a41e18df666e
 +
 +#endif /* __NET_TI_ICSS_IEP_H */
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0071-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0071-HACK-net-ethernet-ti-icss-iep-Fix-sync0-generation-o.patch
@@ -1,4 +1,4 @@
-From ed2e820107911c9b15ef80fd06e5f98fc1e78b7c Mon Sep 17 00:00:00 2001
+From bf22ec796136dbd8ed73f4f17caefb9c28dcefba Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Tue, 20 Apr 2021 13:17:31 +0530
 Subject: [PATCH 071/120] HACK: net: ethernet: ti: icss-iep: Fix sync0
@@ -119,5 +119,5 @@ index 234972a034a9..22034d41c988 100644
  EXPORT_SYMBOL_GPL(icss_iep_put);
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0072-net-ethernet-ti-icss_iep-drop-ICSS_IEP_CAPx_FALL_REG.patch
@@ -1,4 +1,4 @@
-From 0015e379db59c0ddfac3ed212692178e751c9174 Mon Sep 17 00:00:00 2001
+From 4f8cfaa8f98fc86583198263aca592985c01bc39 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:28 +0300
 Subject: [PATCH 072/120] net: ethernet: ti: icss_iep: drop
@@ -80,5 +80,5 @@ index 22034d41c988..60a284c6c0c9 100644
  		[ICSS_IEP_CMP_CFG_REG] = 0x40,
  		[ICSS_IEP_CMP_STAT_REG] = 0x44,
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0073-net-ethernet-ti-icss_iep-fix-access-to-x_REG1-in-non.patch
@@ -1,4 +1,4 @@
-From 4abe34671572e88d308898736ea3a92d3a92fc86 Mon Sep 17 00:00:00 2001
+From 99d1b5f75c514768f94063e29e4125c0d31f5f82 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:29 +0300
 Subject: [PATCH 073/120] net: ethernet: ti: icss_iep: fix access to x_REG1 in
@@ -93,5 +93,5 @@ index 60a284c6c0c9..73c0a31e8245 100644
  			pevent.type = PTP_CLOCK_EXTTS;
  			pevent.index = i;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0074-net-ethernet-ti-icss_iep-disable-extts-and-pps-if-no.patch
@@ -1,4 +1,4 @@
-From a65cf172081875e9af452dd239f17803cb4186b5 Mon Sep 17 00:00:00 2001
+From 4a862d3110f67c90708c2d63b670df8b664bcc36 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:30 +0300
 Subject: [PATCH 074/120] net: ethernet: ti: icss_iep: disable extts and pps if
@@ -37,5 +37,5 @@ index 73c0a31e8245..c0bcb1d1180a 100644
  
  put_iep_device:
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0075-net-ethernet-ti-icss_iep-fix-pps-irq-race-vs-pps-dis.patch
@@ -1,4 +1,4 @@
-From cff99043458b316f3ead41d12dbc06d984c8d14f Mon Sep 17 00:00:00 2001
+From 07da9762274fa716e71ee1d5475bf91337bfde67 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:31 +0300
 Subject: [PATCH 075/120] net: ethernet: ti: icss_iep: fix pps irq race vs pps
@@ -123,5 +123,5 @@ index c0bcb1d1180a..ead1e7c94021 100644
  	mutex_unlock(&iep->ptp_clk_mutex);
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0076-net-ethernet-ti-icss_iep-improve-icss_iep_gettime.patch
@@ -1,4 +1,4 @@
-From 56a9dba458acb45b9038b6ee6068305efed66d75 Mon Sep 17 00:00:00 2001
+From bb19a28f0cf48464f548e172cb54097f63258bc7 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:32 +0300
 Subject: [PATCH 076/120] net: ethernet: ti: icss_iep: improve icss_iep_gettime
@@ -69,5 +69,5 @@ index ead1e7c94021..cbec01328a71 100644
  
  static void icss_iep_enable(struct icss_iep *iep)
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0077-net-ethernet-ti-icss_iep-simplify-peroutput-processi.patch
@@ -1,4 +1,4 @@
-From de543dcb33cdc12f0ac7fdc3c17ac7997c0a554e Mon Sep 17 00:00:00 2001
+From 9a38c779b4bfcda5d8f3c3d48ceb6edd9ba59039 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:33 +0300
 Subject: [PATCH 077/120] net: ethernet: ti: icss_iep: simplify peroutput
@@ -114,5 +114,5 @@ index cbec01328a71..b39d4c08c6c9 100644
  		hrtimer_start(&iep->sync_timer, ms_to_ktime(110), /* 100ms + buffer */
  			      HRTIMER_MODE_REL);
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0078-net-ethernet-ti-icss_iep-use-readl-writel-in-cap_cmp.patch
@@ -1,4 +1,4 @@
-From 9595c3bcbe19e6ce139d3ba7926bca815410a53a Mon Sep 17 00:00:00 2001
+From 95156ab70cdc9a7d7483dd40c21eb998fa09a893 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:34 +0300
 Subject: [PATCH 078/120] net: ethernet: ti: icss_iep: use readl/writel in
@@ -102,5 +102,5 @@ index b39d4c08c6c9..e2663dd5cf38 100644
  	return HRTIMER_NORESTART;
  }
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0079-net-ethernet-ti-icss_iep-switch-to-.gettimex64.patch
@@ -1,4 +1,4 @@
-From bb0c0b7f719c0bcb95c53b7f414b55b07d1639ae Mon Sep 17 00:00:00 2001
+From 8269ec8374b4fba7e3d72f727e38538ba059e96e Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:35 +0300
 Subject: [PATCH 079/120] net: ethernet: ti: icss_iep: switch to .gettimex64()
@@ -95,5 +95,5 @@ index e2663dd5cf38..c0497b448d68 100644
  	.enable		= icss_iep_ptp_enable,
  };
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0080-net-ethernet-ti-icss_iep-Update-compare-registers-af.patch
@@ -1,4 +1,4 @@
-From 10a1978b55e70ec06156ded47d41ca83e1014e6c Mon Sep 17 00:00:00 2001
+From 743d0e8dd9ca55dfb1d91db78bcb1e1905ded674 Mon Sep 17 00:00:00 2001
 From: Lokesh Vutla <lokeshvutla@ti.com>
 Date: Thu, 29 Apr 2021 18:13:36 +0300
 Subject: [PATCH 080/120] net: ethernet: ti: icss_iep: Update compare registers
@@ -60,5 +60,5 @@ index c0497b448d68..8bad9c86775a 100644
  
  static u64 icss_iep_gettime(struct icss_iep *iep,
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0081-net-ethernet-ti-icss_iep-request-cmp_cap-irq-from-pr.patch
@@ -1,4 +1,4 @@
-From c548b8defa37b3039c4018533be616acf039c108 Mon Sep 17 00:00:00 2001
+From ae1f64efe96232ca0dd5fee91b19c0428d3f5a9b Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:37 +0300
 Subject: [PATCH 081/120] net: ethernet: ti: icss_iep: request cmp_cap irq from
@@ -106,5 +106,5 @@ index 8bad9c86775a..df74b5fd17e9 100644
  	if (IS_ERR(iep_clk))
  		return PTR_ERR(iep_clk);
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0082-net-ethernet-ti-icss_iep-set-phc-time-to-system-time.patch
@@ -1,4 +1,4 @@
-From ccd1062fe6f3039e3aed39a32a63f167aea75753 Mon Sep 17 00:00:00 2001
+From bc356187dbf204cbaed511ef32044b70307ca378 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:38 +0300
 Subject: [PATCH 082/120] net: ethernet: ti: icss_iep: set phc time to system
@@ -28,5 +28,5 @@ index df74b5fd17e9..08b456f0bc12 100644
  	iep->clk_tick_time = def_inc;
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0083-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0083-net-ethernet-ti-icss_iep-use-devm_platform_ioremap_r.patch
@@ -1,4 +1,4 @@
-From 49d88d6b08a827d08743d336722b3bc179cf3f9e Mon Sep 17 00:00:00 2001
+From ad046e905b0b4de115acdee8ebf886a7ecccf1b8 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Thu, 29 Apr 2021 18:13:39 +0300
 Subject: [PATCH 083/120] net: ethernet: ti: icss_iep: use
@@ -35,5 +35,5 @@ index 08b456f0bc12..640f483854d0 100644
  		return -ENODEV;
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0084-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0084-arm64-dts-ti-k3-am65-main-Add-ICSSG-IEP-nodes.patch
@@ -1,4 +1,4 @@
-From 24dfafe1339618f30d85f4a26694b5bdbb8fcf2c Mon Sep 17 00:00:00 2001
+From e1510ebe25c77e492696e86707515c8c1cda5960 Mon Sep 17 00:00:00 2001
 From: Suman Anna <s-anna@ti.com>
 Date: Tue, 16 Mar 2021 18:00:25 -0500
 Subject: [PATCH 084/120] arm64: dts: ti: k3-am65-main: Add ICSSG IEP nodes
@@ -77,5 +77,5 @@ index 2911b4286c97..351183c116c5 100644
  			compatible = "ti,pruss-mii", "syscon";
  			reg = <0x32000 0x100>;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0085-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0085-dt-bindings-net-Add-binding-for-ti-icssg-prueth-devi.patch
@@ -1,4 +1,4 @@
-From 12be3002f447b55e488c55a15df15fd8d6d8f96b Mon Sep 17 00:00:00 2001
+From 587b8e70550a559c842b93eaa3cd0ae83821ef24 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:22 +0300
 Subject: [PATCH 085/120] dt-bindings: net: Add binding for ti,icssg-prueth
@@ -149,5 +149,5 @@ index 000000000000..67609e26afa5
 +		};
 +	};
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0086-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0086-net-ti-icssg-prueth-Add-ICSSG-ethernet-driver.patch
@@ -1,4 +1,4 @@
-From 4448d2d89ef53bba82836985852143d32bb0aa18 Mon Sep 17 00:00:00 2001
+From 2d43833fe08fa52ef40f38c035e7ca6709929203 Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:23 +0300
 Subject: [PATCH 086/120] net: ti: icssg-prueth: Add ICSSG ethernet driver
@@ -4497,5 +4497,5 @@ index 5fdd6f03446d..2a034c08b4c2 100644
  /*
   * enum pruss_gp_mux_sel - PRUSS GPI/O Mux modes for the
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0087-net-ethernet-ti-icssg_prueth-add-10M-full-duplex-sup.patch
@@ -1,4 +1,4 @@
-From aa6c514c6b1750ba1e723826c02bc71b2477b52f Mon Sep 17 00:00:00 2001
+From 57aa680ac6355781651bf5188ef29bf83617929d Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:24 +0300
 Subject: [PATCH 087/120] net: ethernet: ti: icssg_prueth: add 10M full duplex
@@ -250,5 +250,5 @@ index bf52d350bdd0..644a22b53424 100644
  #define TAS_GATE_MASK_LIST0                                0x0100
  /*TAS gate mask for windows list1*/
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0088-net-ethernet-ti-icssg_prueth-Use-DMA-device-for-DMA-.patch
@@ -1,4 +1,4 @@
-From 24b0b22d44cc8baa7042fa45252b0dc29373c2e2 Mon Sep 17 00:00:00 2001
+From e127f8b8ea421d35cf3bb14855268b2c57983827 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Tue, 18 May 2021 23:37:25 +0300
 Subject: [PATCH 088/120] net: ethernet: ti: icssg_prueth: Use DMA device for
@@ -342,5 +342,5 @@ index 69c558eb004d..2e8d45c8c25d 100644
  	struct k3_udma_glue_rx_channel *rx_chn;
  	u32 descs_num;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0089-net-ethernet-ti-icss_iep-add-icss_iep_get_idx-api.patch
@@ -1,4 +1,4 @@
-From e0b0e9c188c17dd7bffba22d6ebe631bc83bdc31 Mon Sep 17 00:00:00 2001
+From e730686324de02fc0097957b123a7e02244cad12 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:26 +0300
 Subject: [PATCH 089/120] net: ethernet: ti: icss_iep: add icss_iep_get_idx()
@@ -59,5 +59,5 @@ index a41e18df666e..eefc8c8bd8cc 100644
  int icss_iep_init(struct icss_iep *iep, const struct icss_iep_clockops *clkops,
  		  void *clockops_data, u32 cycle_time_ns);
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0090-net-ethernet-ti-icss_iep-use-readl-in-icss_iep_get_c.patch
@@ -1,4 +1,4 @@
-From 93d5d23272614eccea07c3dee9102bce10493cc5 Mon Sep 17 00:00:00 2001
+From 75f1ff7c0162f4b2f451ec37804b344a5b7f650c Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:27 +0300
 Subject: [PATCH 090/120] net: ethernet: ti: icss_iep: use readl() in
@@ -35,5 +35,5 @@ index 51f8717fc446..23e72e0ffe46 100644
  	return val;
  }
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0091-net-ethernet-ti-icss_iep-fix-init-for-sr2.0.patch
@@ -1,4 +1,4 @@
-From 5ebe99300e633584c7974a8b2741e50db0cb95b7 Mon Sep 17 00:00:00 2001
+From 1f10976bd36581d9bec23e1cd35e47d3455e8824 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:28 +0300
 Subject: [PATCH 091/120] net: ethernet: ti: icss_iep: fix init for sr2.0
@@ -147,5 +147,5 @@ index 23e72e0ffe46..eec7e9fb1f61 100644
  	dev_set_drvdata(dev, iep);
  	icss_iep_disable(iep);
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0092-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0092-net-ethernet-ti-icss_iep-sr2.0-fix-NULL-pointer-exce.patch
@@ -1,4 +1,4 @@
-From f1dd4072ed013041ab66396f031a16e4eeb2ca91 Mon Sep 17 00:00:00 2001
+From cf1c897c7c60a644c3d2b4494920192bc68a71bb Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:29 +0300
 Subject: [PATCH 092/120] net: ethernet: ti: icss_iep: sr2.0 fix NULL pointer
@@ -38,5 +38,5 @@ index eec7e9fb1f61..0ed54c8251e2 100644
  	}
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0093-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0093-net-ti-ethernet-icssg-prueth-add-packet-timestamping.patch
@@ -1,4 +1,4 @@
-From 691ce87406017977129fd4dbcdc9dc7c97e61847 Mon Sep 17 00:00:00 2001
+From 4dd14bd644ca1c52ed0530f73f1646f3f0b2f26e Mon Sep 17 00:00:00 2001
 From: Roger Quadros <rogerq@ti.com>
 Date: Tue, 18 May 2021 23:37:30 +0300
 Subject: [PATCH 093/120] net: ti: ethernet: icssg-prueth: add packet
@@ -856,5 +856,5 @@ index 2e8d45c8c25d..156716bf0a76 100644
  
  struct emac_tx_ts_response_sr1 {
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0094-net-ethernet-ti-icssg_prueth-add-am64x-icssg-support.patch
@@ -1,4 +1,4 @@
-From 7ccc80ed87e1110e25ac3d6e5e7a0e146e382a19 Mon Sep 17 00:00:00 2001
+From ea69e81b007accf7a00a120ab14d0538f3543f6c Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 18 May 2021 23:37:33 +0300
 Subject: [PATCH 094/120] net: ethernet: ti: icssg_prueth: add am64x icssg
@@ -120,5 +120,5 @@ index 156716bf0a76..b536ac5ec0bf 100644
  
  struct emac_tx_ts_response_sr1 {
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0095-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0095-net-ethernet-ti-icssg_prueth-am65x-SR2.0-add-10M-ful.patch
@@ -1,4 +1,4 @@
-From 18bf989426f345f7073194b4c25eae363926e9e8 Mon Sep 17 00:00:00 2001
+From 3fc5135e347404a4539eb19613ff6b25efb33279 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 19 May 2021 19:31:36 +0300
 Subject: [PATCH 095/120] net: ethernet: ti: icssg_prueth: am65x SR2.0 add 10M
@@ -158,5 +158,5 @@ index b536ac5ec0bf..7cc81c67bf72 100644
  
  /**
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0096-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0096-net-ti-icssg_prueth-Free-desc-pool-before-DMA-channe.patch
@@ -1,4 +1,4 @@
-From 569f0cabdcadb6461b33fe3a0eab928f3ee1f669 Mon Sep 17 00:00:00 2001
+From 8b9038294fe41319edff998fb4aae1f50a5dbfb5 Mon Sep 17 00:00:00 2001
 From: Vignesh Raghavendra <vigneshr@ti.com>
 Date: Mon, 21 Jun 2021 15:47:49 +0530
 Subject: [PATCH 096/120] net: ti: icssg_prueth: Free desc pool before DMA
@@ -48,5 +48,5 @@ index ef7392a2b9da..38d151dca81c 100644
  		 * end after all channel resources are freed
  		 */
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0097-net-ethernet-icssg-prueth-fix-rgmii-tx-delay-configu.patch
@@ -1,4 +1,4 @@
-From 13adfe5410273ebc2f9003c6472919ef1199a6d0 Mon Sep 17 00:00:00 2001
+From 1ce29d394bee3cb643dc3763c759868b71577379 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:47 +0300
 Subject: [PATCH 097/120] net: ethernet: icssg-prueth: fix rgmii tx delay
@@ -125,5 +125,5 @@ index 38d151dca81c..d19a05fd8b06 100644
  		if (ret)
  			goto put_cores;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0098-net-ethernet-icssg-prueth-enable-fixed-link-connecti.patch
@@ -1,4 +1,4 @@
-From 80683059df2308fea4ecb4f9261e2374f554863e Mon Sep 17 00:00:00 2001
+From 5cfddadac0fd3abf5bfefbaaac806b1c9194c862 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Fri, 18 Jun 2021 20:51:48 +0300
 Subject: [PATCH 098/120] net: ethernet: icssg-prueth: enable "fixed-link"
@@ -71,5 +71,5 @@ index d19a05fd8b06..3b1769a5e2b3 100644
  		ret = -EPROBE_DEFER;
  		goto free;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0099-net-ethernet-icssg-prueth-fix-bug-scheduling-while-a.patch
@@ -1,4 +1,4 @@
-From 1b9d6cf8e6714bc084677073338ee75863051433 Mon Sep 17 00:00:00 2001
+From 6547298840b4a735de3654fc52fd90d3bb218b74 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:12 +0300
 Subject: [PATCH 099/120] net: ethernet: icssg-prueth: fix bug 'scheduling
@@ -133,5 +133,5 @@ index 7cc81c67bf72..59dec45a3c86 100644
  	struct pruss_mem_region dram;
  };
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0100-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0100-net-ethernet-icssg-prueth-fix-enabling-disabling-por.patch
@@ -1,4 +1,4 @@
-From 7e3a3d4e66d82291c4fa91a82d571509061d008d Mon Sep 17 00:00:00 2001
+From 50f3a68d5e6259b2ed8bcae035a8cf86ae0fa98a Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Wed, 7 Jul 2021 14:43:13 +0300
 Subject: [PATCH 100/120] net: ethernet: icssg-prueth: fix enabling/disabling
@@ -59,5 +59,5 @@ index f212e5904afc..abd062bedebb 100644
  
  reset_tx_chan:
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0101-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0101-arm64-dts-ti-iot2050-Add-icssg-prueth-nodes-for-PG1-.patch
@@ -1,4 +1,4 @@
-From 51482cca475600eb25309c54b81dd84c6e26e7b7 Mon Sep 17 00:00:00 2001
+From f36936d566fc1de2a56bd5b26b7c14a3b610a927 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Sat, 27 Jun 2020 10:53:13 +0200
 Subject: [PATCH 101/120] arm64: dts: ti: iot2050: Add icssg-prueth nodes for
@@ -206,5 +206,5 @@ index d8661096f2de..51e82e08550a 100644
  
  &icssg1_mdio {
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0102-HACK-setting-the-RJ45-port-led-behavior.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0102-HACK-setting-the-RJ45-port-led-behavior.patch
@@ -1,4 +1,4 @@
-From 9332d4f11017122fcfaea96184d2140f9f338d6f Mon Sep 17 00:00:00 2001
+From 997d99df23ba58b6ac1bc98d4f449a7468333a0f Mon Sep 17 00:00:00 2001
 From: zengchao <chao.zeng@siemens.com>
 Date: Wed, 6 Nov 2019 11:21:49 +0800
 Subject: [PATCH 102/120] HACK: setting the RJ45 port led behavior
@@ -37,5 +37,5 @@ index f86acad0aad4..604a1a5b06ef 100644
  }
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0103-WIP-feat-extend-led-panic-indicator-on-and-off.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0103-WIP-feat-extend-led-panic-indicator-on-and-off.patch
@@ -1,4 +1,4 @@
-From a35d6689532c0baf5da781d9068520bf11f4caef Mon Sep 17 00:00:00 2001
+From c376f6590f5dca828e7230727391de120ec4bfee Mon Sep 17 00:00:00 2001
 From: Su Baocheng <baocheng.su@siemens.com>
 Date: Tue, 22 Dec 2020 15:05:56 +0800
 Subject: [PATCH 103/120] WIP: feat:extend led panic-indicator on and off
@@ -124,5 +124,5 @@ index 6a8d6409c993..d84423d42f89 100644
  	int 		num_leds;
  	const struct gpio_led *leds;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0104-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0104-WIP-arm64-dts-ti-iot2050-Add-node-for-generic-spidev.patch
@@ -1,4 +1,4 @@
-From 3e93951d6e063de2033baebce22451484ac962bc Mon Sep 17 00:00:00 2001
+From 89a9796640d285de4c99e8b5d69aaa36213982f8 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Thu, 11 Mar 2021 15:28:21 +0100
 Subject: [PATCH 104/120] WIP: arm64: dts: ti: iot2050: Add node for generic
@@ -33,5 +33,5 @@ index 51e82e08550a..fcf877d3d504 100644
  
  &tscadc0 {
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0105-watchdog-rti-wdt-Provide-set_timeout-handler-to-make.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0105-watchdog-rti-wdt-Provide-set_timeout-handler-to-make.patch
@@ -1,4 +1,4 @@
-From 9f70151b4f4e874126179cdc69e65dee9f9f15b8 Mon Sep 17 00:00:00 2001
+From f47f363e1d62621f70e11a4022784f0a26a606d2 Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Mon, 13 Sep 2021 12:27:17 +0200
 Subject: [PATCH 105/120] watchdog: rti-wdt: Provide set_timeout handler to
@@ -57,5 +57,5 @@ index 06f9d0ee1340..15a476b8aa78 100644
  };
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0106-dt-bindings-net-ti-icssg-prueth-Add-documentation-fo.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0106-dt-bindings-net-ti-icssg-prueth-Add-documentation-fo.patch
@@ -1,4 +1,4 @@
-From 923d73dfec95351f24e92c0704e30d411bdb2d5f Mon Sep 17 00:00:00 2001
+From 66d09960a7df8382602e36871cea9c12d62493d7 Mon Sep 17 00:00:00 2001
 From: Murali Karicheri <m-karicheri2@ti.com>
 Date: Tue, 12 Oct 2021 13:54:41 +0300
 Subject: [PATCH 106/120] dt-bindings: net: ti, icssg-prueth: Add documentation
@@ -37,5 +37,5 @@ index 125a204ef2d2..41cba6907fc9 100644
  Example (k3-am654 base board SR2.0, dual-emac):
  ==============================================
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0107-net-ethernet-icssg-prueth-sr1.0-add-support-for-half.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0107-net-ethernet-icssg-prueth-sr1.0-add-support-for-half.patch
@@ -1,4 +1,4 @@
-From f04f21a00cc76cca675d84edc0368baacda5604f Mon Sep 17 00:00:00 2001
+From b25cefb845e5a1def6fd20716ff1bb6a4fe115a0 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 12 Oct 2021 13:54:42 +0300
 Subject: [PATCH 107/120] net: ethernet: icssg-prueth: sr1.0: add support for
@@ -103,5 +103,5 @@ index 59dec45a3c86..917c6f9a2514 100644
  	/* DMA related */
  	struct prueth_tx_chn tx_chns[PRUETH_MAX_TX_QUEUES];
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0108-net-ethernet-icssg-prueth-sr2.0-add-support-for-half.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0108-net-ethernet-icssg-prueth-sr2.0-add-support-for-half.patch
@@ -1,4 +1,4 @@
-From 255b78d8ccb6a1b9f426fe4ffdb0c1ba3bc342d6 Mon Sep 17 00:00:00 2001
+From 08d465f59ad666dccd323b26f33f6fcfcfaf28e4 Mon Sep 17 00:00:00 2001
 From: Grygorii Strashko <grygorii.strashko@ti.com>
 Date: Tue, 12 Oct 2021 13:54:43 +0300
 Subject: [PATCH 108/120] net: ethernet: icssg-prueth: sr2.0: add support for
@@ -135,5 +135,5 @@ index 644a22b53424..99225d0f1582 100644
  /* Memory Usage of : DMEM1
   *
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0109-arm64-dts-ti-add-the-support-for-the-half-duplex.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0109-arm64-dts-ti-add-the-support-for-the-half-duplex.patch
@@ -1,4 +1,4 @@
-From e495db3b722be2916b1ab24fe789d3a1b7e31bcf Mon Sep 17 00:00:00 2001
+From 234b7eec1db752827d0bdc36c4850b1ef6aee24b Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Fri, 22 Oct 2021 13:37:22 +0800
 Subject: [PATCH 109/120] arm64: dts: ti: add the support for the half-duplex
@@ -31,5 +31,5 @@ index fcf877d3d504..ea8ff74c681c 100644
  			local-mac-address = [00 00 00 00 00 00];
  		};
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0110-USB-serial-cp210x-return-early-on-unchanged-termios.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0110-USB-serial-cp210x-return-early-on-unchanged-termios.patch
@@ -1,4 +1,4 @@
-From 8cec1bc8af327696f03603ab18be2cfdfe687d8b Mon Sep 17 00:00:00 2001
+From fae654d5ce692dc94330affdf7e037e43f0c1236 Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:21 +0100
 Subject: [PATCH 110/120] USB: serial: cp210x: return early on unchanged
@@ -46,5 +46,5 @@ index 6b5ba6180c30..e6a471035c03 100644
  	old_cflag = old_termios->c_cflag;
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0111-USB-serial-cp210x-clean-up-line-control-handling.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0111-USB-serial-cp210x-clean-up-line-control-handling.patch
@@ -1,4 +1,4 @@
-From 693c3636645a3fa4830b7727779d6bfd5ca409a4 Mon Sep 17 00:00:00 2001
+From 405f42b61f22fca3322be211e8c524da6db1592c Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:22 +0100
 Subject: [PATCH 111/120] USB: serial: cp210x: clean up line-control handling
@@ -151,5 +151,5 @@ index e6a471035c03..6709b8cfc6ad 100644
  		struct cp210x_flow_ctl flow_ctl;
  		u32 ctl_hs;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0112-USB-serial-cp210x-set-terminal-settings-on-open.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0112-USB-serial-cp210x-set-terminal-settings-on-open.patch
@@ -1,4 +1,4 @@
-From ae0a0b03dc043e27843c2ab56bc9af9e39c0e1f4 Mon Sep 17 00:00:00 2001
+From 2421075a62ff6a10387d48d27cb47cade8518cdd Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:23 +0100
 Subject: [PATCH 112/120] USB: serial: cp210x: set terminal settings on open
@@ -398,5 +398,5 @@ index 6709b8cfc6ad..908c93309c1b 100644
  }
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0113-USB-serial-cp210x-drop-flow-control-debugging.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0113-USB-serial-cp210x-drop-flow-control-debugging.patch
@@ -1,4 +1,4 @@
-From 5832b3c882ca62cc609abfae5a8634ac0dc6478a Mon Sep 17 00:00:00 2001
+From 8e23f338f998beb9fa3ce6e5a9fc88827f65332c Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:24 +0100
 Subject: [PATCH 113/120] USB: serial: cp210x: drop flow-control debugging
@@ -43,5 +43,5 @@ index 908c93309c1b..af63c411d08c 100644
  		flow_ctl.ulControlHandshake = cpu_to_le32(ctl_hs);
  		flow_ctl.ulFlowReplace = cpu_to_le32(flow_repl);
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0114-USB-serial-cp210x-refactor-flow-control-handling.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0114-USB-serial-cp210x-refactor-flow-control-handling.patch
@@ -1,4 +1,4 @@
-From 6c7dd61d2ee1fd6c54aa246a9c4c9d9c4fc9289b Mon Sep 17 00:00:00 2001
+From 06a4cd5f368f50cceaca4831c0097fda25a08941 Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:25 +0100
 Subject: [PATCH 114/120] USB: serial: cp210x: refactor flow-control handling
@@ -152,5 +152,5 @@ index af63c411d08c..e09110a5f8e5 100644
  	/*
  	 * Enable event-insertion mode only if input parity checking is
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0115-USB-serial-cp210x-clean-up-dtr_rts.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0115-USB-serial-cp210x-clean-up-dtr_rts.patch
@@ -1,4 +1,4 @@
-From 25689f96b8b82e7d3026fe45010ecdb78a3ccd39 Mon Sep 17 00:00:00 2001
+From cc3e234703a7177bd950b3453b93a39a7473e272 Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 16 Nov 2020 17:18:26 +0100
 Subject: [PATCH 115/120] USB: serial: cp210x: clean up dtr_rts()
@@ -41,5 +41,5 @@ index e09110a5f8e5..6443aca5cc3d 100644
  
  static int cp210x_tiocmget(struct tty_struct *tty)
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0116-USB-serial-cp210x-add-support-for-software-flow-cont.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0116-USB-serial-cp210x-add-support-for-software-flow-cont.patch
@@ -1,4 +1,4 @@
-From b524766b46486704408a43f3a73b5727116249a1 Mon Sep 17 00:00:00 2001
+From c0827c69c37ace2cb6ce38288688ec4f1220eb14 Mon Sep 17 00:00:00 2001
 From: Wang Sheng Long <shenglong.wang.ext@siemens.com>
 Date: Mon, 18 Jan 2021 12:13:26 +0100
 Subject: [PATCH 116/120] USB: serial: cp210x: add support for software flow
@@ -139,5 +139,5 @@ index 6443aca5cc3d..aff686b50251 100644
  			__func__, ctl_hs, flow_repl);
  
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0117-USB-serial-cp210x-fix-control-characters-error-handl.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0117-USB-serial-cp210x-fix-control-characters-error-handl.patch
@@ -1,4 +1,4 @@
-From fe70c79c6a590eec9e741bec2deb4d6aad7d84f6 Mon Sep 17 00:00:00 2001
+From 13921e0e550d50f1f8738765682b6ac8ba2ff1e3 Mon Sep 17 00:00:00 2001
 From: Johan Hovold <johan@kernel.org>
 Date: Mon, 5 Jul 2021 10:20:10 +0200
 Subject: [PATCH 117/120] USB: serial: cp210x: fix control-characters error
@@ -49,5 +49,5 @@ index aff686b50251..ce930037c6ea 100644
  
  	ret = cp210x_read_reg_block(port, CP210X_GET_FLOW, &flow_ctl,
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0118-net-ethernet-icssg-prueth-Fix-release-of-iep0-on-pro.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0118-net-ethernet-icssg-prueth-Fix-release-of-iep0-on-pro.patch
@@ -1,4 +1,4 @@
-From b0f3a3c8648b3729959b14245ebed06f88de39b6 Mon Sep 17 00:00:00 2001
+From 5d6645307632553289aafe58f0606c85dfcb632c Mon Sep 17 00:00:00 2001
 From: Jan Kiszka <jan.kiszka@siemens.com>
 Date: Tue, 30 Nov 2021 10:53:42 +0100
 Subject: [PATCH 118/120] net: ethernet: icssg-prueth: Fix release of iep0 on
@@ -26,5 +26,5 @@ index e33aafc9e029..f996273b4ea3 100644
  		prueth->iep1 = NULL;
  		goto free_pool;
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0119-arm64-dts-ti-Indicate-the-green-light-is-off-when-pa.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0119-arm64-dts-ti-Indicate-the-green-light-is-off-when-pa.patch
@@ -1,4 +1,4 @@
-From 5cf2d75c77438d6f9ce858b6311c6d9bc4faab3d Mon Sep 17 00:00:00 2001
+From 1143e495bb41df6406331e083e312fcf03052d38 Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Thu, 16 Dec 2021 15:09:25 +0800
 Subject: [PATCH 119/120] arm64: dts: ti: Indicate the green light is off when
@@ -25,5 +25,5 @@ index ea8ff74c681c..3310880e83ee 100644
  
  		user-led1-red {
 -- 
-2.35.3
+2.34.1
 

--- a/recipes-kernel/linux/files/patches-5.10/0120-arm64-dts-ti-iot2050-Add-support-for-M.2-variant.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0120-arm64-dts-ti-iot2050-Add-support-for-M.2-variant.patch
@@ -1,4 +1,4 @@
-From 2d9ecc4326b94c22dc4e71b359b4e0528e768aa7 Mon Sep 17 00:00:00 2001
+From 4d54ccf8bae2b39fc469912bdfef0eb5bda3f143 Mon Sep 17 00:00:00 2001
 From: chao zeng <chao.zeng@siemens.com>
 Date: Tue, 11 Jan 2022 11:28:24 +0800
 Subject: [PATCH 120/120] arm64: dts: ti: iot2050: Add support for M.2 variant
@@ -15,8 +15,8 @@ Signed-off-by: chao zeng <chao.zeng@siemens.com>
 Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
 ---
  arch/arm64/boot/dts/ti/Makefile               |   3 +
- .../dts/ti/k3-am6548-iot2050-advanced-m2.dts  | 117 ++++++++++++++++++
- 2 files changed, 120 insertions(+)
+ .../dts/ti/k3-am6548-iot2050-advanced-m2.dts  | 118 ++++++++++++++++++
+ 2 files changed, 121 insertions(+)
  create mode 100644 arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2.dts
 
 diff --git a/arch/arm64/boot/dts/ti/Makefile b/arch/arm64/boot/dts/ti/Makefile
@@ -35,10 +35,10 @@ index e8a07d411627..dfe266547170 100644
  
 diff --git a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2.dts b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2.dts
 new file mode 100644
-index 000000000000..cb0f3a872920
+index 000000000000..cbc411c8fe1d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2.dts
-@@ -0,0 +1,117 @@
+@@ -0,0 +1,118 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (c) Siemens AG, 2018-2022
@@ -107,7 +107,7 @@ index 000000000000..cb0f3a872920
 +
 +&main_gpio0 {
 +	pinctrl-names = "default";
-+	pinctrl-0 = <&main_m2_pcie_mux_control>;
++	pinctrl-0 = <&main_m2_pcie_mux_control &arduino_io_d4_to_d9_pins_default>;
 +};
 +
 +&main_gpio1 {
@@ -116,6 +116,7 @@ index 000000000000..cb0f3a872920
 +		&main_m2_enable_pins_default
 +		&main_pmx0_m2_config_pins_default
 +		&main_pmx1_m2_config_pins_default
++		&cp2102n_reset_pin_default
 +	>;
 +};
 +
@@ -157,5 +158,5 @@ index 000000000000..cb0f3a872920
 +	/delete-property/ snps,dis-u2-entry-quirk;
 +};
 -- 
-2.35.3
+2.34.1
 


### PR DESCRIPTION
For the nodes main_gpio0 and main_gpio1,
when we add the property pinctrl-0, it would override the previous property not to add to the previous node. So it would lack some configurations.

Add the property back to solve this issue.

Signed-off-by: chao zeng <chao.zeng@siemens.com>