### PR TITLE
Make the PRODUCT_GENERATION global

### DIFF
--- a/conf/machine/iot2050.conf
+++ b/conf/machine/iot2050.conf
@@ -11,8 +11,10 @@
 
 DISTRO_ARCH ?= "arm64"
 
-PREFERRED_PROVIDER_u-boot-${MACHINE} ?= "u-boot-iot2050-pg2"
-PREFERRED_PROVIDER_u-boot-${MACHINE}-config ?= "u-boot-iot2050-pg2"
+PRODUCT_GENERATION ?= "pg2"
+
+PREFERRED_PROVIDER_u-boot-${MACHINE} ?= "u-boot-iot2050-${PRODUCT_GENERATION}"
+PREFERRED_PROVIDER_u-boot-${MACHINE}-config ?= "u-boot-iot2050-${PRODUCT_GENERATION}"
 
 KERNEL_NAME ?= "iot2050"
 DTB_FILES ?= " \

--- a/kas-iot2050-boot-pg1.yml
+++ b/kas-iot2050-boot-pg1.yml
@@ -20,4 +20,4 @@ target: u-boot-iot2050
 
 local_conf_header:
   u-boot: |
-    PREFERRED_PROVIDER_u-boot-${MACHINE} = "u-boot-iot2050-pg1"
+    PRODUCT_GENERATION = "pg1"

--- a/recipes-bsp/u-boot/u-boot-iot2050.inc
+++ b/recipes-bsp/u-boot/u-boot-iot2050.inc
@@ -11,8 +11,6 @@
 
 require recipes-bsp/u-boot/u-boot-custom.inc
 
-PRODUCT_GENERATION = "${@d.getVar('PN').split('-')[3]}"
-
 SRC_URI += " \
     file://rules.tmpl \
     file://prebuild \


### PR DESCRIPTION
So that this information could also be used by other components, such as OPTee, when it warns the RPMB setup on PG1 devices.
