### PR TITLE
optee-os: Warn RPMB setup on PG1

### DIFF
--- a/recipes-bsp/optee-os/optee-os-iot2050_3.19.0.bb
+++ b/recipes-bsp/optee-os/optee-os-iot2050_3.19.0.bb
@@ -33,6 +33,9 @@ python() {
     import re
 
     overrides = d.getVar('OVERRIDES')
-    if re.search("rpmb-setup", overrides) and re.search("secureboot", overrides):
-        bb.fatal("Not possible to use Secure Boot and RPMB setup for OPTEE")
+    if re.search("rpmb-setup", overrides):
+        if re.search("secureboot", overrides):
+            bb.fatal("Not possible to use Secure Boot and RPMB setup for OPTEE")
+        if d.getVar('PRODUCT_GENERATION') == "pg1":
+            bb.warn("PG1 devices do not supported RPMB based secure storage")
 }


### PR DESCRIPTION
PG1 device should not support RPMB based secure storage.
