### PR TITLE
u-boot-iot2050: Make m.2 power control also avaiable to minipcie

### DIFF
--- a/recipes-bsp/u-boot/files/0033-iot2050-Refactor-the-m.2-and-minipcie-power-pin.patch
+++ b/recipes-bsp/u-boot/files/0033-iot2050-Refactor-the-m.2-and-minipcie-power-pin.patch
@@ -1,0 +1,129 @@
+From 6d1a8bcf8438affd65c98857b793bfe45f0a003a Mon Sep 17 00:00:00 2001
+From: Baocheng Su <baocheng.su@siemens.com>
+Date: Mon, 10 Apr 2023 13:25:47 +0800
+Subject: [PATCH] iot2050: Refactor the m.2 and minipcie power pin
+
+Make the m.2 power control pin also available on miniPCIE variants.
+
+This can fix some miniPCIE card hang issue, by forcing a power on reset
+during boot.
+
+Signed-off-by: Baocheng Su <baocheng.su@siemens.com>
+---
+ arch/arm/dts/k3-am65-iot2050-common-pg2.dtsi   |  5 ++++-
+ arch/arm/dts/k3-am65-iot2050-common.dtsi       | 11 +++++++++++
+ arch/arm/dts/k3-am6548-iot2050-advanced-m2.dts |  8 +-------
+ board/siemens/iot2050/board.c                  | 12 ++++++++----
+ 4 files changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/arch/arm/dts/k3-am65-iot2050-common-pg2.dtsi b/arch/arm/dts/k3-am65-iot2050-common-pg2.dtsi
+index e7e0ca4159..c6d9d49c1e 100644
+--- a/arch/arm/dts/k3-am65-iot2050-common-pg2.dtsi
++++ b/arch/arm/dts/k3-am65-iot2050-common-pg2.dtsi
+@@ -20,7 +20,10 @@
+ 
+ &main_gpio1 {
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&cp2102n_reset_pin_default>;
++	pinctrl-0 = <
++		&main_pcie_enable_pins_default
++		&cp2102n_reset_pin_default
++	>;
+ 	gpio-line-names =
+ 		"", "", "", "", "", "", "", "", "", "",
+ 		"", "", "", "", "", "", "", "", "", "",
+diff --git a/arch/arm/dts/k3-am65-iot2050-common.dtsi b/arch/arm/dts/k3-am65-iot2050-common.dtsi
+index 65da226847..e60006bec2 100644
+--- a/arch/arm/dts/k3-am65-iot2050-common.dtsi
++++ b/arch/arm/dts/k3-am65-iot2050-common.dtsi
+@@ -233,6 +233,12 @@
+ };
+ 
+ &main_pmx0 {
++	main_pcie_enable_pins_default: main-pcie-enable-pins-default {
++		pinctrl-single,pins = <
++			AM65X_IOPAD(0x01c4, PIN_INPUT_PULLUP, 7)  /* (AH13) GPIO1_17 */
++		>;
++	};
++
+ 	main_uart1_pins_default: main-uart1-pins-default {
+ 		pinctrl-single,pins = <
+ 			AM65X_IOPAD(0x0174, PIN_INPUT,  6)  /* (AE23) UART1_RXD */
+@@ -385,6 +391,11 @@
+ 		"", "IO9";
+ };
+ 
++&main_gpio1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&main_pcie_enable_pins_default>;
++};
++
+ &wkup_gpio0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <
+diff --git a/arch/arm/dts/k3-am6548-iot2050-advanced-m2.dts b/arch/arm/dts/k3-am6548-iot2050-advanced-m2.dts
+index cb0f3a8729..99a519fd8b 100644
+--- a/arch/arm/dts/k3-am6548-iot2050-advanced-m2.dts
++++ b/arch/arm/dts/k3-am6548-iot2050-advanced-m2.dts
+@@ -27,12 +27,6 @@
+ };
+ 
+ &main_pmx0 {
+-	main_m2_enable_pins_default: main-m2-enable-pins-default {
+-		pinctrl-single,pins = <
+-			AM65X_IOPAD(0x01c4, PIN_INPUT_PULLUP, 7)  /* (AH13) GPIO1_17 */
+-		>;
+-	};
+-
+ 	main_bkey_pcie_reset: main-bkey-pcie-reset {
+ 		pinctrl-single,pins = <
+ 			AM65X_IOPAD(0x01bc, PIN_OUTPUT_PULLUP, 7)  /* (AG13) GPIO1_15 */
+@@ -72,7 +66,7 @@
+ &main_gpio1 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <
+-		&main_m2_enable_pins_default
++		&main_pcie_enable_pins_default
+ 		&main_pmx0_m2_config_pins_default
+ 		&main_pmx1_m2_config_pins_default
+ 	>;
+diff --git a/board/siemens/iot2050/board.c b/board/siemens/iot2050/board.c
+index 2e90d3bd8c..a0b12c564a 100644
+--- a/board/siemens/iot2050/board.c
++++ b/board/siemens/iot2050/board.c
+@@ -178,6 +178,12 @@ static void remove_mmc1_target(void)
+ 	free(boot_targets);
+ }
+ 
++static void enable_mpcie_m2_power(void)
++{
++	set_pinvalue("gpio@601000_17", "P3V3_MPCIE_M2_EN", 1);
++	udelay(4 * 100);
++}
++
+ void set_board_info_env(void)
+ {
+ 	struct iot2050_info *info = IOT2050_INFO_DATA;
+@@ -281,10 +287,6 @@ static void m2_connector_setup(void)
+ 	struct m2_config_pins config_pins;
+ 	unsigned int n;
+ 
+-	/* enable M.2 connector power */
+-	set_pinvalue("gpio@601000_17", "P3V3_M2_EN", 1);
+-	udelay(4 * 100);
+-
+ 	if (m2_manual_config < CONNECTOR_MODE_INVALID) {
+ 		mode_info = " [manual mode]";
+ 		connector_mode = m2_manual_config;
+@@ -422,6 +424,8 @@ int board_late_init(void)
+ 	/* change CTRL_MMR register to let serdes0 not output USB3.0 signals. */
+ 	writel(0x3, SERDES0_LANE_SELECT);
+ 
++	enable_mpcie_m2_power();
++
+ 	if (board_is_m2())
+ 		m2_connector_setup();
+ 
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/u-boot-iot2050_2022.01.inc
+++ b/recipes-bsp/u-boot/u-boot-iot2050_2022.01.inc
@@ -45,6 +45,7 @@ SRC_URI += " \
     file://0030-efi_loader-signature-export-efi_hash_regions.patch \
     file://0031-efi_loader-image_loader-add-a-missing-digest-verific.patch \
     file://0032-spl-fit-Report-fdt-error-for-loading-u-boot.patch \
+    file://0033-iot2050-Refactor-the-m.2-and-minipcie-power-pin.patch \
     "
 
 SRC_URI[sha256sum] = "81b4543227db228c03f8a1bf5ddbc813b0bb8f6555ce46064ef721a6fc680413"


### PR DESCRIPTION
Issue is that sometimes, some miniPCIE card hangs, due to firmware/software issue. Such hang could not be recovered by software reset, since it is not power on reset.

However, the power supply design on M.2 variant, that control the 3.3V power pin through a GPIO is proven to work against such scenario. With this GPIO, during boot, a POR will be triggered to fully recover the miniPCIE or M.2 module.

So port this design also to the miniPCIE variants.

The target branch is stable/V01.03