### PR TITLE
optee-os-iot2050: Rename download tarball name

### DIFF
--- a/recipes-bsp/optee-os/optee-os-iot2050_3.19.0.bb
+++ b/recipes-bsp/optee-os/optee-os-iot2050_3.19.0.bb
@@ -10,7 +10,7 @@
 
 require recipes-bsp/optee-os/optee-os-custom.inc
 
-SRC_URI += "https://github.com/OP-TEE/optee_os/archive/${PV}.tar.gz"
+SRC_URI += "https://github.com/OP-TEE/optee_os/archive/${PV}.tar.gz;downloadfilename=${PN}-${PV}.tar.gz"
 SRC_URI[sha256sum] = "5e0c03bbc4d106f262a6bd33333c002c3380205ae6b82334aa7b644721ff7868"
 
 S = "${WORKDIR}/optee_os-${PV}"


### PR DESCRIPTION
To avoid file name collision, which was true for optee since the client and the os shares the same version schema.
