### PR TITLE
add commandline tool to check rtc battery status

### DIFF
--- a/recipes-app/read-rtc-battery/files/src/CMakeLists.txt
+++ b/recipes-app/read-rtc-battery/files/src/CMakeLists.txt
@@ -1,7 +1,15 @@
+#
+# Copyright (c) Siemens AG, 2019-2023
+#
+# Authors:
+#  Torsten Hahn <torsten.hahn.extern@siemens.com>
+#
+# This file is subject to the terms and conditions of the MIT License.  See
+# COPYING.MIT file in the top-level directory.
+#
 cmake_minimum_required(VERSION 3.2)
 project(read-rtc-battery)
 include_directories(.)
 add_executable(readrtcbattery readrtcbattery.c)
 set(CMAKE_INSTALL_PREFIX "/usr")
-# target_link_libraries(switchserialmode usb-1.0 gpiod)
 install(TARGETS readrtcbattery RUNTIME DESTINATION bin)

--- a/recipes-app/read-rtc-battery/files/src/CMakeLists.txt
+++ b/recipes-app/read-rtc-battery/files/src/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.2)
+project(read-rtc-battery)
+include_directories(.)
+add_executable(readrtcbattery readrtcbattery.c)
+set(CMAKE_INSTALL_PREFIX "/usr")
+# target_link_libraries(switchserialmode usb-1.0 gpiod)
+install(TARGETS readrtcbattery RUNTIME DESTINATION bin)

--- a/recipes-app/read-rtc-battery/files/src/readrtcbattery.c
+++ b/recipes-app/read-rtc-battery/files/src/readrtcbattery.c
@@ -1,0 +1,47 @@
+#include <sys/ioctl.h>
+#include <stdio.h>
+#include <linux/rtc.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+int main()
+{
+    int fd; // Device file path
+    int batteryStatus; // Status of battery 
+    int retval = 0; // Return value of ioctl function (-1 = Error)
+
+    // 1st step: Open Driver
+    printf("\nOpening Driver\n");
+    fd = open("/dev/rtc", O_RDONLY);
+
+    // 2nd step: Display error in command line if the device
+    // file wasn't found and close application
+    if(fd < 0) {
+        printf("Device file not found n\n");
+        return 0;
+    }
+
+
+    // 3rd step: Read out 
+    printf("Process ioctl access to read battery status\n");
+    retval = ioctl(fd, RTC_VL_DATA_INVALID, &batteryStatus);
+
+    if (retval == -1){
+        // 4th step: Display error in command line if the ioctl function isn't able to access 
+        // the specific function
+        printf("Error access ioctl function \n");
+        return 0; 
+    } else {
+        // 5th step: Print battery status
+        printf("Battery status (1 = Error) %d\n", batteryStatus);
+    }
+        // Close driver
+        printf("Closing Driver\n");
+        close(fd);
+} // main

--- a/recipes-app/read-rtc-battery/files/src/readrtcbattery.c
+++ b/recipes-app/read-rtc-battery/files/src/readrtcbattery.c
@@ -37,7 +37,6 @@ int main()
     }
 
     // 3rd step: Read out 
-    printf("Process ioctl access to read battery status\n");
     retval = ioctl(fd, RTC_VL_DATA_INVALID, &batteryStatus);
 
     if (retval == -1) {
@@ -49,8 +48,6 @@ int main()
         // 5th step: Print battery status
         printf("Battery status (1 = Error) %d\n", batteryStatus);
     }
-    // Close driver
-    printf("Closing Driver\n");
     close(fd);
 
     return EXIT_SUCCESS;

--- a/recipes-app/read-rtc-battery/files/src/readrtcbattery.c
+++ b/recipes-app/read-rtc-battery/files/src/readrtcbattery.c
@@ -1,3 +1,13 @@
+/**
+* Copyright (c) Siemens AG, 2019-2023
+*
+* Authors:
+*  Torsten Hahn <torsten.hahn.extern@siemens.com>
+*
+* This file is subject to the terms and conditions of the MIT License.  See
+* COPYING.MIT file in the top-level directory.
+*
+**/
 #include <sys/ioctl.h>
 #include <stdio.h>
 #include <linux/rtc.h>
@@ -17,31 +27,31 @@ int main()
     int retval = 0; // Return value of ioctl function (-1 = Error)
 
     // 1st step: Open Driver
-    printf("\nOpening Driver\n");
     fd = open("/dev/rtc", O_RDONLY);
 
     // 2nd step: Display error in command line if the device
     // file wasn't found and close application
-    if(fd < 0) {
-        printf("Device file not found n\n");
-        return 0;
+    if (fd < 0) {
+        printf("Device file not found\n");
+        return EXIT_FAILURE;
     }
-
 
     // 3rd step: Read out 
     printf("Process ioctl access to read battery status\n");
     retval = ioctl(fd, RTC_VL_DATA_INVALID, &batteryStatus);
 
-    if (retval == -1){
+    if (retval == -1) {
         // 4th step: Display error in command line if the ioctl function isn't able to access 
         // the specific function
         printf("Error access ioctl function \n");
-        return 0; 
+        return EXIT_FAILURE; 
     } else {
         // 5th step: Print battery status
         printf("Battery status (1 = Error) %d\n", batteryStatus);
     }
-        // Close driver
-        printf("Closing Driver\n");
-        close(fd);
+    // Close driver
+    printf("Closing Driver\n");
+    close(fd);
+
+    return EXIT_SUCCESS;
 } // main

--- a/recipes-app/read-rtc-battery/read-rtc-battery_0.1.bb
+++ b/recipes-app/read-rtc-battery/read-rtc-battery_0.1.bb
@@ -1,0 +1,30 @@
+#
+# Copyright (c) Siemens AG, 2019-2023
+#
+# Authors:
+#  Torsten Hahn <torsten.hahn.extern@siemens.com>
+#
+# This file is subject to the terms and conditions of the MIT License.  See
+# COPYING.MIT file in the top-level directory.
+#
+
+inherit dpkg
+
+DESCRIPTION = "Commandline tool to read the state of the rtc battery"
+MAINTAINER = "torsten.hahn.ext@siemens.com"
+
+SRC_URI = "file://src"
+
+S = "${WORKDIR}/src"
+
+DEBIAN_BUILD_DEPENDS = "cmake"
+DEBIAN_DEPENDS = "\${shlibs:Depends}"
+
+do_prepare_build[cleandirs] += "${S}/debian"
+
+do_prepare_build() {
+    deb_debianize
+}
+
+# propably correct permissions 
+

--- a/recipes-core/images/iot2050-image-example.bb
+++ b/recipes-core/images/iot2050-image-example.bb
@@ -45,6 +45,7 @@ IMAGE_INSTALL += " \
     libteec1 \
     optee-client-dev \
     tee-supplicant \
+    read-rtc-battery \
     "
 
 IOT2050_CORAL_SUPPORT ?= "1"


### PR DESCRIPTION
The patch adds the readrtcbattery commandline tool that prints the current status of the rtc battery (1 == faulty, 0 == ok). 