### PR TITLE
Automate the RPMB key pairing

### DIFF
--- a/recipes-bsp/u-boot/README.md
+++ b/recipes-bsp/u-boot/README.md
@@ -95,9 +95,33 @@ key, together with a special U-Boot binary for kicking off the key programming.
 > To protected the programmed RPMB key, it is required to flash a signed image,
 > program secure boot keys and enable secure boot.
 
+When booting this special firmware, the RPMB key provisioning starts
+automatically. The result could be checked either:
 
-To kick off the key programming, when booting the special firmware, press any
-key to enter to the u-boot console and issue below commands:
+- By Linux `mmc` command (with `mmc-utils` installed):
+
+    ```shell
+    mmc rpmb read-counter /dev/mmcblk1rpmb
+    ```
+
+    Returned "RPMB operation failed, retcode 0x0007" means no RPMB key was
+    enrolled. on the other hand, the write counter value of RPMB will be read
+    out, for the very first time enrolled RPMB key, the message is like this:
+    "Counter value: 0x00000cef".
+
+- Or by checking the u-boot log, an successful provisioning is indicated with
+  something like:
+
+    ```
+    Wrote 2 bytes
+    Read 2 bytes, value = 1
+    ```
+
+    If failed, the log would print something like "Failed to write(read)
+    persistent value".
+
+You can also perform the key provisioning manually by breaking the u-boot
+autoboot then manually run below commands in u-boot console:
 
 ```
 mmc dev 1
@@ -108,14 +132,10 @@ optee_rpmb read_pvalue paired 2
 `mmc dev 1` is for setting the eMMC as the current mmc device.
 
 `optee_rpmb write_pvalue paired 1` triggers the RPMB key programming, then write
-a persistent value 1 named with `paired` to the RPMB based secure storage. A
-successful running of this command returns:
-```
-Wrote 2 bytes
-```
+a persistent value 1 named with `paired` to the RPMB based secure storage.
 
 `optee_rpmb read_pvalue paired 2` reads back the written persistent value for
-checking. It should return
-```
-Read 2 bytes, value = 1
-```
+checking.
+
+The auto provisioning is actually calling these three commands, so you would see
+similar return messages.

--- a/recipes-bsp/u-boot/files/rpmb-setup.cfg
+++ b/recipes-bsp/u-boot/files/rpmb-setup.cfg
@@ -1,0 +1,2 @@
+### RPMB key pairing config
+CONFIG_BOOTCOMMAND="setenv pair_rpmb_key 'mmc dev 1; optee_rpmb write_pvalue paired 1; optee_rpmb read_pvalue paired 2;'; run pair_rpmb_key; run start_watchdog; run distro_bootcmd"

--- a/recipes-bsp/u-boot/u-boot-iot2050.inc
+++ b/recipes-bsp/u-boot/u-boot-iot2050.inc
@@ -23,6 +23,8 @@ SRC_URI:append:secureboot = " \
     file://secure-boot.cfg"
 SRC_URI:append:otpcmd = " \
     file://otpcmd.cfg"
+SRC_URI:append:rpmb-setup = " \
+    file://rpmb-setup.cfg"
 
 U_BOOT_BIN = "flash.bin"
 U_BOOT_ENV = "u-boot-initial-env"
@@ -80,6 +82,14 @@ do_prepare_build:append:otpcmd() {
     ln -sf /usr/lib/secure-boot-otp-provisioning/otpcmd.bin ${S}
     sed -ni '/### OTP command config/q;p' ${S}/configs/${U_BOOT_CONFIG}
     cat ${WORKDIR}/otpcmd.cfg >> ${S}/configs/${U_BOOT_CONFIG}
+}
+
+do_prepare_build:append:rpmb-setup() {
+    if [ "${PRODUCT_GENERATION}" = "pg1" ]; then
+        bbwarn "PG1 devices do not support RPMB based secure storage"
+    fi
+    sed -ni '/### RPMB key pairing config/q;p' ${S}/configs/${U_BOOT_CONFIG}
+    cat ${WORKDIR}/rpmb-setup.cfg >> ${S}/configs/${U_BOOT_CONFIG}
 }
 
 do_deploy() {

--- a/recipes-core/images/iot2050-package-selections.inc
+++ b/recipes-core/images/iot2050-package-selections.inc
@@ -57,6 +57,7 @@ IOT2050_DEBIAN_DEBUG_PACKAGES = " \
     usb-modeswitch \
     systemd-timesyncd \
     efitools \
+    mmc-utils \
     "
 
 # wifi support


### PR DESCRIPTION
Before some manual steps were required under u-boot console to trigger
the RPMB key provisioning, this was not so friendly for both the users
and the factory during manufactoring.

With this change, manual trigger is never required. Now by booting the
special firmware, the RPMB key is auto provisioned. And the result could
be checked both from frimware booting log and from linux `mmc` command.

Although, with a well equiped kernel image - with CONFIG_TEE_STMM_EFI or
CONFIG_TCG_FTPM_TEE enabled, it is also possible to auto provision the
RPMB key by a simple booting of that OS image, this brings extra
dependency on the OS image. It's better for the bootloader to finish
this task by its own, which benifits for some operation envioronment,
such as the manufactoring.