### PR TITLE
iot2050:watchdog: Add support for WDIOF_CARDRESET

### DIFF
--- a/recipes-bsp/k3-rti-wdt/k3-rti-wdt_1.2.bb
+++ b/recipes-bsp/k3-rti-wdt/k3-rti-wdt_1.2.bb
@@ -13,7 +13,7 @@ inherit dpkg
 SRC_URI = " \
     git://github.com/siemens/k3-rti-wdt.git;protocol=https;branch=master \
     file://rules"
-SRCREV = "33a6680184996074ca9731710161520edf334725"
+SRCREV = "806a7597d7853962d3eaac6340067829af0306c0"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-bsp/u-boot/files/0022-Add-a-reserved-memory-for-watchdog.patch
+++ b/recipes-bsp/u-boot/files/0022-Add-a-reserved-memory-for-watchdog.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Li Hua Qian <huaqian.li@siemens.com>
+Date: Wed, 7 Jun 2023 11:29:59 +0800
+Subject: [PATCH] Add a reserved memory for watchdog
+
+To have the WDIOF_CARDRESET support for the TI AM65x platform watchdog,
+this patch reserves the memory, which indicates if the current boot due
+to a watchdog reset.
+
+Signed-off-by: Li Hua Qian <huaqian.li@siemens.com>
+---
+ arch/arm/dts/k3-am65-iot2050-common.dtsi | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/arch/arm/dts/k3-am65-iot2050-common.dtsi b/arch/arm/dts/k3-am65-iot2050-common.dtsi
+index e60006be..acc41335 100644
+--- a/arch/arm/dts/k3-am65-iot2050-common.dtsi
++++ b/arch/arm/dts/k3-am65-iot2050-common.dtsi
+@@ -64,6 +64,12 @@
+ 			alignment = <0x1000>;
+ 			no-map;
+ 		};
++
++		/* To reserve the power-on(PON) reason for watchdog reset */
++		wdt_reset_memory_region: wdt-memory@a2200000 {
++			reg = <0x00 0xa2200000 0x00 0x00001000>;
++			no-map;
++		};
+ 	};
+ 
+ 	leds {
+@@ -731,6 +737,11 @@
+ 	mboxes = <&mailbox0_cluster1 &mbox_mcu_r5fss0_core1>;
+ };
+ 
++&mcu_rti1 {
++	memory-region = <&wdt_reset_memory_region>;
++
++};
++
+ &icssg0_mdio {
+ 	status = "disabled";
+ };

--- a/recipes-bsp/u-boot/u-boot-iot2050_2022.10.inc
+++ b/recipes-bsp/u-boot/u-boot-iot2050_2022.10.inc
@@ -4,6 +4,7 @@
 # Authors:
 #  Jan Kiszka <jan.kiszka@siemens.com>
 #  Su Baocheng <baocheng.su@siemens.com>
+#  Li Huaqian <huaqian.li@siemens.com>
 #
 # This file is subject to the terms and conditions of the MIT License.  See
 # COPYING.MIT file in the top-level directory.
@@ -34,6 +35,7 @@ SRC_URI += " \
     file://0019-iot2050-Refactor-the-m.2-and-minipcie-power-pin.patch \
     file://0020-configs-Increase-malloc-size-after-relocation.patch \
     file://0021-configs-iot2050-Enabled-keyed-autoboot.patch \
+    file://0022-Add-a-reserved-memory-for-watchdog.patch \
     "
 
 SRC_URI[sha256sum] = "50b4482a505bc281ba8470c399a3c26e145e29b23500bc35c50debd7fa46bdf8"

