### PR TITLE
ci cancel in progress for same branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,10 @@ name: CI
 
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   debian-example-image:
     name: Debian example image


### PR DESCRIPTION
This could save some resources, also makes the queue shorter,
environmentally friendly :)