### PR TITLE
Bennie/mraa pinmux fix

### DIFF
--- a/recipes-app/mraa/files/0002-common-increase-pin-name-size.patch
+++ b/recipes-app/mraa/files/0002-common-increase-pin-name-size.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+Date: Mon, 27 Feb 2023 16:31:13 +0100
+Subject: [PATCH] common: increase pin name size
+
+Some pin names are longer than 12 characters.
+32 characters should be enough while consuming not too
+much space.
+
+Signed-off-by: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+---
+ api/mraa/common.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/api/mraa/common.h b/api/mraa/common.h
+index 6675f2d15771..13df2f1681fe 100644
+--- a/api/mraa/common.h
++++ b/api/mraa/common.h
+@@ -32,7 +32,7 @@
+ /** Max size off Mraa Platform name */
+ #define MRAA_PLATFORM_NAME_MAX_SIZE 64
+ /** Size off Mraa pin name */
+-#define MRAA_PIN_NAME_SIZE 12
++#define MRAA_PIN_NAME_SIZE 32
+ 
+ /** Bit Shift for Mraa sub platform */
+ #define MRAA_SUB_PLATFORM_BIT_SHIFT 9

--- a/recipes-app/mraa/files/0003-iot2050-add-debugfs-pinmux-support.patch
+++ b/recipes-app/mraa/files/0003-iot2050-add-debugfs-pinmux-support.patch
@@ -1,0 +1,796 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+Date: Thu, 23 Mar 2023 10:21:58 +0100
+Subject: [PATCH] iot2050: add debugfs pinmux support
+
+This patch adds support for multiplexing pins via debugfs rather
+than access memory mapped pad-configuration registers.
+The debugfs pinmux offers the possbility to run mraa on iot2050
+platforms as regular user instead of root by adjusting privileges
+on debugfs files.
+
+Bias settings are currently also configured by accessing pinmux.
+Unfortunatelly a proper upstream-like pinconf usage is currently
+not possible.
+
+Note: In case debugfs mux fails MRAA falls back to mmap mux.
+
+Signed-off-by: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+---
+ src/arm/siemens/iot2050.c  | 547 ++++++++++++++++++++++++++++++++++++-
+ src/arm/siemens/platform.c |   4 +-
+ 2 files changed, 540 insertions(+), 11 deletions(-)
+
+diff --git a/src/arm/siemens/iot2050.c b/src/arm/siemens/iot2050.c
+index cec25faf0547..d315733d5ef4 100644
+--- a/src/arm/siemens/iot2050.c
++++ b/src/arm/siemens/iot2050.c
+@@ -24,6 +24,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <sys/mman.h>
++#include <limits.h>
+ #include <mraa/types.h>
+ 
+ #include "common.h"
+@@ -39,6 +40,9 @@ typedef struct {
+     uint16_t    index;
+     uint16_t    pinmap;
+     int8_t      mode[MAX_MUX_REGISTER_MODE];
++    const char *debugfs_path[MAX_MUX_REGISTER_MODE];
++    const char *pmx_function[MAX_MUX_REGISTER_MODE];
++    const char *pmx_group[MAX_MUX_REGISTER_MODE];
+ }regmux_info_t;
+ 
+ static void *pinmux_instance = NULL;
+@@ -75,30 +79,126 @@ iot2050_get_regmux_by_pinmap(int pinmap)
+     return NULL;
+ }
+ 
++static mraa_result_t
++iot2050_mux_debugfs(const char *base_dir, const char *group, const char *function, mraa_gpio_mode_t gpio_mode)
++{
++    FILE *fd = NULL;
++    char p_pinmux[PATH_MAX];
++    char mux[MRAA_PIN_NAME_SIZE];
++    int ret;
++
++    syslog(LOG_DEBUG, "iot2050: debugfs: enter\n");
++
++    if (!base_dir || !group || !function) {
++        syslog(LOG_ERR, "iot2050: debugfs: Invalid parameter base_dir=%s, group=%s, function=%s!\n", base_dir, group, function);
++        return MRAA_ERROR_INVALID_PARAMETER;
++    }
++
++    ret = snprintf(p_pinmux, PATH_MAX, "/sys/kernel/debug/pinctrl/%s/pinmux-select", base_dir);
++    if (ret < 0) {
++        ret = MRAA_ERROR_UNSPECIFIED;
++        goto err;
++    }
++
++    fd = fopen(p_pinmux, "w");
++    if (!fd) {
++        ret = MRAA_ERROR_INVALID_RESOURCE;
++        goto err;
++    }
++
++    switch (gpio_mode) {
++        case MRAA_GPIO_PULLUP:
++            snprintf(mux, MRAA_PIN_NAME_SIZE, "%s-%s", group, "pullup");
++            break;
++        case MRAA_GPIO_PULLDOWN:
++            snprintf(mux, MRAA_PIN_NAME_SIZE, "%s-%s", group, "pulldown");
++            break;
++        default:
++            strncpy(mux, group, MRAA_PIN_NAME_SIZE);
++    }
++
++    syslog(LOG_DEBUG, "iot2050: debugfs: group: %s, function: %s\n", mux, mux);
++
++    ret = fprintf(fd, "%s %s\n", mux, mux);
++    if (ret < 0) {
++        ret = MRAA_ERROR_UNSPECIFIED;
++        goto err_close;
++    }
++
++    fclose(fd);
++    return MRAA_SUCCESS;
++
++err_close:
++    fclose(fd);
++err:
++    syslog(LOG_ERR, "iot2050: debugfs: Pinmux failed(%d)! group: %s, function: %s", ret, group, function);
++    return ret;
++}
++
++static mraa_result_t
++iot2050_mux_mmap(int phy_pin, int mode, mraa_gpio_mode_t gpio_mode)
++{
++    int8_t mux_mode;
++    regmux_info_t *info = &pinmux_info[phy_pin];
++
++    syslog(LOG_ERR, "iot2050: mmap: Debugfs pinmux failed! Falling back to mmap!");
++
++    pinmux_instance = platfrom_pinmux_get_instance("iot2050");
++    if (!pinmux_instance) {
++        syslog(LOG_ERR, "iot2050: mmap: Pinmux failed! Can't get pinmux instance!");
++        return MRAA_ERROR_INVALID_RESOURCE;
++    }
++
++    mux_mode = info->mode[mode];
++    if (mux_mode < 0) {
++        return MRAA_ERROR_FEATURE_NOT_SUPPORTED;
++    }
++
++    syslog(LOG_DEBUG, "REGMUX[phy_pin %d] group %d index %d mode %d\n", phy_pin, info->group, info->index, mux_mode);
++
++    platform_pinmux_select_func(pinmux_instance, info->group, info->index, mux_mode);
++    /* Configure as input and output for default */
++    platform_pinmux_select_inout(pinmux_instance, info->group, info->index);
++
++    switch (gpio_mode) {
++        case MRAA_GPIO_PULLUP:
++            platform_pinmux_select_pull_up(pinmux_instance, info->group, info->index);
++            break;
++        case MRAA_GPIO_PULLDOWN:
++            platform_pinmux_select_pull_down(pinmux_instance, info->group, info->index);
++            break;
++        default:
++            break;
++    }
++    return MRAA_SUCCESS;
++}
++
++
+ static mraa_result_t
+ iot2050_mux_init_reg(int phy_pin, int mode)
+ {
+     regmux_info_t *info = &pinmux_info[phy_pin];
+     int8_t mux_mode;
++    mraa_result_t ret;
+ 
+     if((phy_pin < 0) || (phy_pin > MRAA_IOT2050_PINCOUNT))
+         return MRAA_SUCCESS;
+     if((mode < 0) || (mode >= MAX_MUX_REGISTER_MODE)) {
+         return MRAA_ERROR_FEATURE_NOT_SUPPORTED;
+     }
+-    if(mode == MUX_REGISTER_MODE_AIO) {
++    /* Dedicated SoC pins that have been statically defined in DTB */
++    if(mode == MUX_REGISTER_MODE_AIO || mode == MUX_REGISTER_MODE_I2C) {
+         return MRAA_SUCCESS;
+     }
+     mux_mode = info->mode[mode];
+     if(mux_mode < 0) {
+         return MRAA_ERROR_FEATURE_NOT_SUPPORTED;
+     }
+-    syslog(LOG_DEBUG, "REGMUX[phy_pin %d] group %d index %d mode %d\n", phy_pin, info->group, info->index, mux_mode);
+ 
+-    platform_pinmux_select_func(pinmux_instance, info->group, info->index, mux_mode);
+-    /* Configure as input and output for default */
+-    platform_pinmux_select_inout(pinmux_instance, info->group, info->index);
+-    return MRAA_SUCCESS;
++    ret = iot2050_mux_debugfs(info->debugfs_path[mode], info->pmx_group[mode], info->pmx_function[mode], 0);
++    if (ret != MRAA_SUCCESS)
++        return iot2050_mux_mmap(phy_pin, mode, 0);
++    return ret;
+ }
+ 
+ static mraa_result_t
+@@ -172,7 +272,10 @@ iot2050_gpio_mode_replace(mraa_gpio_context dev, mraa_gpio_mode_t mode)
+                 goto failed;
+             }
+             if(info) {
+-                platform_pinmux_select_pull_up(pinmux_instance, info->group, info->index);
++                ret = iot2050_mux_debugfs(info->debugfs_path[0], info->pmx_group[0], info->pmx_function[0], mode);
++                if (ret != MRAA_SUCCESS)
++                    ret = iot2050_mux_mmap(dev->phy_pin, 0, mode);
++
+             }
+             break;
+         case MRAA_GPIO_PULLDOWN:
+@@ -181,7 +284,9 @@ iot2050_gpio_mode_replace(mraa_gpio_context dev, mraa_gpio_mode_t mode)
+                 goto failed;
+             }
+             if(info) {
+-                platform_pinmux_select_pull_down(pinmux_instance, info->group, info->index);
++                ret = iot2050_mux_debugfs(info->debugfs_path[0], info->pmx_group[0], info->pmx_function[0], mode);
++                if (ret != MRAA_SUCCESS)
++                    ret = iot2050_mux_mmap(dev->phy_pin, 0, mode);
+             }
+             break;
+         case MRAA_GPIO_HIZ:
+@@ -191,7 +296,9 @@ iot2050_gpio_mode_replace(mraa_gpio_context dev, mraa_gpio_mode_t mode)
+                 goto failed;
+             }
+             if(info) {
+-                platform_pinmux_select_pull_disable(pinmux_instance, info->group, info->index);
++                ret = iot2050_mux_debugfs(info->debugfs_path[0], info->pmx_group[0], info->pmx_function[0], mode);
++                if (ret != MRAA_SUCCESS)
++                    ret = iot2050_mux_mmap(dev->phy_pin, 0, mode);
+             }
+             break;
+         case MRAA_GPIOD_ACTIVE_LOW:
+@@ -455,7 +562,7 @@ mraa_siemens_iot2050()
+         free(b->adv_func);
+         goto error;
+     }
+-    pinmux_instance = platfrom_pinmux_get_instance("iot2050");
++
+     /* IO */
+     iot2050_setup_pins(b, pin_index, "IO0",
+                         (mraa_pincapabilities_t) {
+@@ -477,6 +584,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 -1, /*SPI*/
+                                 -1  /*PWM*/
++                            },
++                            {
++                                "4301c000.pinctrl-pinctrl-single",
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "d0-gpio",
++                                "d0-uart0-rxd",
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "d0-gpio",
++                                "d0-uart0-rxd",
++                                NULL,
++                                NULL,
++                                NULL
+                             }
+                         });
+ 
+@@ -510,6 +638,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 -1, /*SPI*/
+                                 -1  /*PWM*/
++                            },
++                            {
++                                "4301c000.pinctrl-pinctrl-single",
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "d1-gpio",
++                                "d1-uart0-txd",
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "d1-gpio",
++                                "d1-uart0-txd",
++                                NULL,
++                                NULL,
++                                NULL
+                             }
+                         });
+     iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 30, d4201_gpio_base+1, d4202_gpio_base+1, NULL, 0);
+@@ -542,6 +691,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 -1, /*SPI*/
+                                 -1  /*PWM*/
++                            },
++                            {
++                                "4301c000.pinctrl-pinctrl-single",
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "d2-gpio",
++                                "d1-uart0-ctsn",
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "d2-gpio",
++                                "d1-uart0-ctsn",
++                                NULL,
++                                NULL,
++                                NULL
+                             }
+                         });
+     iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 31, d4201_gpio_base+2, d4202_gpio_base+2, NULL, 0);
+@@ -574,6 +744,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 -1, /*SPI*/
+                                 -1  /*PWM*/
++                            },
++                            {
++                                "4301c000.pinctrl-pinctrl-single",
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "d3-gpio",
++                                "d3-uart0-rtsn",
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "d3-gpio",
++                                "d3-uart0-rtsn",
++                                NULL,
++                                NULL,
++                                NULL
+                             }
+                         });
+     iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 33, d4201_gpio_base+3, d4202_gpio_base+3, NULL, 0);
+@@ -606,6 +797,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 -1, /*SPI*/
+                                 5   /*PWM*/
++                            },
++                            {
++                                "11c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "11c000.pinctrl-pinctrl-single"
++                            },
++                            {
++                                "d4-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "d4-ehrpwm0-a"
++                            },
++                            {
++                                "d4-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "d4-ehrpwm0-a"
+                             }
+                         });
+     iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 33, d4201_gpio_base+4, d4202_gpio_base+4, NULL, 0);
+@@ -638,6 +850,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 -1, /*SPI*/
+                                 5   /*PWM*/
++                            },
++                            {
++                                "11c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "11c000.pinctrl-pinctrl-single"
++                            },
++                            {
++                                "d5-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "d5-ehrpwm1-a"
++                            },
++                            {
++                                "d5-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "d5-ehrpwm1-a"
+                             }
+                         });
+     iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 35, d4201_gpio_base+5, d4202_gpio_base+5, NULL, 0);
+@@ -670,6 +903,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 -1, /*SPI*/
+                                 5   /*PWM*/
++                            },
++                            {
++                                "11c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "11c000.pinctrl-pinctrl-single"
++                            },
++                            {
++                                "d6-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "d6-ehrpwm2-a"
++                            },
++                            {
++                                "d6-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "d6-ehrpwm2-a"
+                             }
+                         });
+     iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 38, d4201_gpio_base+6, d4202_gpio_base+6, NULL, 0);
+@@ -702,6 +956,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 -1, /*SPI*/
+                                 5   /*PWM*/
++                            },
++                            {
++                                "11c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "11c000.pinctrl-pinctrl-single"
++                            },
++                            {
++                                "d7-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "d7-ehrpwm3-a"
++                            },
++                            {
++                                "d7-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "d7-ehrpwm3-a"
+                             }
+                         });
+     iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 43, d4201_gpio_base+7, d4202_gpio_base+7, NULL, 0);
+@@ -734,6 +1009,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 -1, /*SPI*/
+                                 5   /*PWM*/
++                            },
++                            {
++                                "11c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "11c000.pinctrl-pinctrl-single"
++                            },
++                            {
++                                "d8-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "d8-ehrpwm4-a"
++                            },
++                            {
++                                "d8-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "d8-ehrpwm4-a"
+                             }
+                         });
+     iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 48, d4201_gpio_base+8, d4202_gpio_base+8, NULL, 0);
+@@ -766,6 +1062,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 -1, /*SPI*/
+                                 5   /*PWM*/
++                            },
++                            {
++                                "11c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "11c000.pinctrl-pinctrl-single"
++                            },
++                            {
++                                "d9-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "d9-ehrpwm5-a"
++                            },
++                            {
++                                "d9-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                "d9-ehrpwm5-a"
+                             }
+                         });
+     iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 51, d4201_gpio_base+9, d4202_gpio_base+9, NULL, 0);
+@@ -798,6 +1115,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 0, /*SPI*/
+                                 -1  /*PWM*/
++                            },
++                            {
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL
++                            },
++                            {
++                                "d10-gpio",
++                                NULL,
++                                NULL,
++                                "d10-spi0-cs0",
++                                NULL
++                            },
++                            {
++                                "d10-gpio",
++                                NULL,
++                                NULL,
++                                "d10-spi0-cs0",
++                                NULL
+                             }
+                         });
+     iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 51, d4201_gpio_base+10, d4202_gpio_base+10, NULL, 0);
+@@ -830,6 +1168,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 0, /*SPI*/
+                                 -1  /*PWM*/
++                            },
++                            {
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL
++                            },
++                            {
++                                "d11-gpio",
++                                NULL,
++                                NULL,
++                                "d11-spi0-d0",
++                                NULL
++                            },
++                            {
++                                "d11-gpio",
++                                NULL,
++                                NULL,
++                                "d11-spi0-d0",
++                                NULL
+                             }
+                         });
+     iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 49, d4201_gpio_base+11, d4202_gpio_base+11, NULL, 0);
+@@ -862,6 +1221,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 0, /*SPI*/
+                                 -1  /*PWM*/
++                            },
++                            {
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL
++                            },
++                            {
++                                "d12-gpio",
++                                NULL,
++                                NULL,
++                                "d12-spi0-d1",
++                                NULL
++                            },
++                            {
++                                "d12-gpio",
++                                NULL,
++                                NULL,
++                                "d12-spi0-d1",
++                                NULL
+                             }
+                         });
+     iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 50, d4201_gpio_base+12, d4202_gpio_base+12, NULL, 0);
+@@ -894,6 +1274,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 0, /*SPI*/
+                                 -1  /*PWM*/
++                            },
++                            {
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL
++                            },
++                            {
++                                "d13-gpio",
++                                NULL,
++                                NULL,
++                                "d13-spi0-clk",
++                                NULL
++                            },
++                            {
++                                "d13-gpio",
++                                NULL,
++                                NULL,
++                                "d13-spi0-clk",
++                                NULL
+                             }
+                         });
+     iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 48, d4201_gpio_base+13, d4202_gpio_base+13, NULL, 0);
+@@ -926,6 +1327,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 -1, /*SPI*/
+                                 -1  /*PWM*/
++                            },
++                            {
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "a0-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "a0-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
+                             }
+                         });
+     mux_info[0].pin = d4200_gpio_base+8;
+@@ -971,6 +1393,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 -1, /*SPI*/
+                                 -1  /*PWM*/
++                            },
++                            {
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "a1-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "a1-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
+                             }
+                         });
+     mux_info[0].pin = d4200_gpio_base+9;
+@@ -1016,6 +1459,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 -1, /*SPI*/
+                                 -1  /*PWM*/
++                            },
++                            {
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "a2-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "a2-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
+                             }
+                         });
+     mux_info[0].pin = d4200_gpio_base+10;
+@@ -1061,6 +1525,27 @@ mraa_siemens_iot2050()
+                                 -1, /*I2C*/
+                                 -1, /*SPI*/
+                                 -1  /*PWM*/
++                            },
++                            {
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "a3-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "a3-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
+                             }
+                         });
+     mux_info[0].pin = d4200_gpio_base+11;
+@@ -1106,6 +1591,27 @@ mraa_siemens_iot2050()
+                                 0,  /*I2C*/
+                                 -1, /*SPI*/
+                                 -1  /*PWM*/
++                            },
++                            {
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "a4-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "a4-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
+                             }
+                         });
+     mux_info[0].pin = d4200_gpio_base+12;
+@@ -1169,6 +1675,27 @@ mraa_siemens_iot2050()
+                                 0,  /*I2C*/
+                                 -1, /*SPI*/
+                                 -1  /*PWM*/
++                            },
++                            {
++                                "4301c000.pinctrl-pinctrl-single",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "a5-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
++                            },
++                            {
++                                "a5-gpio",
++                                NULL,
++                                NULL,
++                                NULL,
++                                NULL
+                             }
+                         });
+     mux_info[0].pin = d4200_gpio_base+13;
+diff --git a/src/arm/siemens/platform.c b/src/arm/siemens/platform.c
+index faa808a4c6d0..fb87a7f2c47a 100644
+--- a/src/arm/siemens/platform.c
++++ b/src/arm/siemens/platform.c
+@@ -35,7 +35,9 @@ platfrom_pinmux_get_instance(char *platform)
+     if((instance) && (instance->initialized == false) && (instance->ops.init)) {
+         return instance->ops.init()?instance:NULL;
+     }
+-    else {
++    else if((instance) && (instance->initialized == true)) {
++        return instance;
++    } else {
+         return NULL;
+     }
+ }