--- a/recipes-kernel/linux/files/patches-5.10/0221-dt-bindings-watchdog-ti-rti-wdt-Add-support-for-WDIO.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0221-dt-bindings-watchdog-ti-rti-wdt-Add-support-for-WDIO.patch
@@ -1,0 +1,68 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Li Hua Qian <huaqian.li@siemens.com>
+Date: Fri, 7 Jul 2023 16:47:41 +0800
+Subject: [PATCH] dt-bindings: watchdog: ti,rti-wdt: Add support for
+ WDIOF_CARDRESET
+
+TI RTI (Real Time Interrupt) Watchdog doesn't support to record the
+watchdog cause. Add a reserved memory to know the last reboot was caused
+by the watchdog card. In the reserved memory, some specific info will be
+saved to indicate whether the watchdog reset was triggered in last
+boot.
+
+Signed-off-by: Li Hua Qian <huaqian.li@siemens.com>
+---
+ .../bindings/watchdog/ti,rti-wdt.yaml         | 28 ++++++++++++++++++-
+ 1 file changed, 27 insertions(+), 1 deletion(-)
+
+diff --git a/Documentation/devicetree/bindings/watchdog/ti,rti-wdt.yaml b/Documentation/devicetree/bindings/watchdog/ti,rti-wdt.yaml
+index c1348db59374..c10c571bf3c9 100644
+--- a/Documentation/devicetree/bindings/watchdog/ti,rti-wdt.yaml
++++ b/Documentation/devicetree/bindings/watchdog/ti,rti-wdt.yaml
+@@ -40,6 +40,20 @@ properties:
+   assigned-clocks-parents:
+     maxItems: 1
+ 
++  memory-region:
++    maxItems: 1
++    description:
++      Contains the watchdog reserved memory. It is optional.
++      In the reserved memory, the specified values, which are
++      PON_REASON_SOF_NUM(0xBBBBCCCC), PON_REASON_MAGIC_NUM(0xDDDDDDDD),
++      and PON_REASON_EOF_NUM(0xCCCCBBBB), are pre-stored at the first
++      3 * 4 bytes to tell that last boot was caused by watchdog reset.
++      Once the PON reason is captured by driver(rti_wdt.c), the driver
++      is supposed to wipe the whole memory region. Surely, if this
++      property is set, at least 12 bytes reserved memory starting from
++      specific memory address(0xa220000) should be set. More please
++      refer to example.
++
+ required:
+   - compatible
+   - reg
+@@ -53,7 +67,18 @@ examples:
+     /*
+      * RTI WDT in main domain on J721e SoC. Assigned clocks are used to
+      * select the source clock for the watchdog, forcing it to tick with
+-     * a 32kHz clock in this case.
++     * a 32kHz clock in this case. Add a reserved memory(optional) to keep
++     * the watchdog reset cause persistent, which was be written in 12 bytes
++     * starting from 0xa2200000 by RTI Watchdog Firmware, then make it
++     * possible to get watchdog reset cause in driver.
++     *
++     * Reserved memory should be defined as follows:
++     * reserved-memory {
++     *     wdt_reset_memory_region: wdt-memory@a2200000 {
++     *         reg = <0x00 0xa2200000 0x00 0x1000>;
++     *         no-map;
++     *     };
++     * }
+      */
+     #include <dt-bindings/soc/ti,sci_pm_domain.h>
+ 
+@@ -64,4 +89,5 @@ examples:
+         power-domains = <&k3_pds 252 TI_SCI_PD_EXCLUSIVE>;
+         assigned-clocks = <&k3_clks 252 1>;
+         assigned-clock-parents = <&k3_clks 252 5>;
++        memory-region = <&wdt_reset_memory_region>;
+     };

