### PR TITLE
swupdate: Align completion helper and README to EFI Boot Guard schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,9 @@ You can find more details and options for the command `swupdate` in the [SWUpdat
 
 NOTE: The used SWUpdate package does not contain a web-app example.
 
-SWUpdate will write the image to the unused root partition and
-sets the necessary U-Boot variables.
+SWUpdate will write the image to the unused root partition and updates the EFI
+Boot Guard state. EFI Boot Guard is the bootloader that controls which of the
+two kernels and root file systems are booted.
 
 3. Reboot the system into the new root file system. The switch between the root file systems
 occurs automatically and requires no user interaction.
@@ -166,28 +167,20 @@ After a reboot, the device boots into the new root file system. If the boot is
 successful the update process needs to be completed by calling:
 
 ```shell
-$ complete_update.sh success
+$ complete_update.sh
 ```
 
-The script sets the update state in the U-Boot environment to the initial state.
+The script sets the update state in the EFI Boot Guard configuration to the initial state.
 
 If the update is deemed failed, resetting the device will select the previous root file system.
-Afterwards the failed update is confirmed by calling:
-
-```shell
-$ complete_update.sh failed
-```
-
-This call reverts the U-Boot environment to the initial state.
-After which you have to manually reboot in order to be effective.
 
 ### U-Boot environment
 
 The bootloader environment needs to be adapted to select the correct
 root file system during boot. This adaptation occurs automatically during the
 first boot by executing the `patch-u-boot-env.service`. This systemd-service
-writes the necessary variables (ustate, sysselect) to the U-Boot environment.
-After writing the U-Boot environment, an update with SWUpdate is possible.
+activates the hardware watchdog in the U-Boot environment, setting it to 60
+seconds by default.
 
 #### Revert to the default environment
 

--- a/recipes-core/swupdate-complete-update-helper/files/complete_update.sh
+++ b/recipes-core/swupdate-complete-update-helper/files/complete_update.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) Siemens AG, 2021
+# Copyright (c) Siemens AG, 2021-2023
 #
 # Authors:
 #  Quirin Gylstorff <quirin.gylstorff@siemens.com>
@@ -9,45 +9,23 @@
 
 set -e
 
-USTATE="$(fw_printenv -n ustate | tail -1)"
+eval $(bg_printenv -c -o ustate -r)
 if [ -z "$USTATE" ]; then
-    echo "$0: ustate is not set - abort!"
+    echo "$0: EFI Boot Guard is not configured - abort!"
     exit 1
 fi
 
-case "$1" in
-    success)
-        case "$USTATE" in
-            0)
-                # If no update was pending, ignore this
-                exit 0
-                ;;
-            2)
-                fw_setenv ustate 0
-                exit 0
-                ;;
-            *)
-                echo "$0: attempt to acknowledge while in wrong state('$USTATE' instead of '0')" >&2
-                exit 1
-                ;;
-        esac
+case "$USTATE" in
+0)
+    # If no update was pending, ignore this
+    exit 0
     ;;
-    failed)
-        case "$USTATE" in
-            3)
-                fw_setenv ustate 0
-                exit 0
-                ;;
-            *)
-                echo "$0: attempt to acknowledge failure while in wrong state('$USTATE' instead of '3')" >&2
-                exit 1
-                ;;
-        esac
-        ;;
-    *)
-        echo "usage: $0 <action>" >&2
-        echo "" >&2
-        echo "<action>: 'success', 'failed' " >&2
-        exit 1
-        ;;
+2)
+    bg_setenv -c
+    exit 0
+    ;;
+*)
+    echo "$0: attempt to acknowledge while in wrong state('$USTATE' instead of '2')" >&2
+    exit 1
+    ;;
 esac


### PR DESCRIPTION
This was forgotten when migrating from U-Boot script-based switching to EFI Boot Guard. Simplify the complete_update.sh script at this chance as there is no longer a need to reset any state after a rollback.
@gylstorffq