### PR TITLE
allow to override initramfs conf of iot2050-debian

### DIFF
--- a/conf/distro/iot2050-debian.conf
+++ b/conf/distro/iot2050-debian.conf
@@ -51,8 +51,8 @@ SDK_FORMATS = "tar.xz docker-archive"
 
 # used for SWUpdate boot
 IMAGE_CLASSES += "squashfs verity"
-ABROOTFS_IMAGE_RECIPE = "iot2050-image-swu-example"
-VERITY_IMAGE_RECIPE = "iot2050-image-swu-example"
-INITRAMFS_RECIPE = "iot2050-initramfs"
+ABROOTFS_IMAGE_RECIPE ?= "iot2050-image-swu-example"
+VERITY_IMAGE_RECIPE ?= "iot2050-image-swu-example"
+INITRAMFS_RECIPE ?= "iot2050-initramfs"
 
-PREFERRED_PROVIDER_secure-boot-secrets = "secure-boot-custmpk"
+PREFERRED_PROVIDER_secure-boot-secrets ?= "secure-boot-custmpk"


### PR DESCRIPTION
This patch allows to derive custom swupdate images from the iot2050-debian distro. Previously, derived swu images could not be created as the abrootfs image name could not be overwritten, hence always pointed to the example image. This led to hard-to-debug situations where the boot failed as the image UUIDs did not match.

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>