--- a/recipes-kernel/linux/files/patches-5.10/0222-arm64-dts-ti-Add-reserved-memory-for-watchdog.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0222-arm64-dts-ti-Add-reserved-memory-for-watchdog.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Li Hua Qian <huaqian.li@siemens.com>
+Date: Mon, 12 Jun 2023 16:21:36 +0800
+Subject: [PATCH] arm64: dts: ti: Add reserved memory for watchdog
+
+This patch adds a reserved memory for the TI AM65X platform watchdog to
+reserve the specific info, triggering the watchdog reset in last boot,
+to know if the board reboot is due to a watchdog reset.
+
+Signed-off-by: Li Hua Qian <huaqian.li@siemens.com>
+---
+ arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi
+index 3310880e83ee..5961b0943cf5 100644
+--- a/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi
++++ b/arch/arm64/boot/dts/ti/k3-am65-iot2050-common.dtsi
+@@ -67,6 +67,12 @@ rtos_ipc_memory_region: ipc-memories@a2000000 {
+ 			alignment = <0x1000>;
+ 			no-map;
+ 		};
++
++		/* To reserve the power-on(PON) reason for watchdog reset */
++		wdt_reset_memory_region: wdt-memory@a2200000 {
++			reg = <0x00 0xa2200000 0x00 0x1000>;
++			no-map;
++		};
+ 	};
+ 
+ 	leds {
+@@ -879,6 +885,10 @@ &mcu_r5fss0_core1 {
+ 	mboxes = <&mailbox0_cluster1 &mbox_mcu_r5fss0_core1>;
+ };
+ 
++&mcu_rti1 {
++	memory-region = <&wdt_reset_memory_region>;
++};
++
+ &icssg0_mdio {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&icssg0_mdio_pins_default>;

--- a/recipes-kernel/linux/files/patches-5.10/0223-watchdog-rit_wdt-Add-support-for-WDIOF_CARDRESET.patch
+++ b/recipes-kernel/linux/files/patches-5.10/0223-watchdog-rit_wdt-Add-support-for-WDIOF_CARDRESET.patch
@@ -1,0 +1,97 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Li Hua Qian <huaqian.li@siemens.com>
+Date: Mon, 12 Jun 2023 16:21:36 +0800
+Subject: [PATCH] watchdog:rit_wdt: Add support for WDIOF_CARDRESET
+
+This patch adds the WDIOF_CARDRESET support for the platform watchdog
+whose hardware does not support this feature, to know if the board
+reboot is due to a watchdog reset.
+
+This is done via reserved memory(RAM), which indicates if specific
+info saved, triggering the watchdog reset in last boot.
+
+Signed-off-by: Li Hua Qian <huaqian.li@siemens.com>
+---
+ drivers/watchdog/rti_wdt.c | 48 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 48 insertions(+)
+
+diff --git a/drivers/watchdog/rti_wdt.c b/drivers/watchdog/rti_wdt.c
+index 15a476b8aa78..6821bd5a42d6 100644
+--- a/drivers/watchdog/rti_wdt.c
++++ b/drivers/watchdog/rti_wdt.c
+@@ -14,6 +14,8 @@
+ #include <linux/mod_devicetable.h>
+ #include <linux/module.h>
+ #include <linux/moduleparam.h>
++#include <linux/of.h>
++#include <linux/of_address.h>
+ #include <linux/platform_device.h>
+ #include <linux/pm_runtime.h>
+ #include <linux/types.h>
+@@ -52,6 +54,11 @@
+ 
+ #define DWDST			BIT(1)
+ 
++#define PON_REASON_SOF_NUM	0xBBBBCCCC
++#define PON_REASON_MAGIC_NUM	0xDDDDDDDD
++#define PON_REASON_EOF_NUM	0xCCCCBBBB
++#define RESERVED_MEM_MIN_SIZE	12
++
+ static int heartbeat = DEFAULT_HEARTBEAT;
+ 
+ /*
+@@ -215,6 +222,11 @@ static int rti_wdt_probe(struct platform_device *pdev)
+ 	struct rti_wdt_device *wdt;
+ 	struct clk *clk;
+ 	u32 last_ping = 0;
++	struct device_node *node;
++	u32 reserved_mem_size;
++	struct resource res;
++	u32 *vaddr;
++	u64 paddr;
+ 
+ 	wdt = devm_kzalloc(dev, sizeof(*wdt), GFP_KERNEL);
+ 	if (!wdt)
+@@ -303,6 +315,42 @@ static int rti_wdt_probe(struct platform_device *pdev)
+ 		}
+ 	}
+ 
++	node = of_parse_phandle(pdev->dev.of_node, "memory-region", 0);
++	if (node) {
++		ret = of_address_to_resource(node, 0, &res);
++		if (ret) {
++			dev_err(dev, "No memory address assigned to the region.\n");
++			goto err_iomap;
++		}
++
++		/*
++		 * If reserved memory is defined for watchdog reset cause.
++		 * Readout the Power-on(PON) reason and pass to bootstatus.
++		 */
++		paddr = res.start;
++		reserved_mem_size = resource_size(&res);
++		if (reserved_mem_size < RESERVED_MEM_MIN_SIZE) {
++			dev_err(dev, "The size of reserved memory is too small.\n");
++			ret = -EINVAL;
++			goto err_iomap;
++		}
++
++		vaddr = memremap(paddr, reserved_mem_size, MEMREMAP_WB);
++		if (vaddr == NULL) {
++			dev_err(dev, "Failed to map memory-region.\n");
++			ret = -ENOMEM;
++			goto err_iomap;
++		}
++
++		if (vaddr[0] == PON_REASON_SOF_NUM &&
++		    vaddr[1] == PON_REASON_MAGIC_NUM &&
++		    vaddr[2] == PON_REASON_EOF_NUM) {
++			wdd->bootstatus |= WDIOF_CARDRESET;
++		}
++		memset(vaddr, 0, reserved_mem_size);
++		memunmap(vaddr);
++	}
++
+ 	watchdog_init_timeout(wdd, heartbeat, dev);
+ 
+ 	ret = watchdog_register_device(wdd);


### PR DESCRIPTION
This patch adds the WDIOF_CARDRESET support for the TI AM65x platform
watchdog, to know if the board reboot is due to a watchdog reset.

This is done via reserved memory(RAM), which indicates if specific
info saved in k3-rti-wdt, triggering the watchdog reset in last boot.