--- a/recipes-app/mraa/mraa_2.2.0+git.bb
+++ b/recipes-app/mraa/mraa_2.2.0+git.bb
@@ -13,6 +13,8 @@ DESCRIPTION = "Low Level Skeleton Library for Communication on GNU/Linux platfor
 MAINTAINER = "le.jin@siemens.com"
 SRC_URI += "git://github.com/eclipse/mraa.git;protocol=https;branch=master \
             file://0001-gpio-Fix-JS-binding-regarding-interrupt-injections.patch \
+            file://0002-common-increase-pin-name-size.patch \
+            file://0003-iot2050-add-debugfs-pinmux-support.patch \
             file://rules"
 SRCREV = "8b1c54934e80edc2d36abac9d9c96fe1e01cb669"
 

--- a/recipes-kernel/linux/files/patches-5.10/0211-pinctrl-pinmux-add-function-selector-to-pinmux-funct.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0211-pinctrl-pinmux-add-function-selector-to-pinmux-funct.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Drew Fustini <drew@beagleboard.org>
+Date: Sat, 23 Jan 2021 12:22:14 -0800
+Subject: [PATCH] pinctrl: pinmux: add function selector to pinmux-functions
+
+Add the function selector to the pinmux-functions debugfs output. This
+is an integer which is the index into the pinmux function tree.  It will
+make it easier to correlate function name to function selector without
+having to count the lines in the output.
+
+Example output of "pinmux-functions":
+
+function 0: pinmux-uart0-pins, groups = [ pinmux-uart0-pins ]
+function 1: pinmux-uart1-pins, groups = [ pinmux-uart1-pins ]
+function 2: pinmux-uart2-pins, groups = [ pinmux-uart2-pins ]
+function 3: pinmux-mmc0-pins, groups = [ pinmux-mmc0-pins ]
+function 3: pinmux-mmc1-pins, groups = [ pinmux-mmc1-pins ]
+function 5: pinmux-i2c0-pins, groups = [ pinmux-i2c0-pins ]
+function 6: pinmux-i2c1-pins, groups = [ pinmux-i2c1-pins ]
+function 7: pinmux-i2c2-pins, groups = [ pinmux-i2c2-pins ]
+function 8: pinmux-pwm0-pins, groups = [ pinmux-pwm0-pins ]
+function 9: pinmux-pwm1-pins, groups = [ pinmux-pwm1-pins ]
+function 10: pinmux-adc-pins, groups = [ pinmux-adc-pins ]
+
+Cc: Jason Kridner <jkridner@beagleboard.org>
+Cc: Robert Nelson <robertcnelson@beagleboard.org>
+Cc: Linus Walleij <linus.walleij@linaro.org>
+Cc: Tony Lindgren <tony@atomide.com>
+Cc: Andy Shevchenko <andy.shevchenko@gmail.com>
+Cc: Alexandre Belloni <alexandre.belloni@bootlin.com>
+Signed-off-by: Drew Fustini <drew@beagleboard.org>
+Link: https://lore.kernel.org/r/20210123202212.528046-1-drew@beagleboard.org
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/pinmux.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/pinctrl/pinmux.c b/drivers/pinctrl/pinmux.c
+index bab888fe3f8e..36a11c9e893a 100644
+--- a/drivers/pinctrl/pinmux.c
++++ b/drivers/pinctrl/pinmux.c
+@@ -564,7 +564,7 @@ static int pinmux_functions_show(struct seq_file *s, void *what)
+ 			continue;
+ 		}
+ 
+-		seq_printf(s, "function: %s, groups = [ ", func);
++		seq_printf(s, "function %d: %s, groups = [ ", func_selector, func);
+ 		for (i = 0; i < num_groups; i++)
+ 			seq_printf(s, "%s ", groups[i]);
+ 		seq_puts(s, "]\n");

