### PR TITLE
linux-iot2050: Update patch for TEE-based EFI variable driver

### DIFF
--- a/recipes-kernel/linux/files/patches-5.10/0210-efi-Add-tee-based-EFI-variable-driver.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0210-efi-Add-tee-based-EFI-variable-driver.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Masahisa Kojima <masahisa.kojima@linaro.org>
-Date: Mon, 20 Feb 2023 14:17:22 +0900
+Date: Fri, 26 May 2023 03:07:47 +0200
 Subject: [PATCH] efi: Add tee-based EFI variable driver
 
 When the flash is not owned by the non-secure world, accessing the EFI
@@ -29,15 +29,18 @@ so that this tee_stmm_efi module is probed after tee-supplicant starts,
 since "SetVariable" EFI Runtime Variable Service requires to
 interact with tee-supplicant.
 
+Acked-by: Sumit Garg <sumit.garg@linaro.org>
 Co-developed-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
 Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
 Signed-off-by: Masahisa Kojima <masahisa.kojima@linaro.org>
+[Jan: ported to 5.10]
+Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
 ---
  drivers/firmware/efi/Kconfig                 |  15 +
  drivers/firmware/efi/Makefile                |   1 +
- drivers/firmware/efi/stmm/mm_communication.h | 249 ++++++++
- drivers/firmware/efi/stmm/tee_stmm_efi.c     | 626 +++++++++++++++++++
- 4 files changed, 891 insertions(+)
+ drivers/firmware/efi/stmm/mm_communication.h | 236 +++++++
+ drivers/firmware/efi/stmm/tee_stmm_efi.c     | 607 +++++++++++++++++++
+ 4 files changed, 859 insertions(+)
  create mode 100644 drivers/firmware/efi/stmm/mm_communication.h
  create mode 100644 drivers/firmware/efi/stmm/tee_stmm_efi.c
 
@@ -78,14 +81,14 @@ index d6ca2da19339..6a5b4d81672a 100644
 +obj-$(CONFIG_TEE_STMM_EFI)		+= stmm/tee_stmm_efi.o
 diff --git a/drivers/firmware/efi/stmm/mm_communication.h b/drivers/firmware/efi/stmm/mm_communication.h
 new file mode 100644
-index 000000000000..a7fa6723d56e
+index 000000000000..52a1f32cd1eb
 --- /dev/null
 +++ b/drivers/firmware/efi/stmm/mm_communication.h
-@@ -0,0 +1,249 @@
+@@ -0,0 +1,236 @@
 +/* SPDX-License-Identifier: GPL-2.0+ */
 +/*
 + *  Headers for EFI variable service via StandAloneMM, EDK2 application running
-+ *  in OP-TEE
++ *  in OP-TEE. Most of the structs and defines resemble the EDK2 naming.
 + *
 + *  Copyright (c) 2017, Intel Corporation. All rights reserved.
 + *  Copyright (C) 2020 Linaro Ltd.
@@ -102,7 +105,10 @@ index 000000000000..a7fa6723d56e
 +
 +#define PTA_STMM_CMD_COMMUNICATE 0
 +
-+/* OP-TEE is using big endian GUIDs while UEFI uses little endian ones */
++/*
++ * Defined in OP-TEE, this UUID is used to identify the pseudo-TA.
++ * OP-TEE is using big endian GUIDs while UEFI uses little endian ones
++ */
 +#define PTA_STMM_UUID \
 +	UUID_INIT(0xed32d533, 0x99e6, 0x4209, \
 +		  0x9c, 0xc0, 0x2d, 0x72, 0xcd, 0xd9, 0x98, 0xa7)
@@ -110,8 +116,6 @@ index 000000000000..a7fa6723d56e
 +#define EFI_MM_VARIABLE_GUID \
 +	EFI_GUID(0xed32d533, 0x99e6, 0x4209, \
 +		 0x9c, 0xc0, 0x2d, 0x72, 0xcd, 0xd9, 0x98, 0xa7)
-+
-+/* Defined in EDK2 MdePkg/Include/Protocol/MmCommunication.h */
 +
 +/**
 + * struct efi_mm_communicate_header - Header used for SMM variable communication
@@ -121,7 +125,7 @@ index 000000000000..a7fa6723d56e
 + *                header
 + * @data:         payload of the message
 + *
-+ * Defined in EDK2 as EFI_MM_COMMUNICATE_HEADER.
++ * Defined in the PI spec as EFI_MM_COMMUNICATE_HEADER.
 + * To avoid confusion in interpreting frames, the communication buffer should
 + * always begin with efi_mm_communicate_header.
 + */
