### PR TITLE
refactor: use change-dir to split rootfs parts

### DIFF
--- a/wic/iot2050-swu-secure.wks.in
+++ b/wic/iot2050-swu-secure.wks.in
@@ -14,7 +14,7 @@ part --source rawcopy --sourceparams "file=${IMAGE_FULLNAME}.verity" --align 102
 part --source empty --align 1024 --fixed-size 4G --uuid "${ABROOTFS_PART_UUID_B}"
 
 # persistent partitions
-part /var --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/var --label var --fstype=ext4 --mkfs-extraopts "-T default" --align 1024  --size 512M
-part /home --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/home --label home --fstype=ext4 --mkfs-extraopts "-T default" --align 1024  --size 1G
+part /var --source rootfs --change-directory=var --label var --fstype=ext4 --mkfs-extraopts "-T default" --align 1024  --size 512M
+part /home --source rootfs --change-directory=home --label home --fstype=ext4 --mkfs-extraopts "-T default" --align 1024  --size 1G
 
 bootloader --ptable gpt --append "console=ttyS3,115200n8 earlycon=ns16550a,mmio32,0x02810000 rootwait watchdog.handle_boot_enabled=0 panic=5 ${EXTRA_KERNEL_PARAMS}"

--- a/wic/iot2050-swu.wks.in
+++ b/wic/iot2050-swu.wks.in
@@ -14,7 +14,7 @@ part --source rawcopy --sourceparams "file=${IMAGE_FULLNAME}.squashfs" --align 1
 part --source empty --align 1024 --fixed-size 4G --uuid "${ABROOTFS_PART_UUID_B}"
 
 # persistent partitions
-part /var --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/var --label var --fstype=ext4 --mkfs-extraopts "-T default" --ondisk sda --align 1024  --size 512M
-part /home --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/home --label home --fstype=ext4 --mkfs-extraopts "-T default" --ondisk sda --align 1024  --size 512M
+part /var --source rootfs --change-directory=var --label var --fstype=ext4 --mkfs-extraopts "-T default" --ondisk sda --align 1024  --size 512M
+part /home --source rootfs --change-directory=home --label home --fstype=ext4 --mkfs-extraopts "-T default" --ondisk sda --align 1024  --size 512M
 
 bootloader --ptable gpt --append "${CONSOLE_KERNEL_PARAMS} rootwait watchdog.handle_boot_enabled=0 ${EXTRA_KERNEL_PARAMS}"


### PR DESCRIPTION
This patch refactors the WKS script w.r.t how the rootfs is distributed across multiple partitions. Previously we used rootfs-dir with a full rootfs paths plus the sub directory. However, this is not ideal, as the relation to the rootfs folder is lost and also the new rootfs dir is technically not a rootfs. While this aparently did not create any issues in meta-iot2050, we still believe it is semantically incorrect.

This patch switches that over to the WIC option --change-directory that is provided exactly for this use-case and only deploys a subdirectory without loosing the rootfs relation with the permissions pseudo dir.