--- a/recipes-kernel/linux/files/patches-5.10/0212-pinctrl-single-set-function-name-when-adding-functio.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0212-pinctrl-single-set-function-name-when-adding-functio.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Drew Fustini <drew@beagleboard.org>
+Date: Mon, 25 Jan 2021 12:35:43 -0800
+Subject: [PATCH] pinctrl: single: set function name when adding function
+
+pcs_add_function() fails to set the function name in struct pcs_function
+when adding a new function.  As a result this line in pcs_set_mux():
+
+        dev_dbg(pcs->dev, "enabling %s function%i\n",
+                func->name, fselector);
+
+prints "(null)" for the function:
+
+pinctrl-single 44e10800.pinmux: enabling (null) function0
+pinctrl-single 44e10800.pinmux: enabling (null) function1
+pinctrl-single 44e10800.pinmux: enabling (null) function2
+pinctrl-single 44e10800.pinmux: enabling (null) function3
+
+With this fix, the output is now:
+
+pinctrl-single 44e10800.pinmux: enabling pinmux-uart0-pins function0
+pinctrl-single 44e10800.pinmux: enabling pinmux-mmc0-pins function1
+pinctrl-single 44e10800.pinmux: enabling pinmux-i2c0-pins function2
+pinctrl-single 44e10800.pinmux: enabling pinmux-mmc0-pins function3
+
+Cc: Jason Kridner <jkridner@beagleboard.org>
+Cc: Robert Nelson <robertcnelson@beagleboard.org>
+Cc: Linus Walleij <linus.walleij@linaro.org>
+Cc: Tony Lindgren <tony@atomide.com>
+Signed-off-by: Drew Fustini <drew@beagleboard.org>
+Acked-by: Tony Lindgren <tony@atomide.com>
+Link: https://lore.kernel.org/r/20210125203542.51513-1-drew@beagleboard.org
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/pinctrl-single.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/pinctrl/pinctrl-single.c b/drivers/pinctrl/pinctrl-single.c
+index d139cd9e6d13..e366bf9416ce 100644
+--- a/drivers/pinctrl/pinctrl-single.c
++++ b/drivers/pinctrl/pinctrl-single.c
+@@ -788,6 +788,7 @@ static int pcs_add_function(struct pcs_device *pcs,
+ 
+ 	function->vals = vals;
+ 	function->nvals = nvals;
++	function->name = name;
+ 
+ 	selector = pinmux_generic_add_function(pcs->pctl, name,
+ 					       pgnames, npgnames,

--- a/recipes-kernel/linux/files/patches-5.10/0213-pinctrl-use-to-octal-permissions-for-debugfs-files.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0213-pinctrl-use-to-octal-permissions-for-debugfs-files.patch
@@ -1,0 +1,92 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Drew Fustini <drew@beagleboard.org>
+Date: Mon, 1 Mar 2021 21:30:56 -0800
+Subject: [PATCH] pinctrl: use to octal permissions for debugfs files
+
+Switch over pinctrl debugfs files to use octal permissions as they are
+preferred over symbolic permissions. Refer to commit f90774e1fd27
+("checkpatch: look for symbolic permissions and suggest octal instead").
+
+Note: S_IFREG flag is added to the mode by __debugfs_create_file()
+in fs/debugfs/inode.c
+
+Suggested-by: Joe Perches <joe@perches.com>
+Suggested-by: Andy Shevchenko <andy.shevchenko@gmail.com>
+Reviewed-by: Andy Shevchenko <andy.shevchenko@gmail.com>
+Reviewed-by: Geert Uytterhoeven <geert+renesas@glider.be>
+Reviewed-by: Tony Lindgren <tony@atomide.com>
+Signed-off-by: Drew Fustini <drew@beagleboard.org>
+Link: https://lore.kernel.org/r/20210302053059.1049035-2-drew@beagleboard.org
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/core.c    | 12 ++++++------
+ drivers/pinctrl/pinconf.c |  4 ++--
+ drivers/pinctrl/pinmux.c  |  4 ++--
+ 3 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/pinctrl/core.c b/drivers/pinctrl/core.c
+index 840000870d5a..aa5a1178c8eb 100644
+--- a/drivers/pinctrl/core.c
++++ b/drivers/pinctrl/core.c
+@@ -1892,11 +1892,11 @@ static void pinctrl_init_device_debugfs(struct pinctrl_dev *pctldev)
+ 			dev_name(pctldev->dev));
+ 		return;
+ 	}
+-	debugfs_create_file("pins", S_IFREG | S_IRUGO,
++	debugfs_create_file("pins", 0444,
+ 			    device_root, pctldev, &pinctrl_pins_fops);
+-	debugfs_create_file("pingroups", S_IFREG | S_IRUGO,
++	debugfs_create_file("pingroups", 0444,
+ 			    device_root, pctldev, &pinctrl_groups_fops);
+-	debugfs_create_file("gpio-ranges", S_IFREG | S_IRUGO,
++	debugfs_create_file("gpio-ranges", 0444,
+ 			    device_root, pctldev, &pinctrl_gpioranges_fops);
+ 	if (pctldev->desc->pmxops)
+ 		pinmux_init_device_debugfs(device_root, pctldev);
+@@ -1918,11 +1918,11 @@ static void pinctrl_init_debugfs(void)
+ 		return;
+ 	}
+ 
+-	debugfs_create_file("pinctrl-devices", S_IFREG | S_IRUGO,
++	debugfs_create_file("pinctrl-devices", 0444,
+ 			    debugfs_root, NULL, &pinctrl_devices_fops);
+-	debugfs_create_file("pinctrl-maps", S_IFREG | S_IRUGO,
++	debugfs_create_file("pinctrl-maps", 0444,
+ 			    debugfs_root, NULL, &pinctrl_maps_fops);
+-	debugfs_create_file("pinctrl-handles", S_IFREG | S_IRUGO,
++	debugfs_create_file("pinctrl-handles", 0444,
+ 			    debugfs_root, NULL, &pinctrl_fops);
+ }
+ 
+diff --git a/drivers/pinctrl/pinconf.c b/drivers/pinctrl/pinconf.c
+index 02c075cc010b..d9d54065472e 100644
+--- a/drivers/pinctrl/pinconf.c
++++ b/drivers/pinctrl/pinconf.c
+@@ -370,9 +370,9 @@ DEFINE_SHOW_ATTRIBUTE(pinconf_groups);
+ void pinconf_init_device_debugfs(struct dentry *devroot,
+ 			 struct pinctrl_dev *pctldev)
+ {
+-	debugfs_create_file("pinconf-pins", S_IFREG | S_IRUGO,
++	debugfs_create_file("pinconf-pins", 0444,
+ 			    devroot, pctldev, &pinconf_pins_fops);
+-	debugfs_create_file("pinconf-groups", S_IFREG | S_IRUGO,
++	debugfs_create_file("pinconf-groups", 0444,
+ 			    devroot, pctldev, &pinconf_groups_fops);
+ }
+ 
+diff --git a/drivers/pinctrl/pinmux.c b/drivers/pinctrl/pinmux.c
+index 36a11c9e893a..9c0174520e78 100644
+--- a/drivers/pinctrl/pinmux.c
++++ b/drivers/pinctrl/pinmux.c
+@@ -676,9 +676,9 @@ DEFINE_SHOW_ATTRIBUTE(pinmux_pins);
+ void pinmux_init_device_debugfs(struct dentry *devroot,
+ 			 struct pinctrl_dev *pctldev)
+ {
+-	debugfs_create_file("pinmux-functions", S_IFREG | S_IRUGO,
++	debugfs_create_file("pinmux-functions", 0444,
+ 			    devroot, pctldev, &pinmux_functions_fops);
+-	debugfs_create_file("pinmux-pins", S_IFREG | S_IRUGO,
++	debugfs_create_file("pinmux-pins", 0444,
+ 			    devroot, pctldev, &pinmux_pins_fops);
+ }
+ 

--- a/recipes-kernel/linux/files/patches-5.10/0214-pinctrl-pinmux-Add-pinmux-select-debugfs-file.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0214-pinctrl-pinmux-Add-pinmux-select-debugfs-file.patch
@@ -1,0 +1,165 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Drew Fustini <drew@beagleboard.org>
+Date: Mon, 1 Mar 2021 21:30:57 -0800
+Subject: [PATCH] pinctrl: pinmux: Add pinmux-select debugfs file
+
+Add "pinmux-select" to debugfs which will activate a pin function for a
+given pin group:
+
+  echo "<group-name function-name>" > pinmux-select
+
+The write operation pinmux_select() handles this by checking that the
+names map to valid selectors and then calling ops->set_mux().
+
+The existing "pinmux-functions" debugfs file lists the pin functions
+registered for the pin controller. For example:
+
+  function: pinmux-uart0, groups = [ pinmux-uart0-pins ]
+  function: pinmux-mmc0, groups = [ pinmux-mmc0-pins ]
+  function: pinmux-mmc1, groups = [ pinmux-mmc1-pins ]
+  function: pinmux-i2c0, groups = [ pinmux-i2c0-pins ]
+  function: pinmux-i2c1, groups = [ pinmux-i2c1-pins ]
+  function: pinmux-spi1, groups = [ pinmux-spi1-pins ]
+
+To activate function pinmux-i2c1 on group pinmux-i2c1-pins:
+
+  echo "pinmux-i2c1-pins pinmux-i2c1" > pinmux-select
+
+Reviewed-by: Andy Shevchenko <andy.shevchenko@gmail.com>
+Reviewed-by: Tony Lindgren <tony@atomide.com>
+Reviewed-by: Geert Uytterhoeven <geert+renesas@glider.be>
+Tested-by: Geert Uytterhoeven <geert+renesas@glider.be>
+Signed-off-by: Drew Fustini <drew@beagleboard.org>
+Link: https://lore.kernel.org/r/20210302053059.1049035-3-drew@beagleboard.org
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/pinmux.c | 102 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 102 insertions(+)
+
+diff --git a/drivers/pinctrl/pinmux.c b/drivers/pinctrl/pinmux.c
+index 9c0174520e78..6cdbd9ccf2f0 100644
+--- a/drivers/pinctrl/pinmux.c
++++ b/drivers/pinctrl/pinmux.c
+@@ -12,6 +12,7 @@
+  */
+ #define pr_fmt(fmt) "pinmux core: " fmt
+ 
++#include <linux/ctype.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+ #include <linux/init.h>
+@@ -673,6 +674,105 @@ void pinmux_show_setting(struct seq_file *s,
+ DEFINE_SHOW_ATTRIBUTE(pinmux_functions);
+ DEFINE_SHOW_ATTRIBUTE(pinmux_pins);
+ 
++#define PINMUX_SELECT_MAX 128
++static ssize_t pinmux_select(struct file *file, const char __user *user_buf,
++				   size_t len, loff_t *ppos)
++{
++	struct seq_file *sfile = file->private_data;
++	struct pinctrl_dev *pctldev = sfile->private;
++	const struct pinmux_ops *pmxops = pctldev->desc->pmxops;
++	const char *const *groups;
++	char *buf, *gname, *fname;
++	unsigned int num_groups;
++	int fsel, gsel, ret;
++
++	if (len > PINMUX_SELECT_MAX)
++		return -ENOMEM;
++
++	buf = kzalloc(PINMUX_SELECT_MAX, GFP_KERNEL);
++	if (!buf)
++		return -ENOMEM;
++
++	ret = strncpy_from_user(buf, user_buf, PINMUX_SELECT_MAX);
++	if (ret < 0)
++		goto exit_free_buf;
++	buf[len-1] = '\0';
++
++	/* remove leading and trailing spaces of input buffer */
++	gname = strstrip(buf);
++	if (*gname == '\0') {
++		ret = -EINVAL;
++		goto exit_free_buf;
++	}
++
++	/* find a separator which is a spacelike character */
++	for (fname = gname; !isspace(*fname); fname++) {
++		if (*fname == '\0') {
++			ret = -EINVAL;
++			goto exit_free_buf;
++		}
++	}
++	*fname = '\0';
++
++	/* drop extra spaces between function and group names */
++	fname = skip_spaces(fname + 1);
++	if (*fname == '\0') {
++		ret = -EINVAL;
++		goto exit_free_buf;
++	}
++
++	ret = pinmux_func_name_to_selector(pctldev, fname);
++	if (ret < 0) {
++		dev_err(pctldev->dev, "invalid function %s in map table\n", fname);
++		goto exit_free_buf;
++	}
++	fsel = ret;
++
++	ret = pmxops->get_function_groups(pctldev, fsel, &groups, &num_groups);
++	if (ret) {
++		dev_err(pctldev->dev, "no groups for function %d (%s)", fsel, fname);
++		goto exit_free_buf;
++	}
++
++	ret = match_string(groups, num_groups, gname);
++	if (ret < 0) {
++		dev_err(pctldev->dev, "invalid group %s", gname);
++		goto exit_free_buf;
++	}
++
++	ret = pinctrl_get_group_selector(pctldev, gname);
++	if (ret < 0) {
++		dev_err(pctldev->dev, "failed to get group selector for %s", gname);
++		goto exit_free_buf;
++	}
++	gsel = ret;
++
++	ret = pmxops->set_mux(pctldev, fsel, gsel);
++	if (ret) {
++		dev_err(pctldev->dev, "set_mux() failed: %d", ret);
++		goto exit_free_buf;
++	}
++	ret = len;
++
++exit_free_buf:
++	kfree(buf);
++
++	return ret;
++}
++
++static int pinmux_select_open(struct inode *inode, struct file *file)
++{
++	return single_open(file, NULL, inode->i_private);
++}
++
++static const struct file_operations pinmux_select_ops = {
++	.owner = THIS_MODULE,
++	.open = pinmux_select_open,
++	.write = pinmux_select,
++	.llseek = no_llseek,
++	.release = single_release,
++};
++
+ void pinmux_init_device_debugfs(struct dentry *devroot,
+ 			 struct pinctrl_dev *pctldev)
+ {
+@@ -680,6 +780,8 @@ void pinmux_init_device_debugfs(struct dentry *devroot,
+ 			    devroot, pctldev, &pinmux_functions_fops);
+ 	debugfs_create_file("pinmux-pins", 0444,
+ 			    devroot, pctldev, &pinmux_pins_fops);
++	debugfs_create_file("pinmux-select", 0200,
++			    devroot, pctldev, &pinmux_select_ops);
+ }
+ 
+ #endif /* CONFIG_DEBUG_FS */

--- a/recipes-kernel/linux/files/patches-5.10/0215-pinctrl-core-Handling-pinmux-and-pinconf-separately.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0215-pinctrl-core-Handling-pinmux-and-pinconf-separately.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Simek <michal.simek@xilinx.com>
+Date: Wed, 10 Mar 2021 09:16:54 +0100
+Subject: [PATCH] pinctrl: core: Handling pinmux and pinconf separately
+
+Right now the handling order depends on how entries are coming which is
+corresponding with order in DT. We have reached the case with DT overlays
+where conf and mux descriptions are exchanged which ends up in sequence
+that firmware has been asked to perform configuration before requesting the
+pin.
+
+The patch is enforcing the order that pin is requested all the time first
+followed by pin configuration. This change will ensure that firmware gets
+requests in the right order.
+
+Signed-off-by: Michal Simek <michal.simek@xilinx.com>
+Link: https://lore.kernel.org/r/cfbe01f791c2dd42a596cbda57e15599969b57aa.1615364211.git.michal.simek@xilinx.com
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/core.c | 23 ++++++++++++++++++++++-
+ 1 file changed, 22 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/pinctrl/core.c b/drivers/pinctrl/core.c
+index aa5a1178c8eb..011e461a766a 100644
+--- a/drivers/pinctrl/core.c
++++ b/drivers/pinctrl/core.c
+@@ -1258,13 +1258,34 @@ static int pinctrl_commit_state(struct pinctrl *p, struct pinctrl_state *state)
+ 
+ 	p->state = NULL;
+ 
+-	/* Apply all the settings for the new state */
++	/* Apply all the settings for the new state - pinmux first */
+ 	list_for_each_entry(setting, &state->settings, node) {
+ 		switch (setting->type) {
+ 		case PIN_MAP_TYPE_MUX_GROUP:
+ 			ret = pinmux_enable_setting(setting);
+ 			break;
+ 		case PIN_MAP_TYPE_CONFIGS_PIN:
++		case PIN_MAP_TYPE_CONFIGS_GROUP:
++			break;
++		default:
++			ret = -EINVAL;
++			break;
++		}
++
++		if (ret < 0)
++			goto unapply_new_state;
++
++		/* Do not link hogs (circular dependency) */
++		if (p != setting->pctldev->p)
++			pinctrl_link_add(setting->pctldev, p->dev);
++	}
++
++	/* Apply all the settings for the new state - pinconf after */
++	list_for_each_entry(setting, &state->settings, node) {
++		switch (setting->type) {
++		case PIN_MAP_TYPE_MUX_GROUP:
++			break;
++		case PIN_MAP_TYPE_CONFIGS_PIN:
+ 		case PIN_MAP_TYPE_CONFIGS_GROUP:
+ 			ret = pinconf_apply_setting(setting);
+ 			break;

--- a/recipes-kernel/linux/files/patches-5.10/0216-pinctrl-core-Set-ret-to-0-when-group-is-skipped.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0216-pinctrl-core-Set-ret-to-0-when-group-is-skipped.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michal Simek <michal.simek@xilinx.com>
+Date: Fri, 12 Mar 2021 08:31:34 +0100
+Subject: [PATCH] pinctrl: core: Set ret to 0 when group is skipped
+
+Static analyzer tool found that the ret variable is not initialized but
+code expects ret value >=0 when pinconf is skipped in the first pinmux
+loop. The same expectation is for pinmux in a pinconf loop.
+That's why initialize ret to 0 to avoid uninitialized ret value in first
+loop or reusing ret value from first loop in second.
+
+Addresses-Coverity: ("Uninitialized variables")
+Signed-off-by: Michal Simek <michal.simek@xilinx.com>
+Cc: Dan Carpenter <dan.carpenter@oracle.com>
+Reviewed-by: Colin Ian King <colin.king@canonical.com>
+Link: https://lore.kernel.org/r/e5203bae68eb94b4b8b4e67e5e7b4d86bb989724.1615534291.git.michal.simek@xilinx.com
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/core.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/pinctrl/core.c b/drivers/pinctrl/core.c
+index 011e461a766a..af9a3f967c99 100644
+--- a/drivers/pinctrl/core.c
++++ b/drivers/pinctrl/core.c
+@@ -1266,6 +1266,7 @@ static int pinctrl_commit_state(struct pinctrl *p, struct pinctrl_state *state)
+ 			break;
+ 		case PIN_MAP_TYPE_CONFIGS_PIN:
+ 		case PIN_MAP_TYPE_CONFIGS_GROUP:
++			ret = 0;
+ 			break;
+ 		default:
+ 			ret = -EINVAL;
+@@ -1284,6 +1285,7 @@ static int pinctrl_commit_state(struct pinctrl *p, struct pinctrl_state *state)
+ 	list_for_each_entry(setting, &state->settings, node) {
+ 		switch (setting->type) {
+ 		case PIN_MAP_TYPE_MUX_GROUP:
++			ret = 0;
+ 			break;
+ 		case PIN_MAP_TYPE_CONFIGS_PIN:
+ 		case PIN_MAP_TYPE_CONFIGS_GROUP:

--- a/recipes-kernel/linux/files/patches-5.10/0217-pinctrl-pinctrl-single-remove-unused-variable.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0217-pinctrl-pinctrl-single-remove-unused-variable.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hanna Hawa <hhhawa@amazon.com>
+Date: Fri, 19 Mar 2021 17:21:31 +0200
+Subject: [PATCH] pinctrl: pinctrl-single: remove unused variable
+
+Remove unused parameter 'num_pins_in_register' from
+pcs_allocate_pin_table().
+
+Reported-by: kernel test robot <lkp@intel.com>
+Signed-off-by: Hanna Hawa <hhhawa@amazon.com>
+Reviewed-by: Tony Lindgren <tony@atomide.com>
+Reviewed-by: Drew Fustini <drew@beagleboard.org>
+Link: https://lore.kernel.org/r/20210319152133.28705-2-hhhawa@amazon.com
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/pinctrl-single.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/drivers/pinctrl/pinctrl-single.c b/drivers/pinctrl/pinctrl-single.c
+index e366bf9416ce..8b832c9a5876 100644
+--- a/drivers/pinctrl/pinctrl-single.c
++++ b/drivers/pinctrl/pinctrl-single.c
+@@ -722,14 +722,12 @@ static int pcs_add_pin(struct pcs_device *pcs, unsigned int offset)
+ static int pcs_allocate_pin_table(struct pcs_device *pcs)
+ {
+ 	int mux_bytes, nr_pins, i;
+-	int num_pins_in_register = 0;
+ 
+ 	mux_bytes = pcs->width / BITS_PER_BYTE;
+ 
+ 	if (pcs->bits_per_mux && pcs->fmask) {
+ 		pcs->bits_per_pin = fls(pcs->fmask);
+ 		nr_pins = (pcs->size * BITS_PER_BYTE) / pcs->bits_per_pin;
+-		num_pins_in_register = pcs->width / pcs->bits_per_pin;
+ 	} else {
+ 		nr_pins = pcs->size / mux_bytes;
+ 	}

--- a/recipes-kernel/linux/files/patches-5.10/0218-pinctrl-core-Fix-kernel-doc-string-for-pin_get_name.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0218-pinctrl-core-Fix-kernel-doc-string-for-pin_get_name.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Date: Thu, 15 Apr 2021 15:35:21 +0300
+Subject: [PATCH] pinctrl: core: Fix kernel doc string for pin_get_name()
+
+The kernel doc string mistakenly advertises the pin_get_name_from_id().
+Fix it, otherwise kernel doc validator is not happy:
+
+.../core.c:168: warning: expecting prototype for pin_get_name_from_id(). Prototype was for pin_get_name() instead
+
+Fixes: dcb5dbc305b9 ("pinctrl: show pin name for pingroups in sysfs")
+Cc: Dong Aisheng <dong.aisheng@linaro.org>
+Signed-off-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Link: https://lore.kernel.org/r/20210415123521.86894-1-andriy.shevchenko@linux.intel.com
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/core.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/pinctrl/core.c b/drivers/pinctrl/core.c
+index af9a3f967c99..81dbb1723ff2 100644
+--- a/drivers/pinctrl/core.c
++++ b/drivers/pinctrl/core.c
+@@ -160,7 +160,7 @@ int pin_get_from_name(struct pinctrl_dev *pctldev, const char *name)
+ }
+ 
+ /**
+- * pin_get_name_from_id() - look up a pin name from a pin id
++ * pin_get_name() - look up a pin name from a pin id
+  * @pctldev: the pin control device to lookup the pin on
+  * @pin: pin number/id to look up
+  */

--- a/recipes-kernel/linux/files/patches-5.10/0219-pinctrl-Introduce-MODE-group-in-enum-pin_config_para.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0219-pinctrl-Introduce-MODE-group-in-enum-pin_config_para.patch
@@ -1,0 +1,187 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Date: Mon, 12 Apr 2021 17:07:40 +0300
+Subject: [PATCH] pinctrl: Introduce MODE group in enum pin_config_param
+
+Better to have a MODE group of settings to keep them together
+when ordered alphabetically. Hence, rename PIN_CONFIG_LOW_POWER_MODE
+to PIN_CONFIG_MODE_LOW_POWER.
+
+Signed-off-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Link: https://lore.kernel.org/r/20210412140741.39946-2-andriy.shevchenko@linux.intel.com
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/pinconf-generic.c       | 6 +++---
+ drivers/pinctrl/pinctrl-lpc18xx.c       | 4 ++--
+ drivers/pinctrl/pinctrl-single.c        | 6 +++---
+ drivers/pinctrl/pinctrl-zynq.c          | 4 ++--
+ drivers/pinctrl/pxa/pinctrl-pxa2xx.c    | 4 ++--
+ drivers/soc/tegra/pmc.c                 | 4 ++--
+ include/linux/pinctrl/pinconf-generic.h | 4 ++--
+ 7 files changed, 16 insertions(+), 16 deletions(-)
+
+diff --git a/drivers/pinctrl/pinconf-generic.c b/drivers/pinctrl/pinconf-generic.c
+index 235f4f689b23..415d1df8f46a 100644
+--- a/drivers/pinctrl/pinconf-generic.c
++++ b/drivers/pinctrl/pinconf-generic.c
+@@ -43,7 +43,7 @@ static const struct pin_config_item conf_items[] = {
+ 	PCONFDUMP(PIN_CONFIG_INPUT_ENABLE, "input enabled", NULL, false),
+ 	PCONFDUMP(PIN_CONFIG_INPUT_SCHMITT, "input schmitt trigger", NULL, false),
+ 	PCONFDUMP(PIN_CONFIG_INPUT_SCHMITT_ENABLE, "input schmitt enabled", NULL, false),
+-	PCONFDUMP(PIN_CONFIG_LOW_POWER_MODE, "pin low power", "mode", true),
++	PCONFDUMP(PIN_CONFIG_MODE_LOW_POWER, "pin low power", "mode", true),
+ 	PCONFDUMP(PIN_CONFIG_OUTPUT_ENABLE, "output enabled", NULL, false),
+ 	PCONFDUMP(PIN_CONFIG_OUTPUT, "pin output", "level", true),
+ 	PCONFDUMP(PIN_CONFIG_OUTPUT_IMPEDANCE_OHMS, "output impedance", "ohms", true),
+@@ -175,8 +175,8 @@ static const struct pinconf_generic_params dt_params[] = {
+ 	{ "input-schmitt", PIN_CONFIG_INPUT_SCHMITT, 0 },
+ 	{ "input-schmitt-disable", PIN_CONFIG_INPUT_SCHMITT_ENABLE, 0 },
+ 	{ "input-schmitt-enable", PIN_CONFIG_INPUT_SCHMITT_ENABLE, 1 },
+-	{ "low-power-disable", PIN_CONFIG_LOW_POWER_MODE, 0 },
+-	{ "low-power-enable", PIN_CONFIG_LOW_POWER_MODE, 1 },
++	{ "low-power-disable", PIN_CONFIG_MODE_LOW_POWER, 0 },
++	{ "low-power-enable", PIN_CONFIG_MODE_LOW_POWER, 1 },
+ 	{ "output-disable", PIN_CONFIG_OUTPUT_ENABLE, 0 },
+ 	{ "output-enable", PIN_CONFIG_OUTPUT_ENABLE, 1 },
+ 	{ "output-high", PIN_CONFIG_OUTPUT, 1, },
+diff --git a/drivers/pinctrl/pinctrl-lpc18xx.c b/drivers/pinctrl/pinctrl-lpc18xx.c
+index 7b2f885e68bd..ed9bf2c89998 100644
+--- a/drivers/pinctrl/pinctrl-lpc18xx.c
++++ b/drivers/pinctrl/pinctrl-lpc18xx.c
+@@ -646,7 +646,7 @@ static const struct pin_config_item lpc18xx_conf_items[ARRAY_SIZE(lpc18xx_params
+ static int lpc18xx_pconf_get_usb1(enum pin_config_param param, int *arg, u32 reg)
+ {
+ 	switch (param) {
+-	case PIN_CONFIG_LOW_POWER_MODE:
++	case PIN_CONFIG_MODE_LOW_POWER:
+ 		if (reg & LPC18XX_SCU_USB1_EPWR)
+ 			*arg = 0;
+ 		else
+@@ -904,7 +904,7 @@ static int lpc18xx_pconf_set_usb1(struct pinctrl_dev *pctldev,
+ 				  u32 param_val, u32 *reg)
+ {
+ 	switch (param) {
+-	case PIN_CONFIG_LOW_POWER_MODE:
++	case PIN_CONFIG_MODE_LOW_POWER:
+ 		if (param_val)
+ 			*reg &= ~LPC18XX_SCU_USB1_EPWR;
+ 		else
+diff --git a/drivers/pinctrl/pinctrl-single.c b/drivers/pinctrl/pinctrl-single.c
+index 8b832c9a5876..cd314a5305a2 100644
+--- a/drivers/pinctrl/pinctrl-single.c
++++ b/drivers/pinctrl/pinctrl-single.c
+@@ -533,7 +533,7 @@ static int pcs_pinconf_get(struct pinctrl_dev *pctldev,
+ 			break;
+ 		case PIN_CONFIG_DRIVE_STRENGTH:
+ 		case PIN_CONFIG_SLEW_RATE:
+-		case PIN_CONFIG_LOW_POWER_MODE:
++		case PIN_CONFIG_MODE_LOW_POWER:
+ 		default:
+ 			*config = data;
+ 			break;
+@@ -571,7 +571,7 @@ static int pcs_pinconf_set(struct pinctrl_dev *pctldev,
+ 			case PIN_CONFIG_INPUT_SCHMITT:
+ 			case PIN_CONFIG_DRIVE_STRENGTH:
+ 			case PIN_CONFIG_SLEW_RATE:
+-			case PIN_CONFIG_LOW_POWER_MODE:
++			case PIN_CONFIG_MODE_LOW_POWER:
+ 				shift = ffs(func->conf[i].mask) - 1;
+ 				data &= ~func->conf[i].mask;
+ 				data |= (arg << shift) & func->conf[i].mask;
+@@ -919,7 +919,7 @@ static int pcs_parse_pinconf(struct pcs_device *pcs, struct device_node *np,
+ 		{ "pinctrl-single,drive-strength", PIN_CONFIG_DRIVE_STRENGTH, },
+ 		{ "pinctrl-single,slew-rate", PIN_CONFIG_SLEW_RATE, },
+ 		{ "pinctrl-single,input-schmitt", PIN_CONFIG_INPUT_SCHMITT, },
+-		{ "pinctrl-single,low-power-mode", PIN_CONFIG_LOW_POWER_MODE, },
++		{ "pinctrl-single,low-power-mode", PIN_CONFIG_MODE_LOW_POWER, },
+ 	};
+ 	static const struct pcs_conf_type prop4[] = {
+ 		{ "pinctrl-single,bias-pullup", PIN_CONFIG_BIAS_PULL_UP, },
+diff --git a/drivers/pinctrl/pinctrl-zynq.c b/drivers/pinctrl/pinctrl-zynq.c
+index c6052a0e827a..5fb924a2eedd 100644
+--- a/drivers/pinctrl/pinctrl-zynq.c
++++ b/drivers/pinctrl/pinctrl-zynq.c
+@@ -1016,7 +1016,7 @@ static int zynq_pinconf_cfg_get(struct pinctrl_dev *pctldev,
+ 	case PIN_CONFIG_SLEW_RATE:
+ 		arg = !!(reg & ZYNQ_PINCONF_SPEED);
+ 		break;
+-	case PIN_CONFIG_LOW_POWER_MODE:
++	case PIN_CONFIG_MODE_LOW_POWER:
+ 	{
+ 		enum zynq_io_standards iostd = zynq_pinconf_iostd_get(reg);
+ 
+@@ -1087,7 +1087,7 @@ static int zynq_pinconf_cfg_set(struct pinctrl_dev *pctldev,
+ 			reg &= ~ZYNQ_PINCONF_IOTYPE_MASK;
+ 			reg |= arg << ZYNQ_PINCONF_IOTYPE_SHIFT;
+ 			break;
+-		case PIN_CONFIG_LOW_POWER_MODE:
++		case PIN_CONFIG_MODE_LOW_POWER:
+ 			if (arg)
+ 				reg |= ZYNQ_PINCONF_DISABLE_RECVR;
+ 			else
+diff --git a/drivers/pinctrl/pxa/pinctrl-pxa2xx.c b/drivers/pinctrl/pxa/pinctrl-pxa2xx.c
+index eab029a21643..d2568dab8c78 100644
+--- a/drivers/pinctrl/pxa/pinctrl-pxa2xx.c
++++ b/drivers/pinctrl/pxa/pinctrl-pxa2xx.c
+@@ -194,7 +194,7 @@ static int pxa2xx_pconf_group_get(struct pinctrl_dev *pctldev,
+ 
+ 	spin_lock_irqsave(&pctl->lock, flags);
+ 	val = readl_relaxed(pgsr) & BIT(pin % 32);
+-	*config = val ? PIN_CONFIG_LOW_POWER_MODE : 0;
++	*config = val ? PIN_CONFIG_MODE_LOW_POWER : 0;
+ 	spin_unlock_irqrestore(&pctl->lock, flags);
+ 
+ 	dev_dbg(pctl->dev, "get sleep gpio state(pin=%d) %d\n",
+@@ -217,7 +217,7 @@ static int pxa2xx_pconf_group_set(struct pinctrl_dev *pctldev,
+ 
+ 	for (i = 0; i < num_configs; i++) {
+ 		switch (pinconf_to_config_param(configs[i])) {
+-		case PIN_CONFIG_LOW_POWER_MODE:
++		case PIN_CONFIG_MODE_LOW_POWER:
+ 			is_set = pinconf_to_config_argument(configs[i]);
+ 			break;
+ 		default:
+diff --git a/drivers/soc/tegra/pmc.c b/drivers/soc/tegra/pmc.c
+index 5726c232e61d..47767b4b7436 100644
+--- a/drivers/soc/tegra/pmc.c
++++ b/drivers/soc/tegra/pmc.c
+@@ -1793,7 +1793,7 @@ static int tegra_io_pad_pinconf_get(struct pinctrl_dev *pctl_dev,
+ 		arg = ret;
+ 		break;
+ 
+-	case PIN_CONFIG_LOW_POWER_MODE:
++	case PIN_CONFIG_MODE_LOW_POWER:
+ 		ret = tegra_io_pad_is_powered(pmc, pad->id);
+ 		if (ret < 0)
+ 			return ret;
+@@ -1830,7 +1830,7 @@ static int tegra_io_pad_pinconf_set(struct pinctrl_dev *pctl_dev,
+ 		arg = pinconf_to_config_argument(configs[i]);
+ 
+ 		switch (param) {
+-		case PIN_CONFIG_LOW_POWER_MODE:
++		case PIN_CONFIG_MODE_LOW_POWER:
+ 			if (arg)
+ 				err = tegra_io_pad_power_disable(pad->id);
+ 			else
+diff --git a/include/linux/pinctrl/pinconf-generic.h b/include/linux/pinctrl/pinconf-generic.h
+index 545e598abb0f..7b5de889574c 100644
+--- a/include/linux/pinctrl/pinconf-generic.h
++++ b/include/linux/pinctrl/pinconf-generic.h
+@@ -76,7 +76,7 @@ struct pinctrl_map;
+  * @PIN_CONFIG_INPUT_SCHMITT_ENABLE: control schmitt-trigger mode on the pin.
+  *      If the argument != 0, schmitt-trigger mode is enabled. If it's 0,
+  *      schmitt-trigger mode is disabled.
+- * @PIN_CONFIG_LOW_POWER_MODE: this will configure the pin for low power
++ * @PIN_CONFIG_MODE_LOW_POWER: this will configure the pin for low power
+  *	operation, if several modes of operation are supported these can be
+  *	passed in the argument on a custom form, else just use argument 1
+  *	to indicate low power mode, argument 0 turns low power mode off.
+@@ -126,7 +126,7 @@ enum pin_config_param {
+ 	PIN_CONFIG_INPUT_ENABLE,
+ 	PIN_CONFIG_INPUT_SCHMITT,
+ 	PIN_CONFIG_INPUT_SCHMITT_ENABLE,
+-	PIN_CONFIG_LOW_POWER_MODE,
++	PIN_CONFIG_MODE_LOW_POWER,
+ 	PIN_CONFIG_OUTPUT_ENABLE,
+ 	PIN_CONFIG_OUTPUT,
+ 	PIN_CONFIG_OUTPUT_IMPEDANCE_OHMS,

--- a/recipes-kernel/linux/files/patches-5.10/0220-arm64-dts-ti-iot2050-Definitions-for-runtime-pinmuxi.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0220-arm64-dts-ti-iot2050-Definitions-for-runtime-pinmuxi.patch
@@ -1,0 +1,769 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+Date: Tue, 21 Feb 2023 11:03:42 +0100
+Subject: [PATCH] arm64: dts: ti: iot2050: Definitions for runtime pinmuxing
+
+Add multiple device tree nodes in order to support
+runtime pinmuxing via debugfs.
+
+All nodes are added to the pinctrl device node,
+since they are now belonging to multiple interfaces now.
+
+Note: Pinconf is also handled by debugfs-pinmux. This is possible since
+pinconf and pinmux accessing the same 32-Bit register and setting the
+function mask to 32-Bit allows writes to the whole register.
+
+Signed-off-by: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+---
+ .../boot/dts/ti/k3-am65-iot2050-common.dtsi   | 669 +++++++++++++++++-
+ .../dts/ti/k3-am6548-iot2050-advanced-m2.dts  |   2 +-
+ 2 files changed, 631 insertions(+), 40 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi
+index 3310880e83ee..f473aedeb1f3 100644
+--- a/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi
++++ b/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi
+@@ -177,6 +177,425 @@ icssg0_emac1: ethernet-mii1 {
+ };
+ 
+ &wkup_pmx0 {
++	pinctrl-names =
++	"default",
++	"d0-uart0-rxd",  "d0-gpio",  "d0-gpio-pullup",  "d0-gpio-pulldown",
++	"d1-uart0-txd",  "d1-gpio",  "d1-gpio-pullup",  "d1-gpio-pulldown",
++	"d2-uart0-ctsn", "d2-gpio",  "d2-gpio-pullup",  "d2-gpio-pulldown",
++	"d3-uart0-rtsn", "d3-gpio",  "d3-gpio-pullup",  "d3-gpio-pulldown",
++	"d10-spi0-cs0",  "d10-gpio", "d10-gpio-pullup", "d10-gpio-pulldown",
++	"d11-spi0-d0",   "d11-gpio", "d11-gpio-pullup", "d11-gpio-pulldown",
++	"d12-spi0-d1",   "d12-gpio", "d12-gpio-pullup", "d12-gpio-pulldown",
++	"d13-spi0-clk",  "d13-gpio", "d13-gpio-pullup", "d13-gpio-pulldown",
++	"a0-gpio", "a0-gpio-pullup", "a0-gpio-pulldown",
++	"a1-gpio", "a1-gpio-pullup", "a1-gpio-pulldown",
++	"a2-gpio", "a2-gpio-pullup", "a2-gpio-pulldown",
++	"a3-gpio", "a3-gpio-pullup", "a3-gpio-pulldown",
++	"a4-gpio", "a4-gpio-pullup", "a4-gpio-pulldown",
++	"a5-gpio", "a5-gpio-pullup", "a5-gpio-pulldown";
++
++	pinctrl-0 = <&d0_uart0_rxd>;
++	pinctrl-1 = <&d0_uart0_rxd>;
++	pinctrl-2 = <&d0_gpio>;
++	pinctrl-3 = <&d0_gpio_pullup>;
++	pinctrl-4 = <&d0_gpio_pulldown>;
++	pinctrl-5 = <&d1_uart0_txd>;
++	pinctrl-6 = <&d1_gpio>;
++	pinctrl-7 = <&d1_gpio_pullup>;
++	pinctrl-8 = <&d1_gpio_pulldown>;
++	pinctrl-9 = <&d2_uart0_ctsn>;
++	pinctrl-10 = <&d2_gpio>;
++	pinctrl-11 = <&d2_gpio_pullup>;
++	pinctrl-12 = <&d2_gpio_pulldown>;
++	pinctrl-13 = <&d3_uart0_rtsn>;
++	pinctrl-14 = <&d3_gpio>;
++	pinctrl-15 = <&d3_gpio_pullup>;
++	pinctrl-16 = <&d3_gpio_pulldown>;
++	pinctrl-17 = <&d10_spi0_cs0>;
++	pinctrl-18 = <&d10_gpio>;
++	pinctrl-19 = <&d10_gpio_pullup>;
++	pinctrl-20 = <&d10_gpio_pulldown>;
++	pinctrl-21 = <&d11_spi0_d0>;
++	pinctrl-22 = <&d11_gpio>;
++	pinctrl-23 = <&d11_gpio_pullup>;
++	pinctrl-24 = <&d11_gpio_pulldown>;
++	pinctrl-25 = <&d12_spi0_d1>;
++	pinctrl-26 = <&d12_gpio>;
++	pinctrl-27 = <&d12_gpio_pullup>;
++	pinctrl-28 = <&d12_gpio_pulldown>;
++	pinctrl-29 = <&d13_spi0_clk>;
++	pinctrl-30 = <&d13_gpio>;
++	pinctrl-31 = <&d13_gpio_pullup>;
++	pinctrl-32 = <&d13_gpio_pulldown>;
++	pinctrl-33 = <&a0_gpio>;
++	pinctrl-34 = <&a0_gpio_pullup>;
++	pinctrl-35 = <&a0_gpio_pulldown>;
++	pinctrl-36 = <&a1_gpio>;
++	pinctrl-37 = <&a1_gpio_pullup>;
++	pinctrl-38 = <&a1_gpio_pulldown>;
++	pinctrl-39 = <&a2_gpio>;
++	pinctrl-40 = <&a2_gpio_pullup>;
++	pinctrl-41 = <&a2_gpio_pulldown>;
++	pinctrl-42 = <&a3_gpio>;
++	pinctrl-43 = <&a3_gpio_pullup>;
++	pinctrl-44 = <&a3_gpio_pulldown>;
++	pinctrl-45 = <&a4_gpio>;
++	pinctrl-46 = <&a4_gpio_pullup>;
++	pinctrl-47 = <&a4_gpio_pulldown>;
++	pinctrl-48 = <&a5_gpio>;
++	pinctrl-49 = <&a5_gpio_pullup>;
++	pinctrl-50 = <&a5_gpio_pulldown>;
++
++	d0_uart0_rxd: d0-uart0-rxd {
++		pinctrl-single,pins = <
++			/* (P4) MCU_UART0_RXD */
++			AM65X_WKUP_IOPAD(0x0044, PIN_INPUT, 4)
++		>;
++	};
++
++	d0_gpio: d0-gpio {
++		pinctrl-single,pins = <
++			/* (P4) WKUP_GPIO0_29 */
++			AM65X_WKUP_IOPAD(0x0044, PIN_INPUT, 7)
++		>;
++	};
++
++	d0_gpio_pullup: d0-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (P4) WKUP_GPIO0_29 */
++			AM65X_WKUP_IOPAD(0x0044, PIN_INPUT_PULLUP, 7)
++		>;
++	};
++
++	d0_gpio_pulldown: d0-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (P4) WKUP_GPIO0_29 */
++			AM65X_WKUP_IOPAD(0x0044, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	d1_uart0_txd: d1-uart0-txd {
++		pinctrl-single,pins = <
++			/* (P5) MCU_UART0_TXD */
++			AM65X_WKUP_IOPAD(0x0048, PIN_OUTPUT, 4)
++		>;
++	};
++
++	d1_gpio: d1-gpio {
++		pinctrl-single,pins = <
++			/* (P5) WKUP_GPIO0_30 */
++			AM65X_WKUP_IOPAD(0x0048, PIN_INPUT, 7)
++		>;
++	};
++
++	d1_gpio_pullup: d1-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (P5) WKUP_GPIO0_30 */
++			AM65X_WKUP_IOPAD(0x0048, PIN_INPUT, 7)
++		>;
++	};
++
++	d1_gpio_pulldown: d1-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (P5) WKUP_GPIO0_30 */
++			AM65X_WKUP_IOPAD(0x0048, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	d2_uart0_ctsn: d2-uart0-ctsn {
++		pinctrl-single,pins = <
++			/* (P1) MCU_UART0_CTSn */
++			AM65X_WKUP_IOPAD(0x004C, PIN_INPUT, 4)
++		>;
++	};
++
++	d2_gpio: d2-gpio {
++		pinctrl-single,pins = <
++			/* (P5) WKUP_GPIO0_31 */
++			AM65X_WKUP_IOPAD(0x004C, PIN_INPUT, 7)
++		>;
++	};
++
++	d2_gpio_pullup: d2-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (P5) WKUP_GPIO0_31 */
++			AM65X_WKUP_IOPAD(0x004C, PIN_INPUT, 7)
++		>;
++	};
++
++	d2_gpio_pulldown: d2-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (P5) WKUP_GPIO0_31 */
++			AM65X_WKUP_IOPAD(0x004C, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	d3_uart0_rtsn: d3-uart0-rtsn {
++		pinctrl-single,pins = <
++			/* (N3) MCU_UART0_RTSn */
++			AM65X_WKUP_IOPAD(0x0054, PIN_OUTPUT, 4)
++		>;
++	};
++
++	d3_gpio: d3-gpio {
++		pinctrl-single,pins = <
++			/* (N3) WKUP_GPIO0_33 */
++			AM65X_WKUP_IOPAD(0x0054, PIN_INPUT, 7)
++		>;
++	};
++
++	d3_gpio_pullup: d3-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (N3) WKUP_GPIO0_33 */
++			AM65X_WKUP_IOPAD(0x0054, PIN_INPUT, 7)
++		>;
++	};
++
++	d3_gpio_pulldown: d3-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (N3) WKUP_GPIO0_33 */
++			AM65X_WKUP_IOPAD(0x0054, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	d10_spi0_cs0: d10-spi0-cs0 {
++		pinctrl-single,pins = <
++			/* (Y4) MCU_SPI0_CS0 */
++			AM65X_WKUP_IOPAD(0x009c, PIN_OUTPUT, 0)
++		>;
++	};
++
++	d10_gpio: d10-gpio {
++		pinctrl-single,pins = <
++			/* (Y4) WKUP_GPIO0_51 */
++			AM65X_WKUP_IOPAD(0x009c, PIN_INPUT, 7)
++		>;
++	};
++
++	d10_gpio_pullup: d10-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (Y4) WKUP_GPIO0_51 */
++			AM65X_WKUP_IOPAD(0x009c, PIN_INPUT, 7)
++		>;
++	};
++
++	d10_gpio_pulldown: d10-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (Y4) WKUP_GPIO0_51 */
++			AM65X_WKUP_IOPAD(0x009c, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	d11_spi0_d0: d11-spi0-d0 {
++		pinctrl-single,pins = <
++			/* (Y3) MCU_SPI0_D0 */
++			AM65X_WKUP_IOPAD(0x0094, PIN_INPUT, 0)
++		>;
++	};
++
++	d11_gpio: d11-gpio {
++		pinctrl-single,pins = <
++			/* (Y3) WKUP_GPIO0_49 */
++			AM65X_WKUP_IOPAD(0x0094, PIN_INPUT, 7)
++		>;
++	};
++
++	d11_gpio_pullup: d11-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (Y3) WKUP_GPIO0_49 */
++			AM65X_WKUP_IOPAD(0x0094, PIN_INPUT, 7)
++		>;
++	};
++
++	d11_gpio_pulldown: d11-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (Y3) WKUP_GPIO0_49 */
++			AM65X_WKUP_IOPAD(0x0094, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	d12_spi0_d1: d12-spi0-d1 {
++		pinctrl-single,pins = <
++			/* (Y2) MCU_SPI0_D1 */
++			AM65X_WKUP_IOPAD(0x0098, PIN_INPUT, 0)
++		>;
++	};
++
++	d12_gpio: d12-gpio {
++		pinctrl-single,pins = <
++			/* (Y2) WKUP_GPIO0_50 */
++			AM65X_WKUP_IOPAD(0x0098, PIN_INPUT, 7)
++		>;
++	};
++
++	d12_gpio_pullup: d12-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (Y2) WKUP_GPIO0_50 */
++			AM65X_WKUP_IOPAD(0x0098, PIN_INPUT, 7)
++		>;
++	};
++
++	d12_gpio_pulldown: d12-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (Y2) WKUP_GPIO0_50 */
++			AM65X_WKUP_IOPAD(0x0098, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	d13_spi0_clk: d13-spi0-clk {
++		pinctrl-single,pins = <
++			/* (Y1) MCU_SPI0_CLK */
++			AM65X_WKUP_IOPAD(0x0090, PIN_INPUT, 7)
++		>;
++	};
++
++	d13_gpio: d13-gpio {
++		pinctrl-single,pins = <
++			/* (Y1) WKUP_GPIO0_48 */
++			AM65X_WKUP_IOPAD(0x0090, PIN_INPUT, 7)
++		>;
++	};
++
++	d13_gpio_pullup: d13-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (Y1) WKUP_GPIO0_48 */
++			AM65X_WKUP_IOPAD(0x0090, PIN_INPUT, 7)
++		>;
++	};
++
++	d13_gpio_pulldown: d13-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (Y1) WKUP_GPIO0_48 */
++			AM65X_WKUP_IOPAD(0x0090, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	a0_gpio: a0-gpio {
++		pinctrl-single,pins = <
++			/* (L6) WKUP_GPIO0_45 */
++			AM65X_WKUP_IOPAD(0x0084, PIN_INPUT, 7)
++		>;
++	};
++
++	a0_gpio_pullup: a0-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (L6) WKUP_GPIO0_45 */
++			AM65X_WKUP_IOPAD(0x0084, PIN_INPUT, 7)
++		>;
++	};
++
++	a0_gpio_pulldown: a0-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (L6) WKUP_GPIO0_45 */
++			AM65X_WKUP_IOPAD(0x0084, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	a1_gpio: a1-gpio {
++		pinctrl-single,pins = <
++			/* (M6) WKUP_GPIO0_44 */
++			AM65X_WKUP_IOPAD(0x0080, PIN_INPUT, 7)
++		>;
++	};
++
++	a1_gpio_pullup: a1-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (M6) WKUP_GPIO0_44 */
++			AM65X_WKUP_IOPAD(0x0080, PIN_INPUT, 7)
++		>;
++	};
++
++	a1_gpio_pulldown: a1-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (M6) WKUP_GPIO0_44 */
++			AM65X_WKUP_IOPAD(0x0080, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	a2_gpio: a2-gpio {
++		pinctrl-single,pins = <
++			/* (L5) WKUP_GPIO0_43 */
++			AM65X_WKUP_IOPAD(0x007C, PIN_INPUT, 7)
++		>;
++	};
++
++	a2_gpio_pullup: a2-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (L5) WKUP_GPIO0_43 */
++			AM65X_WKUP_IOPAD(0x007C, PIN_INPUT, 7)
++		>;
++	};
++
++	a2_gpio_pulldown: a2-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (L5) WKUP_GPIO0_43 */
++			AM65X_WKUP_IOPAD(0x007C, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	a3_gpio: a3-gpio {
++		pinctrl-single,pins = <
++			/* (M5) WKUP_GPIO0_39 */
++			AM65X_WKUP_IOPAD(0x006C, PIN_INPUT, 7)
++		>;
++	};
++
++	a3_gpio_pullup: a3-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (M5) WKUP_GPIO0_39 */
++			AM65X_WKUP_IOPAD(0x006C, PIN_INPUT, 7)
++		>;
++	};
++
++	a3_gpio_pulldown: a3-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (M5) WKUP_GPIO0_39 */
++			AM65X_WKUP_IOPAD(0x006C, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	a4_gpio: a4-gpio {
++		pinctrl-single,pins = <
++			/* (L2) WKUP_GPIO0_42 */
++			AM65X_WKUP_IOPAD(0x0078, PIN_INPUT, 7)
++		>;
++	};
++
++	a4_gpio_pullup: a4-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (L2) WKUP_GPIO0_42 */
++			AM65X_WKUP_IOPAD(0x0078, PIN_INPUT, 7)
++		>;
++	};
++
++	a4_gpio_pulldown: a4-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (L2) WKUP_GPIO0_42 */
++			AM65X_WKUP_IOPAD(0x0078, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	a5_gpio: a5-gpio {
++		pinctrl-single,pins = <
++			/* (N5) WKUP_GPIO0_35 */
++			AM65X_WKUP_IOPAD(0x005C, PIN_INPUT, 7)
++		>;
++	};
++
++	a5_gpio_pullup: a5-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (N5) WKUP_GPIO0_35 */
++			AM65X_WKUP_IOPAD(0x005C, PIN_INPUT_PULLUP, 7)
++		>;
++	};
++
++	a5_gpio_pulldown: a5-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (N5) WKUP_GPIO0_35 */
++			AM65X_WKUP_IOPAD(0x005C, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
+ 	wkup_i2c0_pins_default: wkup-i2c0-pins-default {
+ 		pinctrl-single,pins = <
+ 			/* (AC7) WKUP_I2C0_SCL */
+@@ -209,23 +628,6 @@ AM65X_WKUP_IOPAD(0x0034, PIN_INPUT,  7)
+ 		>;
+ 	};
+ 
+-	arduino_uart_pins_default: arduino-uart-pins-default {
+-		pinctrl-single,pins = <
+-			/* (P4) MCU_UART0_RXD */
+-			AM65X_WKUP_IOPAD(0x0044, PIN_INPUT,  4)
+-			/* (P5) MCU_UART0_TXD */
+-			AM65X_WKUP_IOPAD(0x0048, PIN_OUTPUT, 4)
+-		>;
+-	};
+-
+-	arduino_io_d2_to_d3_pins_default: arduino-io-d2-to-d3-pins-default {
+-		pinctrl-single,pins = <
+-			/* (P1) WKUP_GPIO0_31 */
+-			AM65X_WKUP_IOPAD(0x004C, PIN_OUTPUT, 7)
+-			/* (N3) WKUP_GPIO0_33 */
+-			AM65X_WKUP_IOPAD(0x0054, PIN_OUTPUT, 7)
+-		>;
+-	};
+ 
+ 	arduino_io_oe_pins_default: arduino-io-oe-pins-default {
+ 		pinctrl-single,pins = <
+@@ -240,6 +642,8 @@ AM65X_WKUP_IOPAD(0x0068, PIN_OUTPUT, 7)
+ 			/* (M1) WKUP_GPIO0_41 */
+ 			AM65X_WKUP_IOPAD(0x0074, PIN_OUTPUT, 7)
+ 		>;
++		pinctrl-single,bias-pullup   = <0x20000  0x20000  0x10000  0x30000>;
++		pinctrl-single,bias-pulldown = <0x00000  0x0      0x10000  0x30000>;
+ 	};
+ 
+ 	mcu_fss0_ospi0_pins_default: mcu-fss0-ospi0-pins-default {
+@@ -305,6 +709,214 @@ AM65X_WKUP_IOPAD(0x003C, PIN_OUTPUT, 7)
+ };
+ 
+ &main_pmx0 {
++	pinctrl-names =
++		"default",
++		"d4-ehrpwm0-a", "d4-gpio", "d4-gpio-pullup", "d4-gpio-pulldown",
++		"d5-ehrpwm1-a", "d5-gpio", "d5-gpio-pullup", "d5-gpio-pulldown",
++		"d6-ehrpwm2-a", "d6-gpio", "d6-gpio-pullup", "d6-gpio-pulldown",
++		"d7-ehrpwm3-a", "d7-gpio", "d7-gpio-pullup", "d7-gpio-pulldown",
++		"d8-ehrpwm4-a", "d8-gpio", "d8-gpio-pullup", "d8-gpio-pulldown",
++		"d9-ehrpwm5-a", "d9-gpio", "d9-gpio-pullup", "d9-gpio-pulldown";
++
++	pinctrl-0 = <&d4_ehrpwm0_a>;
++	pinctrl-1 = <&d4_ehrpwm0_a>;
++	pinctrl-2 = <&d4_gpio>;
++	pinctrl-3 = <&d4_gpio_pullup>;
++	pinctrl-4 = <&d4_gpio_pulldown>;
++
++	pinctrl-5 = <&d5_ehrpwm1_a>;
++	pinctrl-6 = <&d5_gpio>;
++	pinctrl-7 = <&d5_gpio_pullup>;
++	pinctrl-8 = <&d5_gpio_pulldown>;
++
++	pinctrl-9 = <&d6_ehrpwm2_a>;
++	pinctrl-10 = <&d6_gpio>;
++	pinctrl-11 = <&d6_gpio_pullup>;
++	pinctrl-12 = <&d6_gpio_pulldown>;
++
++	pinctrl-13 = <&d7_ehrpwm3_a>;
++	pinctrl-14 = <&d7_gpio>;
++	pinctrl-15 = <&d7_gpio_pullup>;
++	pinctrl-16 = <&d7_gpio_pulldown>;
++
++	pinctrl-17 = <&d8_ehrpwm4_a>;
++	pinctrl-18 = <&d8_gpio>;
++	pinctrl-19 = <&d8_gpio_pullup>;
++	pinctrl-20 = <&d8_gpio_pulldown>;
++
++	pinctrl-21 = <&d9_ehrpwm5_a>;
++	pinctrl-22 = <&d9_gpio>;
++	pinctrl-23 = <&d9_gpio_pullup>;
++	pinctrl-24 = <&d9_gpio_pulldown>;
++
++	d4_ehrpwm0_a: d4-ehrpwm0-a {
++		pinctrl-single,pins = <
++			/* (AG18) EHRPWM0_A */
++			AM65X_IOPAD(0x0084, PIN_OUTPUT, 5)
++		>;
++	};
++
++	d4_gpio: d4-gpio {
++		pinctrl-single,pins = <
++			/* (AG18) GPIO0_33 */
++			AM65X_IOPAD(0x0084, PIN_INPUT, 7)
++		>;
++	};
++
++	d4_gpio_pullup: d4-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (AG18) GPIO0_33 */
++			AM65X_IOPAD(0x0084, PIN_INPUT_PULLUP, 7)
++		>;
++	};
++
++	d4_gpio_pulldown: d4-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (AG18) GPIO0_33 */
++			AM65X_IOPAD(0x0084, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	d5_ehrpwm1_a: d5-ehrpwm1-a {
++		pinctrl-single,pins = <
++			/* (AF17) EHRPWM1_A */
++			AM65X_IOPAD(0x008C, PIN_OUTPUT, 5)
++		>;
++	};
++
++	d5_gpio: d5-gpio {
++		pinctrl-single,pins = <
++			/* (AF17) GPIO0_35 */
++			AM65X_IOPAD(0x008C, PIN_INPUT, 7)
++		>;
++	};
++
++	d5_gpio_pullup: d5-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (AF17) GPIO0_35 */
++			AM65X_IOPAD(0x008C, PIN_INPUT_PULLUP, 7)
++		>;
++	};
++
++	d5_gpio_pulldown: d5-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (AF17) GPIO0_35 */
++			AM65X_IOPAD(0x008C, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	d6_ehrpwm2_a: d6-ehrpwm2-a {
++		pinctrl-single,pins = <
++			/* (AH16) EHRPWM2_A */
++			AM65X_IOPAD(0x0098, PIN_OUTPUT, 5)
++		>;
++	};
++
++	d6_gpio: d6-gpio {
++		pinctrl-single,pins = <
++			/* (AH16) GPIO0_38 */
++			AM65X_IOPAD(0x0098, PIN_INPUT, 7)
++		>;
++	};
++
++	d6_gpio_pullup: d6-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (AH16) GPIO0_38 */
++			AM65X_IOPAD(0x0098, PIN_INPUT_PULLUP, 7)
++		>;
++	};
++
++	d6_gpio_pulldown: d6-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (AH16) GPIO0_38 */
++			AM65X_IOPAD(0x0098, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	d7_ehrpwm3_a: d7-ehrpwm3-a {
++		pinctrl-single,pins = <
++			/* (AH15) EHRPWM3_A */
++			AM65X_IOPAD(0x00AC, PIN_OUTPUT, 5)
++		>;
++	};
++
++	d7_gpio: d7-gpio {
++		pinctrl-single,pins = <
++			/* (AH15) GPIO0_43 */
++			AM65X_IOPAD(0x00AC, PIN_INPUT, 7)
++		>;
++	};
++
++	d7_gpio_pullup: d7-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (AH15) GPIO0_43 */
++			AM65X_IOPAD(0x00AC, PIN_INPUT_PULLUP, 7)
++		>;
++	};
++
++	d7_gpio_pulldown: d7-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (AH15) GPIO0_43 */
++			AM65X_IOPAD(0x00AC, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	d8_ehrpwm4_a: d8-ehrpwm4-a {
++		pinctrl-single,pins = <
++			/* (AG15) EHRPWM4_A */
++			AM65X_IOPAD(0x00C0, PIN_OUTPUT, 5)
++		>;
++	};
++
++	d8_gpio: d8-gpio {
++		pinctrl-single,pins = <
++			/* (AG15) GPIO0_48 */
++			AM65X_IOPAD(0x00C0, PIN_INPUT, 7)
++		>;
++	};
++
++	d8_gpio_pullup: d8-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (AG15) GPIO0_48 */
++			AM65X_IOPAD(0x00C0, PIN_INPUT_PULLUP, 7)
++		>;
++	};
++
++	d8_gpio_pulldown: d8-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (AG15) GPIO0_48 */
++			AM65X_IOPAD(0x00C0, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
++	d9_ehrpwm5_a: d9-ehrpwm5-a {
++		pinctrl-single,pins = <
++			/* (AD15) EHRPWM5_A */
++			AM65X_IOPAD(0x00CC, PIN_OUTPUT, 5)
++		>;
++	};
++
++	d9_gpio: d9-gpio {
++		pinctrl-single,pins = <
++			/* (AD15) GPIO0_51 */
++			AM65X_IOPAD(0x00CC, PIN_INPUT, 7)
++		>;
++	};
++
++	d9_gpio_pullup: d9-gpio-pullup {
++		pinctrl-single,pins = <
++			/* (AD15) GPIO0_51 */
++			AM65X_IOPAD(0x00CC, PIN_INPUT_PULLUP, 7)
++		>;
++	};
++
++	d9_gpio_pulldown: d9-gpio-pulldown {
++		pinctrl-single,pins = <
++			/* (AD15) GPIO0_51 */
++			AM65X_IOPAD(0x00CC, PIN_INPUT_PULLDOWN, 7)
++		>;
++	};
++
+ 	main_uart1_pins_default: main-uart1-pins-default {
+ 		pinctrl-single,pins = <
+ 			AM65X_IOPAD(0x0174, PIN_INPUT,  6)  /* (AE23) UART1_RXD */
+@@ -346,17 +958,6 @@ AM65X_IOPAD(0x02c0, PIN_OUTPUT, 0)  /* (AC8) USB1_DRVVBUS */
+ 		>;
+ 	};
+ 
+-	arduino_io_d4_to_d9_pins_default: arduino-io-d4-to-d9-pins-default {
+-		pinctrl-single,pins = <
+-			AM65X_IOPAD(0x0084, PIN_OUTPUT, 7)  /* (AG18) GPIO0_33 */
+-			AM65X_IOPAD(0x008C, PIN_OUTPUT, 7)  /* (AF17) GPIO0_35 */
+-			AM65X_IOPAD(0x0098, PIN_OUTPUT, 7)  /* (AH16) GPIO0_38 */
+-			AM65X_IOPAD(0x00AC, PIN_OUTPUT, 7)  /* (AH15) GPIO0_43 */
+-			AM65X_IOPAD(0x00C0, PIN_OUTPUT, 7)  /* (AG15) GPIO0_48 */
+-			AM65X_IOPAD(0x00CC, PIN_OUTPUT, 7)  /* (AD15) GPIO0_51 */
+-		>;
+-	};
+-
+ 	dss_vout1_pins_default: dss-vout1-pins-default {
+ 		pinctrl-single,pins = <
+ 			AM65X_IOPAD(0x0000, PIN_OUTPUT, 1)  /* VOUT1_DATA0 */
+@@ -477,14 +1078,7 @@ &main_uart2 {
+ 	status = "disabled";
+ };
+ 
+-&mcu_uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&arduino_uart_pins_default>;
+-};
+-
+ &main_gpio0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&arduino_io_d4_to_d9_pins_default>;
+ 	gpio-line-names =
+ 		"main_gpio0-base", "", "", "", "", "", "", "", "", "",
+ 		"", "", "", "", "", "", "", "", "", "",
+@@ -497,12 +1091,12 @@ &main_gpio0 {
+ &wkup_gpio0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <
+-		&arduino_io_d2_to_d3_pins_default
+ 		&arduino_i2c_aio_switch_pins_default
+ 		&arduino_io_oe_pins_default
+ 		&push_button_pins_default
+ 		&db9_com_mode_pins_default
+ 	>;
++
+ 	gpio-line-names =
+ 		/* 0..9 */
+ 		"wkup_gpio0-base", "", "", "", "UART0-mode1", "UART0-mode0",
+@@ -679,9 +1273,6 @@ &usb1 {
+ };
+ 
+ &mcu_spi0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&mcu_spi0_pins_default>;
+-
+ 	#address-cells = <1>;
+ 	#size-cells= <0>;
+ 	ti,pindir-d0-out-d1-in;
+diff --git a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2.dts b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2.dts
+index cbc411c8fe1d..aacbf7c6a3c4 100644
+--- a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2.dts
++++ b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2.dts
+@@ -66,7 +66,7 @@ AM65X_IOPAD(0x001c, PIN_INPUT_PULLUP, 7)  /* (C23) GPIO1_89 */
+ 
+ &main_gpio0 {
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&main_m2_pcie_mux_control &arduino_io_d4_to_d9_pins_default>;
++	pinctrl-0 = <&main_m2_pcie_mux_control>;
+ };
+ 
+ &main_gpio1 {


### PR DESCRIPTION
This pull requests covers roughly the following topics:

* Add patches to mraa for supporting pinmuxing via debugfs rather than mmap'ed access to pad configuration registers
* Add patches (linux-iot2050) for supporting the userspace pinmux feature (available since v5.13)
* Add one patch (linux-iot2050) to adapt the iot20250 device tree to support the userspace pinmux feature 

I see that there are a lot of changes to persistent kernel patch series which have changed due to my workflow. Changes only apply to nothing but the commit hashes. During kernel development I fetched the cip kernel and applied all persistent patches and then recreated them with my additional patchset. 
Please don't hesitate to correct me here!

My patchset starts at "0211-pinctrl-pinmux-add-function-selector-to-pinmux-funct.patch".
  