@@ -134,16 +138,12 @@ index 000000000000..a7fa6723d56e
 +#define MM_COMMUNICATE_HEADER_SIZE \
 +	(sizeof(struct efi_mm_communicate_header))
 +
-+/* Defined in EDK2 ArmPkg/Include/IndustryStandard/ArmMmSvc.h */
-+
 +/* SPM return error codes */
 +#define ARM_SVC_SPM_RET_SUCCESS               0
 +#define ARM_SVC_SPM_RET_NOT_SUPPORTED        -1
 +#define ARM_SVC_SPM_RET_INVALID_PARAMS       -2
 +#define ARM_SVC_SPM_RET_DENIED               -3
 +#define ARM_SVC_SPM_RET_NO_MEMORY            -5
-+
-+/* Defined in EDK2 MdeModulePkg/Include/Guid/SmmVariableCommon.h */
 +
 +#define SMM_VARIABLE_FUNCTION_GET_VARIABLE  1
 +/*
@@ -202,8 +202,6 @@ index 000000000000..a7fa6723d56e
 + * @function:     function to call in Smm.
 + * @ret_status:   return status
 + * @data:         payload
-+ *
-+ * Defined in EDK2 as SMM_VARIABLE_COMMUNICATE_HEADER.
 + */
 +struct smm_variable_communicate_header {
 +	size_t  function;
@@ -224,8 +222,6 @@ index 000000000000..a7fa6723d56e
 + * @attr:         attributes
 + * @name:         variable name
 + *
-+ * Defined in EDK2 as SMM_VARIABLE_COMMUNICATE_ACCESS_VARIABLE.
-+ *
 + */
 +struct smm_variable_access {
 +	efi_guid_t  guid;
@@ -243,8 +239,6 @@ index 000000000000..a7fa6723d56e
 + *
 + * @size:  size to fill in
 + *
-+ * Defined in EDK2 as SMM_VARIABLE_COMMUNICATE_GET_PAYLOAD_SIZE.
-+ *
 + */
 +struct smm_variable_payload_size {
 +	size_t size;
@@ -258,7 +252,6 @@ index 000000000000..a7fa6723d56e
 + * @name_size:  size of the name of the variable
 + * @name:       variable name
 + *
-+ * Defined in EDK2 as SMM_VARIABLE_COMMUNICATE_GET_NEXT_VARIABLE_NAME.
 + */
 +struct smm_variable_getnext {
 +	efi_guid_t  guid;
@@ -278,7 +271,6 @@ index 000000000000..a7fa6723d56e
 + * @max_variable_size:           max variable supported size
 + * @attr:                        attributes to query storage for
 + *
-+ * Defined in EDK2 as SMM_VARIABLE_COMMUNICATE_QUERY_VARIABLE_INFO.
 + */
 +struct smm_variable_query_info {
 +	u64 max_variable_storage;
@@ -302,7 +294,6 @@ index 000000000000..a7fa6723d56e
 + * @maxsize:    maximum allowed size for variable payload checked against
 + *              smm_variable_access->datasize in StMM
 + *
-+ * Defined in EDK2 as VAR_CHECK_VARIABLE_PROPERTY.
 + */
 +struct var_check_property {
 +	u16 revision;
@@ -321,7 +312,6 @@ index 000000000000..a7fa6723d56e
 + * @property:   variable properties struct
 + * @name:       variable name
 + *
-+ * Defined in EDK2 as SMM_VARIABLE_COMMUNICATE_VAR_CHECK_VARIABLE_PROPERTY.
 + */
 +struct smm_variable_var_check_property {
 +	efi_guid_t guid;
@@ -333,19 +323,20 @@ index 000000000000..a7fa6723d56e
 +#endif /* _MM_COMMUNICATION_H_ */
 diff --git a/drivers/firmware/efi/stmm/tee_stmm_efi.c b/drivers/firmware/efi/stmm/tee_stmm_efi.c
 new file mode 100644
-index 000000000000..572604575519
+index 000000000000..ece95bf1ff77
 --- /dev/null
 +++ b/drivers/firmware/efi/stmm/tee_stmm_efi.c
-@@ -0,0 +1,626 @@
+@@ -0,0 +1,607 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + *  EFI variable service via TEE
 + *
 + *  Copyright (C) 2022 Linaro
 + */
-+#include <linux/module.h>
++
 +#include <linux/efi.h>
 +#include <linux/kernel.h>
++#include <linux/module.h>
 +#include <linux/slab.h>
 +#include <linux/tee.h>
 +#include <linux/tee_drv.h>
@@ -463,17 +454,20 @@ index 000000000000..572604575519
 + * mm_communicate() - Adjust the communication buffer to StandAlonneMM and send
 + * it to TEE
 + *
-+ * @comm_buf:		locally allocated communication buffer
-+ * @dsize:		buffer size
++ * @comm_buf:		locally allocated communication buffer, buffer should
++ *			be enough big to have some headers and payload
++ * @payload_size:	payload size
 + * Return:		status code
 + */
-+static efi_status_t mm_communicate(u8 *comm_buf, size_t dsize)
++static efi_status_t mm_communicate(u8 *comm_buf, size_t payload_size)
 +{
++	size_t dsize;
 +	efi_status_t ret;
 +	struct efi_mm_communicate_header *mm_hdr;
 +	struct smm_variable_communicate_header *var_hdr;
 +
-+	dsize += MM_COMMUNICATE_HEADER_SIZE + MM_VARIABLE_COMMUNICATE_SIZE;
++	dsize = payload_size + MM_COMMUNICATE_HEADER_SIZE +
++		MM_VARIABLE_COMMUNICATE_SIZE;
 +	mm_hdr = (struct efi_mm_communicate_header *)comm_buf;
 +	var_hdr = (struct smm_variable_communicate_header *)mm_hdr->data;
 +
@@ -490,15 +484,14 @@ index 000000000000..572604575519
 + * setup_mm_hdr() -	Allocate a buffer for StandAloneMM and initialize the
 + *			header data.
 + *
-+ * @dptr:		pointer address of the corresponding StandAloneMM
-+ *			function
-+ * @payload_size:	buffer size
++ * @dptr:		pointer address to store allocated buffer
++ * @payload_size:	payload size
 + * @func:		standAloneMM function number
 + * @ret:		EFI return code
-+ * Return:		buffer or NULL
++ * Return:		pointer to corresponding StandAloneMM function buffer or NULL
 + */
-+static u8 *setup_mm_hdr(void **dptr, size_t payload_size, size_t func,
-+			efi_status_t *ret)
++static void *setup_mm_hdr(u8 **dptr, size_t payload_size, size_t func,
++			  efi_status_t *ret)
 +{
 +	const efi_guid_t mm_var_guid = EFI_MM_VARIABLE_GUID;
 +	struct efi_mm_communicate_header *mm_hdr;
@@ -532,10 +525,10 @@ index 000000000000..572604575519
 +	var_hdr = (struct smm_variable_communicate_header *)mm_hdr->data;
 +	var_hdr->function = func;
 +	if (dptr)
-+		*dptr = var_hdr->data;
++		*dptr = comm_buf;
 +	*ret = EFI_SUCCESS;
 +
-+	return comm_buf;
++	return var_hdr->data;
 +}
 +
 +/**
@@ -557,8 +550,9 @@ index 000000000000..572604575519
 +	}
 +
 +	payload_size = sizeof(*var_payload);
-+	comm_buf = setup_mm_hdr((void **)&var_payload, payload_size,
-+				SMM_VARIABLE_FUNCTION_GET_PAYLOAD_SIZE, &ret);
++	var_payload = setup_mm_hdr(&comm_buf, payload_size,
++				   SMM_VARIABLE_FUNCTION_GET_PAYLOAD_SIZE,
++				   &ret);
 +	if (!comm_buf)
 +		goto out;
 +
@@ -603,8 +597,8 @@ index 000000000000..572604575519
 +		ret = EFI_INVALID_PARAMETER;
 +		goto out;
 +	}
-+	comm_buf = setup_mm_hdr(
-+		(void **)&smm_property, payload_size,
++	smm_property = setup_mm_hdr(
++		&comm_buf, payload_size,
 +		SMM_VARIABLE_FUNCTION_VAR_CHECK_VARIABLE_PROPERTY_GET, &ret);
 +	if (!comm_buf)
 +		goto out;
@@ -665,8 +659,8 @@ index 000000000000..572604575519
 +
 +	/* Get communication buffer and initialize header */
 +	payload_size = MM_VARIABLE_ACCESS_HEADER_SIZE + name_size + tmp_dsize;
-+	comm_buf = setup_mm_hdr((void **)&var_acc, payload_size,
-+				SMM_VARIABLE_FUNCTION_GET_VARIABLE, &ret);
++	var_acc = setup_mm_hdr(&comm_buf, payload_size,
++			       SMM_VARIABLE_FUNCTION_GET_VARIABLE, &ret);
 +	if (!comm_buf)
 +		goto out;
 +
@@ -738,9 +732,9 @@ index 000000000000..572604575519
 +			max_payload_size - MM_VARIABLE_GET_NEXT_HEADER_SIZE;
 +
 +	payload_size = MM_VARIABLE_GET_NEXT_HEADER_SIZE + out_name_size;
-+	comm_buf = setup_mm_hdr((void **)&var_getnext, payload_size,
-+				SMM_VARIABLE_FUNCTION_GET_NEXT_VARIABLE_NAME,
-+				&ret);
++	var_getnext = setup_mm_hdr(&comm_buf, payload_size,
++				   SMM_VARIABLE_FUNCTION_GET_NEXT_VARIABLE_NAME,
++				   &ret);
 +	if (!comm_buf)
 +		goto out;
 +
@@ -800,8 +794,8 @@ index 000000000000..572604575519
 +	 * so we won't need to account for any failures in reading/setting
 +	 * the properties, if the allocation fails
 +	 */
-+	comm_buf = setup_mm_hdr((void **)&var_acc, payload_size,
-+				SMM_VARIABLE_FUNCTION_SET_VARIABLE, &ret);
++	var_acc = setup_mm_hdr(&comm_buf, payload_size,
++			       SMM_VARIABLE_FUNCTION_SET_VARIABLE, &ret);
 +	if (!comm_buf)
 +		goto out;
 +
@@ -837,35 +831,13 @@ index 000000000000..572604575519
 +	return ret;
 +}
 +
-+static efi_status_t __maybe_unused tee_query_variable_info(u32 attributes,
-+					    u64 *max_variable_storage_size,
-+					    u64 *remain_variable_storage_size,
-+					    u64 *max_variable_size)
++static efi_status_t tee_set_variable_nonblocking(efi_char16_t *name,
++						 efi_guid_t *vendor,
++						 u32 attributes,
++						 unsigned long data_size,
++						 void *data)
 +{
-+	struct smm_variable_query_info *mm_query_info;
-+	size_t payload_size;
-+	efi_status_t ret;
-+	u8 *comm_buf;
-+
-+	payload_size = sizeof(*mm_query_info);
-+	comm_buf = setup_mm_hdr((void **)&mm_query_info, payload_size,
-+				SMM_VARIABLE_FUNCTION_QUERY_VARIABLE_INFO,
-+				&ret);
-+	if (!comm_buf)
-+		goto out;
-+
-+	mm_query_info->attr = attributes;
-+	ret = mm_communicate(comm_buf, payload_size);
-+	if (ret != EFI_SUCCESS)
-+		goto out;
-+	*max_variable_storage_size = mm_query_info->max_variable_storage;
-+	*remain_variable_storage_size =
-+		mm_query_info->remaining_variable_storage;
-+	*max_variable_size = mm_query_info->max_variable_size;
-+
-+out:
-+	kfree(comm_buf);
-+	return ret;
++	return EFI_UNSUPPORTED;
 +}
 +
 +static int tee_stmm_efi_probe(struct device *dev)
@@ -905,8 +877,7 @@ index 000000000000..572604575519
 +	tee_efivar_ops.get_variable = tee_get_variable;
 +	tee_efivar_ops.get_next_variable = tee_get_next_variable;
 +	tee_efivar_ops.set_variable = tee_set_variable;
-+	/* TODO: support non-blocking variant */
-+	tee_efivar_ops.set_variable_nonblocking = NULL;
++	tee_efivar_ops.set_variable_nonblocking = tee_set_variable_nonblocking;
 +	tee_efivar_ops.query_variable_store = efi_query_variable_store;
 +
 +	efivars_generic_ops_unregister();

--- a/recipes-kernel/linux/linux-iot2050-5.10.inc
+++ b/recipes-kernel/linux/linux-iot2050-5.10.inc
@@ -20,6 +20,7 @@ def get_patches(d, patchdir):
 SRC_URI += " \
     https://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git/snapshot/linux-cip-${PV}.tar.gz \
     ${@get_patches(d, 'patches-5.10')} \
+    file://patches-5.10/ \
     file://${KERNEL_DEFCONFIG} \
     file://iot2050_defconfig_extra.cfg"
 


### PR DESCRIPTION
This one is based on v5 that is now staged in efi-next.