### PR TITLE
make example image package selections reusable

### DIFF
--- a/recipes-core/images/iot2050-image-example.bb
+++ b/recipes-core/images/iot2050-image-example.bb
@@ -9,92 +9,11 @@
 #
 
 require recipes-core/images/iot2050-image-base.bb
+require recipes-core/images/iot2050-package-selections.inc
 
 DESCRIPTION = "IOT2050 Debian Example Image"
 
 DEPENDS += "openssl"
-
-# debug tools
-IOT2050_DEBIAN_DEBUG_PACKAGES = " \
-    busybox \
-    bash-completion \
-    less \
-    vim \
-    psmisc \
-    bsdmainutils \
-    nano \
-    ifupdown \
-    iputils-ping \
-    ssh \
-    pciutils \
-    usbutils \
-    ethtool \
-    rt-tests \
-    stress-ng \
-    build-essential \
-    python3 \
-    python-is-python3 \
-    gawk \
-    curl \
-    wget \
-    ca-certificates \
-    resolvconf \
-    python3-newt \
-    gdb \
-    gdbserver \
-    gpiod \
-    network-manager \
-    modemmanager \
-    ppp \
-    isc-dhcp-client \
-    cmake \
-    autoconf \
-    autotools-dev \
-    default-jdk \
-    mosquitto \
-    mosquitto-clients \
-    nodejs \
-    npm \
-    teamd \
-    rsyslog \
-    net-tools \
-    i2c-tools \
-    sudo \
-    usb-modeswitch \
-    systemd-timesyncd \
-    "
-
-# wifi support
-IOT2050_DEBIAN_WIFI_PACKAGES = " \
-    iw \
-    wpasupplicant \
-    firmware-ath9k-htc \
-    firmware-atheros \
-    firmware-brcm80211 \
-    firmware-iwlwifi \
-    firmware-libertas \
-    firmware-ralink \
-    firmware-realtek \
-    firmware-ti-connectivity \
-    "
-
-# bluetooth support
-IOT2050_DEBIAN_BT_PACKAGES = " \
-    bluez \
-    pulseaudio-module-bluetooth \
-    "
-
-# alsa support
-IOT2050_DEBIAN_ALSA_PACKAGES = " \
-    alsa-utils \
-    alsa-tools \
-    "
-
-# multiarch support
-IOT2050_DEBIAN_MULTIARCH_PACKAGES = " \
-    libc6:armhf \
-    libstdc++6:armhf \
-    "
 
 IMAGE_PREINSTALL += " \
     ${IOT2050_DEBIAN_DEBUG_PACKAGES} \
@@ -105,12 +24,6 @@ IMAGE_PREINSTALL += " \
     "
 
 IOT2050_DOCKER_SUPPORT ?= "0"
-
-# docker support
-IOT2050_DEBIAN_DOCKER_PACKAGES = " \
-    docker.io \
-    docker-compose \
-    "
 
 IMAGE_PREINSTALL += "${@ ' \
     ${IOT2050_DEBIAN_DOCKER_PACKAGES} \
@@ -134,8 +47,6 @@ IMAGE_INSTALL += " \
 
 IOT2050_CORAL_SUPPORT ?= "1"
 
-IMAGE_INSTALL += "${@ ' \
-    python3-pycoral \
-    pycoral-examples \
-    gasket-module-${KERNEL_NAME} \
-    ' if d.getVar('IOT2050_CORAL_SUPPORT') == '1' else ''}"
+IMAGE_INSTALL += " \
+    ${@ '${IOT2050_CORAL_PACKAGES}' \
+    if d.getVar('IOT2050_CORAL_SUPPORT') == '1' else ''}"

--- a/recipes-core/images/iot2050-package-selections.inc
+++ b/recipes-core/images/iot2050-package-selections.inc
@@ -1,0 +1,103 @@
+#
+# Copyright (c) Siemens AG, 2023
+#
+# Authors:
+#  Su Baocheng <baocheng.su@siemens.com>
+#
+# This file is subject to the terms and conditions of the MIT License.  See
+# COPYING.MIT file in the top-level directory.
+#
+
+# debug tools
+IOT2050_DEBIAN_DEBUG_PACKAGES = " \
+    busybox \
+    bash-completion \
+    less \
+    vim \
+    psmisc \
+    bsdmainutils \
+    nano \
+    ifupdown \
+    iputils-ping \
+    ssh \
+    pciutils \
+    usbutils \
+    ethtool \
+    rt-tests \
+    stress-ng \
+    build-essential \
+    python3 \
+    python-is-python3 \
+    gawk \
+    curl \
+    wget \
+    ca-certificates \
+    resolvconf \
+    python3-newt \
+    gdb \
+    gdbserver \
+    gpiod \
+    network-manager \
+    modemmanager \
+    ppp \
+    isc-dhcp-client \
+    cmake \
+    autoconf \
+    autotools-dev \
+    default-jdk \
+    mosquitto \
+    mosquitto-clients \
+    nodejs \
+    npm \
+    teamd \
+    rsyslog \
+    net-tools \
+    i2c-tools \
+    sudo \
+    usb-modeswitch \
+    systemd-timesyncd \
+    "
+
+# wifi support
+IOT2050_DEBIAN_WIFI_PACKAGES = " \
+    iw \
+    wpasupplicant \
+    firmware-ath9k-htc \
+    firmware-atheros \
+    firmware-brcm80211 \
+    firmware-iwlwifi \
+    firmware-libertas \
+    firmware-ralink \
+    firmware-realtek \
+    firmware-ti-connectivity \
+    "
+
+# bluetooth support
+IOT2050_DEBIAN_BT_PACKAGES = " \
+    bluez \
+    pulseaudio-module-bluetooth \
+    "
+
+# alsa support
+IOT2050_DEBIAN_ALSA_PACKAGES = " \
+    alsa-utils \
+    alsa-tools \
+    "
+
+# multiarch support
+IOT2050_DEBIAN_MULTIARCH_PACKAGES = " \
+    libc6:armhf \
+    libstdc++6:armhf \
+    "
+
+# docker support
+IOT2050_DEBIAN_DOCKER_PACKAGES = " \
+    docker.io \
+    docker-compose \
+    "
+# coral support
+IOT2050_CORAL_PACKAGES = " \
+    python3-pycoral \
+    pycoral-examples \
+    gasket-module-${KERNEL_NAME} \
+    "


### PR DESCRIPTION
This patch carves out the package selections from the example image. The selections provide great value for downstream users that do not want to base their image on the example image, but still want to avoid re-creating these selections to e.g. make wifi work.

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>