### PR TITLE
lightdm-fb: add hotplug support for display port

### DIFF
--- a/kas/opt/lxde.yml
+++ b/kas/opt/lxde.yml
@@ -13,4 +13,4 @@ header:
 
 local_conf_header:
   add-lxde: |
-    IMAGE_INSTALL += "lxde-touch"
+    IMAGE_INSTALL += "lxde-touch lightdm-fb"

--- a/recipes-core/lightdm-fb/files/postinst
+++ b/recipes-core/lightdm-fb/files/postinst
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Siemens AG, 2023
+#
+# This file is subject to the terms and conditions of the MIT License.  See
+# COPYING.MIT file in the top-level directory.
+#
+
+# Add support for hotplug of Display Port
+sed -i 's/LABEL="systemd_end"/SUBSYSTEM=="graphics", KERNEL=="fb0", SYMLINK="fb0", TAG+="systemd"\nLABEL="systemd_end"/g' /lib/udev/rules.d/99-systemd.rules
+
+sed -i '/plymouth/d' /lib/systemd/system/lightdm.service
+sed -i '/Service/i Conflicts=getty@tty1.service getty@tty7.service\nAfter=getty@tty1.service getty@tty7.service\nBindsTo=dev-fb0.device\nAfter=dev-fb0.device\n' /lib/systemd/system/lightdm.service

--- a/recipes-core/lightdm-fb/lightdm-fb_0.1.bb
+++ b/recipes-core/lightdm-fb/lightdm-fb_0.1.bb
@@ -1,0 +1,14 @@
+#
+# Copyright (c) Siemens AG, 2023
+#
+# This file is subject to the terms and conditions of the MIT License.  See
+# COPYING.MIT file in the top-level directory.
+#
+
+inherit dpkg-raw
+
+DESCRIPTION = "Add hotplug Display Port support for Light Desktop Manager"
+
+DEBIAN_DEPENDS = "lightdm,systemd"
+
+SRC_URI = "file://postinst"


### PR DESCRIPTION
Add hotplug support for display port.
Add lightdm-fb package to lxde.yml by default

Fixes: https://github.com/siemens/meta-iot2050/issues/463