### PR TITLE
secure-boot-otp-provisioning: Reword the README.md

### DIFF
--- a/recipes-bsp/secure-boot-otp-provisioning/README.md
+++ b/recipes-bsp/secure-boot-otp-provisioning/README.md
@@ -22,8 +22,7 @@ the second keys is leaked as well, user can switch to use this key.
 ```shell
 openssl req -x509 -newkey rsa:4096 -keyout custMpk.pem -nodes -outform pem -out custMpk.crt -sha256
 openssl req -x509 -newkey rsa:4096 -keyout custSmpk.pem -nodes -outform pem -out custSmpk.crt -sha256
-# optional the third key
-#openssl req -x509 -newkey rsa:4096 -keyout custBmpk.pem -nodes -outform pem -out custBmpk.crt -sha256
+openssl req -x509 -newkey rsa:4096 -keyout custBmpk.pem -nodes -outform pem -out custBmpk.crt -sha256
 ```
 
 > :warning:
@@ -155,7 +154,7 @@ Above options could also be achieved by:
 
 Then 
 
-- select `Firmware image for PG2 devices` as the `Image type`
+- select `Firmware images` as the `Image type`
 - check `Secure boot` and `OTP provisioning` in `Image features`
 - select among `OTP provisioning command type`
 


### PR DESCRIPTION
Change the TUI method description according to the latest Kconfig wordings.

Meanwhile make the third key generation not optional, to trim the operation branches.