### PR TITLE
iot2050-example-image: Fix wrongly installed openssl armhf

### DIFF
--- a/recipes-core/images/iot2050-image-example.bb
+++ b/recipes-core/images/iot2050-image-example.bb
@@ -28,7 +28,8 @@ IMAGE_PREINSTALL += "${@ ' \
     ' if d.getVar('IOT2050_DOCKER_SUPPORT') == '1' else ''}"
 
 IMAGE_INSTALL += " \
-    openssl-compat \
+    libssl1.1-compat \
+    openssl \
     expand-on-first-boot \
     sshd-regen-keys \
     regen-rootfs-uuid \

--- a/recipes-security/openssl/openssl_latest.bb
+++ b/recipes-security/openssl/openssl_latest.bb
@@ -16,6 +16,8 @@ SRC_URI = " \
     "
 CHANGELOG_V="<orig-version>+iot2050"
 
+PROVIDES += "libssl1.1"
+
 DEB_BUILD_OPTIONS += "nocheck"
 
 do_prepare_build() {


### PR DESCRIPTION
The openssl (target version, arm64) should be installed into the example image, not the openssl-compat (armhf version).

Meanwhile integrate the libssl1.1-compat for armhf compatible architecture.

Test result:

```shell
root@iot2050-debian:~# apt list --installed | grep ssl

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

libssl-dev/now 1.1.1n-0+deb11u4+iot2050 arm64 [installed,local]
libssl1.1/now 1.1.1n-0+deb11u4+iot2050 arm64 [installed,local]
libssl1.1/now 1.1.1n-0+deb11u4+iot2050 armhf [installed,local]
openssl/now 1.1.1n-0+deb11u4+iot2050 arm64 [installed,local]
```