### PR TITLE
u-boot-iot2050: Backport keyed autoboot patch

### DIFF
--- a/recipes-bsp/u-boot/files/0021-configs-iot2050-Enabled-keyed-autoboot.patch
+++ b/recipes-bsp/u-boot/files/0021-configs-iot2050-Enabled-keyed-autoboot.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jan Kiszka <jan.kiszka@siemens.com>
+Date: Thu, 27 Jul 2023 06:34:56 +0200
+Subject: [PATCH] configs: iot2050: Enabled keyed autoboot
+
+Only accept SPACE to stop autobooting. This is safer to avoid accidental
+interruptions on unattended devices.
+
+Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
+---
+ configs/iot2050_pg1_defconfig | 4 ++++
+ configs/iot2050_pg2_defconfig | 4 ++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/configs/iot2050_pg1_defconfig b/configs/iot2050_pg1_defconfig
+index 49f8110936..5034719b8b 100644
+--- a/configs/iot2050_pg1_defconfig
++++ b/configs/iot2050_pg1_defconfig
+@@ -32,6 +32,10 @@ CONFIG_OF_BOARD_SETUP=y
+ CONFIG_BOOTSTAGE=y
+ CONFIG_SHOW_BOOT_PROGRESS=y
+ CONFIG_SPL_SHOW_BOOT_PROGRESS=y
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_AUTOBOOT_FLUSH_STDIN=y
++CONFIG_AUTOBOOT_PROMPT="Hit SPACE to stop autoboot in %d seconds...\n"
++CONFIG_AUTOBOOT_STOP_STR=" "
+ CONFIG_BOOTCOMMAND="run start_watchdog; run distro_bootcmd"
+ CONFIG_CONSOLE_MUX=y
+ # CONFIG_DISPLAY_CPUINFO is not set
+diff --git a/configs/iot2050_pg2_defconfig b/configs/iot2050_pg2_defconfig
+index a31691a1d1..9c107d27f9 100644
+--- a/configs/iot2050_pg2_defconfig
++++ b/configs/iot2050_pg2_defconfig
+@@ -32,6 +32,10 @@ CONFIG_OF_BOARD_SETUP=y
+ CONFIG_BOOTSTAGE=y
+ CONFIG_SHOW_BOOT_PROGRESS=y
+ CONFIG_SPL_SHOW_BOOT_PROGRESS=y
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_AUTOBOOT_FLUSH_STDIN=y
++CONFIG_AUTOBOOT_PROMPT="Hit SPACE to stop autoboot in %d seconds...\n"
++CONFIG_AUTOBOOT_STOP_STR=" "
+ CONFIG_BOOTCOMMAND="run start_watchdog; run distro_bootcmd"
+ CONFIG_CONSOLE_MUX=y
+ # CONFIG_DISPLAY_CPUINFO is not set

--- a/recipes-bsp/u-boot/u-boot-iot2050_2022.10.inc
+++ b/recipes-bsp/u-boot/u-boot-iot2050_2022.10.inc
@@ -33,6 +33,7 @@ SRC_URI += " \
     file://0018-efi_loader-Let-networking-support-depend-on-NETDEVIC.patch \
     file://0019-iot2050-Refactor-the-m.2-and-minipcie-power-pin.patch \
     file://0020-configs-Increase-malloc-size-after-relocation.patch \
+    file://0021-configs-iot2050-Enabled-keyed-autoboot.patch \
     "
 
 SRC_URI[sha256sum] = "50b4482a505bc281ba8470c399a3c26e145e29b23500bc35c50debd7fa46bdf8"


### PR DESCRIPTION
This shall avoid accidental interruptions of the boot process.