### PR TITLE
Fix for RPMB key writing

### DIFF
--- a/kas/opt/rpmb-setup.yml
+++ b/kas/opt/rpmb-setup.yml
@@ -13,4 +13,5 @@ header:
 
 local_conf_header:
   optee-os-iot2050_override: |
+    OVERRIDES .= ":uefi-stmm"
     OVERRIDES .= ":rpmb-setup"

--- a/kas/opt/secure-boot.yml
+++ b/kas/opt/secure-boot.yml
@@ -10,6 +10,7 @@ header:
 
 local_conf_header:
   secureboot_override: |
+    OVERRIDES .= ":uefi-stmm"
     OVERRIDES .= ":secureboot"
   secure-boot-signer: |
     IMAGER_BUILD_DEPS += "ebg-secure-boot-signer"

--- a/recipes-bsp/optee-os/optee-os-iot2050_3.21.0.bb
+++ b/recipes-bsp/optee-os/optee-os-iot2050_3.21.0.bb
@@ -11,10 +11,10 @@
 require recipes-bsp/optee-os/optee-os-custom.inc
 require optee-os-iot2050_${PV}.inc
 
-# StMM integration
-DEPENDS:append:secureboot = " edk2-standalonemm-rpmb"
-DEBIAN_BUILD_DEPENDS:append:secureboot = ", edk2-standalonemm-rpmb"
-OPTEE_EXTRA_BUILDARGS:append:secureboot = " \
+# StMM integration, required by UEFI auth variable management
+DEPENDS:append:uefi-stmm = " edk2-standalonemm-rpmb"
+DEBIAN_BUILD_DEPENDS:append:uefi-stmm = ", edk2-standalonemm-rpmb"
+OPTEE_EXTRA_BUILDARGS:append:uefi-stmm = " \
     CFG_STMM_PATH=/usr/lib/edk2/BL32_AP_MM.fd \
     "
 

--- a/recipes-bsp/u-boot/files/0020-configs-Increase-malloc-size-after-relocation.patch
+++ b/recipes-bsp/u-boot/files/0020-configs-Increase-malloc-size-after-relocation.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Neha Malcom Francis <n-francis@ti.com>
+Date: Wed, 11 Jan 2023 18:11:23 +0530
+Subject: [PATCH] configs: Increase malloc size after relocation
+
+Current default size of 0x100000 is not capable of getting the FIT
+buffer during boot when transitioning to using binman generated boot
+images for certain K3 devices, so increase it to 0x400000. Since A72 SPL
+is coming after relocation to DDR this should not be an issue for any K3
+device, so make it default for all.
+
+Signed-off-by: Neha Malcom Francis <n-francis@ti.com>
+Acked-by: Andrew Davis <afd@ti.com>
+---
+ common/spl/Kconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/common/spl/Kconfig b/common/spl/Kconfig
+index a25d8fd2e0845300cde5e1782bc19c5608de576b..3c2af453ab66e2161d258c182d95371fb465f9ec 100644
+--- a/common/spl/Kconfig
++++ b/common/spl/Kconfig
+@@ -385,6 +385,7 @@ config SPL_STACK_R_ADDR
+ config SPL_STACK_R_MALLOC_SIMPLE_LEN
+ 	depends on SPL_STACK_R && SPL_SYS_MALLOC_SIMPLE
+ 	hex "Size of malloc_simple heap after switching to DRAM SPL stack"
++	default 0x400000 if ARCH_K3 && ARM64
+ 	default 0x100000
+ 	help
+ 	  Specify the amount of the stack to use as memory pool for

--- a/recipes-bsp/u-boot/u-boot-iot2050_2022.10.inc
+++ b/recipes-bsp/u-boot/u-boot-iot2050_2022.10.inc
@@ -32,6 +32,7 @@ SRC_URI += " \
     file://0017-spl-fit-Report-fdt-error-for-loading-u-boot.patch \
     file://0018-efi_loader-Let-networking-support-depend-on-NETDEVIC.patch \
     file://0019-iot2050-Refactor-the-m.2-and-minipcie-power-pin.patch \
+    file://0020-configs-Increase-malloc-size-after-relocation.patch \
     "
 
 SRC_URI[sha256sum] = "50b4482a505bc281ba8470c399a3c26e145e29b23500bc35c50debd7fa46bdf8"


### PR DESCRIPTION
Currently the RPMB key writing does not work:

1st issue was u-boot SPL complaining:

| alloc space exhausted
| Could not get FIT buffer of 1057180 bytes
|         check CONFIG_SYS_SPL_MALLOC_SIZE

This is fixed by expanding the heap size for malloc_simple.

Then comes to this issue:

| IOT2050> setenv -e -nv -bs -rt pairing 1
| I/TC: Reserved shared memory is enabled
| I/TC: Dynamic shared memory is enabled
| I/TC: Normal World virtualization support is disabled | I/TC: Asynchronous notifications are disabled
| E/LD:  init_elf:486 sys_open_ta_bin(ed32d533-99e6-4209-9cc0-2d72cdd998a7) | E/TC:? 0 ldelf_init_with_ldelf:131 ldelf failed with res: 0xffff0009 | Unable to open OP-TEE session (err=-5)
| mm_communicate failed!
| Error: Cannot initialize UEFI sub-system, r = 3

This is due to the StMM is not integrated for the rpmb-setup override.