### PR TITLE
ti-pruss-firmware: Set DEBIAN_COMPAT to overcome do_dpkg_build fail

### DIFF
--- a/recipes-bsp/ti-pruss-firmware/ti-pruss-firmware_09.00.00.005.bb
+++ b/recipes-bsp/ti-pruss-firmware/ti-pruss-firmware_09.00.00.005.bb
@@ -34,3 +34,5 @@ do_install() {
     install -v -d ${D}/lib/firmware/ti-pruss
     install -v -m 644 ${WORKDIR}/am65x-*.elf ${D}/lib/firmware/ti-pruss
 }
+
+DEBIAN_COMPAT = "10"


### PR DESCRIPTION
With latest ISAR in our layers we observed do_dpkg_build was giving following errors:
  - objcopy: Unable to recognise the format of the input file `debian/ti-pruss-firmware/usr/lib/debug/.dwz/aarch64-linux-gnu/ti-pruss-firmware.debug'
  - strip: Unable to recognise the format of the input file `debian/ti-pruss-firmware/lib/firmware/ti-pruss/am65x-sr2-rtu0-prueth-fw.elf' 
 This occurs with the change in default DEBIAN_COMPAT version. Build passes if we use DEBIAN_COMPAT = "10" instead of default debhelper-compat = 13