### PR TITLE
Fix MRAA non-root access

### DIFF
--- a/kas-iot2050-example.yml
+++ b/kas-iot2050-example.yml
@@ -22,3 +22,12 @@ local_conf_header:
     USERS += "root"
     USER_root[password] ??= "root"
     USER_root[flags] ??= "clear-text-password force-passwd-change"
+
+  iot2050_user: |
+    GROUPS += "gpio pinctrl i2c spi pwm iio dialout"
+
+    USERS += "iot2050"
+    USER_iot2050[password] ??= "iot2050"
+    USER_iot2050[flags] ??= "clear-text-password force-passwd-change create-home"
+    USER_iot2050[groups] ??= "gpio pinctrl i2c spi pwm iio dialout"
+    USER_iot2050[shell] ??= "/bin/bash"

--- a/recipes-app/board-conf-tools/files/board-conf-tools/board-bootup-conf.py
+++ b/recipes-app/board-conf-tools/files/board-conf-tools/board-bootup-conf.py
@@ -42,6 +42,13 @@ def setPinmux(index, mode):
         uart = mraa.Uart(0)
         uart.setFlowcontrol(False, True)
 
+def preAllocatePwm():
+    """ Allocate PWM pins upfront for creating PWM sysfs entries and adjusting permissions accordingly.
+        This is required for non-root access to PWM pins.
+    """
+    for i in [4, 5, 6, 7, 8, 9]:
+        p = mraa.Pwm(i, owner=False)
+        p.close()
 
 def initAruinoPins():
     for i in range(0, 20):
@@ -74,6 +81,7 @@ def getBoardModel():
 def main():
     initExternalSerialMode()
     if "IOT2050 Advanced SM" != getBoardModel():
+        preAllocatePwm()
         initAruinoPins()
 
 

--- a/recipes-app/mraa/files/0004-iot2050-Add-support-for-the-new-IOT2050-SM-variant.patch
+++ b/recipes-app/mraa/files/0004-iot2050-Add-support-for-the-new-IOT2050-SM-variant.patch
@@ -15,7 +15,7 @@ Signed-off-by: Li Hua Qian <huaqian.li@siemens.com>
  4 files changed, 75 insertions(+)
 
 diff --git a/api/mraa/types.h b/api/mraa/types.h
-index 8c9a30639450..1c1dd330a3c5 100644
+index f64c40d119a8..b46dbfe737f5 100644
 --- a/api/mraa/types.h
 +++ b/api/mraa/types.h
 @@ -69,6 +69,7 @@ typedef enum {
@@ -46,10 +46,10 @@ index 76df024e7759..e7991862d6b4 100644
  }
  #endif
 diff --git a/src/arm/arm.c b/src/arm/arm.c
-index 0a44d0f6399d..50b3d4d5d22e 100644
+index 45fe84ff0090..ddb96c986e10 100644
 --- a/src/arm/arm.c
 +++ b/src/arm/arm.c
-@@ -99,6 +99,8 @@ mraa_arm_platform()
+@@ -100,6 +100,8 @@ mraa_arm_platform()
              platform_type = MRAA_RASPBERRY_PI;
          else if (mraa_file_contains("/proc/device-tree/model", "ADLINK ARM, LEC-PX30"))
              platform_type = MRAA_ADLINK_IPI;
@@ -58,7 +58,7 @@ index 0a44d0f6399d..50b3d4d5d22e 100644
          else if (mraa_file_contains("/proc/device-tree/model", "SIMATIC IOT2050"))
              platform_type = MRAA_SIEMENS_IOT2050;
      }
-@@ -130,6 +132,9 @@ mraa_arm_platform()
+@@ -131,6 +133,9 @@ mraa_arm_platform()
          case MRAA_SIEMENS_IOT2050:
              plat = mraa_siemens_iot2050();
              break;

--- a/recipes-app/mraa/files/0005-gpio-chardev-init-compatibility.patch
+++ b/recipes-app/mraa/files/0005-gpio-chardev-init-compatibility.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+Date: Fri, 12 Apr 2024 10:22:49 +0200
+Subject: [PATCH] gpio-chardev: init compatibility
+
+Pins initialized with mraa_gpio_chardev_init() should behave more
+like pins initialized with mraa_gpio_init(). This applies
+especially for several attributes of the
+pin's mraa_gpio_context struct:
+
+* advance_func: Required to execute custom functions of the pin's
+                function table.
+* phy_pin: Required to distinguish between board pins and onboard
+           mulitplexer pins(pull_en, out_en)
+
+Signed-off-by: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+---
+ src/gpio/gpio.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/src/gpio/gpio.c b/src/gpio/gpio.c
+index f13081f514af..a0c56c1e7e16 100644
+--- a/src/gpio/gpio.c
++++ b/src/gpio/gpio.c
+@@ -505,6 +505,16 @@ mraa_gpio_chardev_init(int pins[], int num_pins)
+     /* Initialize events array. */
+     dev->events = NULL;
+ 
++    /*
++     * Single pin init
++     * Stay compatible to mraa_gpio_init()
++     */
++    if (num_pins == 1) {
++        dev->advance_func = board->adv_func;
++        dev->pin = pins[0];
++        dev->phy_pin = dev->pin;
++    }
++
+     return dev;
+ }
+ 

--- a/recipes-app/mraa/files/0006-gpio-chardev-add-support-for-more-direction-flags.patch
+++ b/recipes-app/mraa/files/0006-gpio-chardev-add-support-for-more-direction-flags.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+Date: Fri, 12 Apr 2024 10:25:28 +0200
+Subject: [PATCH] gpio-chardev: add support for more direction flags
+
+This adds support for the MRAA_GPIO_OUT_HIGH and
+MRAA_GPIO_OUT_LOW direction flags when setting the direction
+via gpio-chardev.
+
+Signed-off-by: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+---
+ src/gpio/gpio.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/src/gpio/gpio.c b/src/gpio/gpio.c
+index a0c56c1e7e16..ae84d324ff2c 100644
+--- a/src/gpio/gpio.c
++++ b/src/gpio/gpio.c
+@@ -1208,6 +1208,8 @@ mraa_gpio_chardev_dir(mraa_gpio_context dev, mraa_gpio_dir_t dir)
+     }
+ 
+     switch (dir) {
++        case MRAA_GPIO_OUT_HIGH:
++        case MRAA_GPIO_OUT_LOW:
+         case MRAA_GPIO_OUT:
+             flags |= GPIOHANDLE_REQUEST_OUTPUT;
+             flags &= ~GPIOHANDLE_REQUEST_INPUT;
+@@ -1237,6 +1239,15 @@ mraa_gpio_chardev_dir(mraa_gpio_context dev, mraa_gpio_dir_t dir)
+         gpio_iter->gpiod_handle = line_handle;
+     }
+ 
++    switch (dir) {
++        case MRAA_GPIO_OUT_LOW:
++            mraa_gpio_write(dev, 0);
++            break;
++        case MRAA_GPIO_OUT_HIGH:
++            mraa_gpio_write(dev, 1);
++            break;
++    }
++
+     return MRAA_SUCCESS;
+ }
+ 

--- a/recipes-app/mraa/files/0007-gpio-chardev-fix-ressource-handling.patch
+++ b/recipes-app/mraa/files/0007-gpio-chardev-fix-ressource-handling.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+Date: Fri, 12 Apr 2024 10:31:32 +0200
+Subject: [PATCH] gpio-chardev: fix ressource handling
+
+- "path" should only be freed in else statement.
+- close "fh" only if not already allocated/opened
+
+Signed-off-by: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+---
+ src/gpio/gpio_chardev.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/gpio/gpio_chardev.c b/src/gpio/gpio_chardev.c
+index 2cd159680010..e8ff4f3046d4 100644
+--- a/src/gpio/gpio_chardev.c
++++ b/src/gpio/gpio_chardev.c
+@@ -266,7 +266,7 @@ mraa_get_chip_base_by_number(unsigned number)
+     path = mraa_file_unglob(glob);
+     free(glob);
+     if (!path) {
+-        syslog(LOG_ERR, "[GPIOD_INTERFACE]: invalid chip number");
++        syslog(LOG_ERR, "[GPIOD_INTERFACE]: invalid chip number: %d", number);
+         res = -1;
+     } else {
+         fh = fopen(path, "r");
+@@ -274,9 +274,11 @@ mraa_get_chip_base_by_number(unsigned number)
+             syslog(LOG_ERR, "[GPIOD_INTERFACE]: could not read from %s", path);
+             res = -1;
+         }
++        free(path);
+     }
+ 
+-    free(path);
++    if(fh)
++        fclose(fh);
+     return res;
+ #endif
+ }

--- a/recipes-app/mraa/files/0008-iot2050-add-helper-function-to-convert-gpio-number-t.patch
+++ b/recipes-app/mraa/files/0008-iot2050-add-helper-function-to-convert-gpio-number-t.patch
@@ -1,0 +1,73 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+Date: Fri, 12 Apr 2024 10:00:34 +0200
+Subject: [PATCH] iot2050: add helper function to convert gpio number to name
+
+This function converts a GPIO number known to the OS into a name
+provided by the GPIO subsystem.
+
+This prepares for gpio-chardev support on the iot2050 platform and
+should be replaced as soon as the pin definitions in
+mraa_siemens_iot2050() have been adopted to use GPIO pin names
+instead of GPIO pin numbers.
+
+Signed-off-by: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+---
+ src/arm/siemens/iot2050.c | 44 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 44 insertions(+)
+
+diff --git a/src/arm/siemens/iot2050.c b/src/arm/siemens/iot2050.c
+index ace9a0790090..47ea628725df 100644
+--- a/src/arm/siemens/iot2050.c
++++ b/src/arm/siemens/iot2050.c
+@@ -65,6 +65,50 @@ iot2050_locate_phy_pin_by_name(mraa_board_t *board, char *pin_name)
+     return -1;
+ }
+ 
++static int
++iot2050_pin_to_name(int pin, char *name)
++{
++    int i, base, lines, offset, num_chips;
++    mraa_gpiod_line_info *linfo;
++    mraa_gpiod_chip_info* cinfo;
++
++    num_chips = mraa_get_number_of_gpio_chips();
++    if(num_chips < 0)
++        goto err;
++
++    for (i=0; i<num_chips; i++) {
++        base = mraa_get_chip_base_by_number(i);
++        if(base < 0){
++            syslog(LOG_ERR, "iot2050: mraa_get_chip_base_by_number failed: chip%d", i);
++            goto err;
++        }
++
++        cinfo = mraa_get_chip_info_by_number(i);
++        if(cinfo == NULL){
++            syslog(LOG_ERR, "iot2050: mraa_get_chip_info_by_number failed: chip%d", i);
++            goto err;
++        }
++
++        lines = cinfo->chip_info.lines;
++        close(cinfo->chip_fd);
++        free(cinfo);
++        if(pin >= base && pin < base + lines) {
++            offset = pin - base;
++            linfo = mraa_get_line_info_by_chip_number(i, offset);
++            if(linfo == NULL) {
++                syslog(LOG_ERR, "iot2050: mraa_get_line_info_by_chip_number(%d, %d) failed", i, offset);
++                goto err;
++            }
++            strncpy(name, linfo->name, MRAA_PIN_NAME_SIZE);
++            free(linfo);
++            return 0;
++        }
++    }
++err:
++    syslog(LOG_ERR, "iot2050: conversion from pin id to gpio-name failed: pin%d", pin);
++    return -1;
++}
++
+ static inline regmux_info_t*
+ iot2050_get_regmux_by_pinmap(int pinmap)
+ {

--- a/recipes-app/mraa/files/0009-iot2050-add-support-for-gpio-chardev-interface.patch
+++ b/recipes-app/mraa/files/0009-iot2050-add-support-for-gpio-chardev-interface.patch
@@ -1,0 +1,101 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+Date: Fri, 12 Apr 2024 10:09:25 +0200
+Subject: [PATCH] iot2050: add support for gpio-chardev interface
+
+This patch enables the gpio-chardev support on iot2050 platforms.
+
+The iot2050_gpio_init_internal_replace() function is used
+to initialize helper pins that control the direction and pull
+onboard multiplexers via mraa_gpio_init_raw(), since the
+mraa_gpio_init_internal() currently only handles sysfs pin
+initialization.
+
+Signed-off-by: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+---
+ src/arm/siemens/iot2050.c | 38 +++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 37 insertions(+), 1 deletion(-)
+
+diff --git a/src/arm/siemens/iot2050.c b/src/arm/siemens/iot2050.c
+index 47ea628725df..a5c5ebed7a2d 100644
+--- a/src/arm/siemens/iot2050.c
++++ b/src/arm/siemens/iot2050.c
+@@ -268,19 +268,26 @@ iot2050_gpio_dir_pre(mraa_gpio_context dev, mraa_gpio_dir_t dir)
+                     goto failed;
+                 }
+             }
++
+             if(dir == MRAA_GPIO_IN) {
+                 syslog(LOG_DEBUG, "GPIODIR[phy_pin %d] gpio set out en %d to %d\n", pin, plat->pins[pin].gpio.output_enable, !plat->pins[pin].gpio.complex_cap.output_en_high);
+                 if(mraa_gpio_write(output_en_pins[pin], !plat->pins[pin].gpio.complex_cap.output_en_high) != MRAA_SUCCESS) {
++                    mraa_gpio_close(output_en_pins[pin]);
++                    output_en_pins[pin] = NULL;
+                     goto failed;
+                 }
+             } else {
+                 syslog(LOG_DEBUG, "GPIODIR[phy_pin %d] gpio set out en %d to %d\n", pin, plat->pins[pin].gpio.output_enable, plat->pins[pin].gpio.complex_cap.output_en_high);
+                 if(mraa_gpio_write(output_en_pins[pin], plat->pins[pin].gpio.complex_cap.output_en_high) != MRAA_SUCCESS) {
++                    mraa_gpio_close(output_en_pins[pin]);
++                    output_en_pins[pin] = NULL;
+                     goto failed;
+                 }
+             }
+         }
+     }
++    mraa_gpio_close(output_en_pins[pin]);
++    output_en_pins[pin] = NULL;
+     return MRAA_SUCCESS;
+ failed:
+     syslog(LOG_ERR, "iot2050: Error setting gpio direction");
+@@ -363,6 +370,34 @@ failed:
+     return ret;
+ }
+ 
++static mraa_result_t
++iot2050_gpio_init_internal_replace(mraa_gpio_context dev, int pin)
++{
++    char pname[MRAA_PIN_NAME_SIZE];
++    mraa_gpio_context cdev;
++    mraa_result_t status;
++
++    syslog(LOG_DEBUG, "iot2050: iot2050_gpio_init_internal_replace (pin: %d)", pin);
++
++    status = iot2050_pin_to_name(dev->pin, pname);
++    if (status) {
++        syslog(LOG_ERR, "gpio%i: init: Failed to get pin name", pin);
++        return MRAA_ERROR_NO_DATA_AVAILABLE;
++    }
++
++    cdev = mraa_gpio_init_by_name(pname);
++    if (cdev == NULL) {
++        syslog(LOG_ERR, "gpio%i: init: Failed to initialize by name", pin);
++        return MRAA_ERROR_NO_RESOURCES;
++    }
++    memcpy(dev, cdev, sizeof(*cdev));
++    free(cdev);
++
++    dev->pin = pin;
++    dev->phy_pin = -1;
++
++    return MRAA_SUCCESS;
++}
+ static inline void
+ iot2050_setup_pins(mraa_board_t *board, int pin_index, char *pin_name, mraa_pincapabilities_t cap, regmux_info_t mux_info)
+ {
+@@ -588,7 +623,7 @@ mraa_siemens_iot2050()
+     memset(output_en_pins, 0, sizeof(mraa_gpio_context) * MRAA_IOT2050_PINCOUNT);
+     b->platform_name = PLATFORM_NAME;
+     b->phy_pin_count = MRAA_IOT2050_PINCOUNT;
+-    b->chardev_capable = 0;
++    b->chardev_capable = 1;
+     b->adc_raw = 12;
+     b->adc_supported = 12;
+     b->pwm_default_period = 1000; /*us*/
+@@ -599,6 +634,7 @@ mraa_siemens_iot2050()
+     if(b->adv_func == NULL) {
+         goto error;
+     }
++    b->adv_func->gpio_init_internal_replace = &iot2050_gpio_init_internal_replace;
+     b->adv_func->gpio_dir_pre = &iot2050_gpio_dir_pre;
+     b->adv_func->gpio_mode_replace = &iot2050_gpio_mode_replace;
+     b->adv_func->mux_init_reg = &iot2050_mux_init_reg;

--- a/recipes-app/mraa/files/0010-iot2050-fix-pinmux-handling-of-user-pin.patch
+++ b/recipes-app/mraa/files/0010-iot2050-fix-pinmux-handling-of-user-pin.patch
@@ -1,0 +1,127 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+Date: Thu, 18 Apr 2024 13:00:21 +0200
+Subject: [PATCH] iot2050: fix pinmux handling of user pin
+
+This properly sets up the regmux info definition for the user pin
+(pin 20) and skips the debugfs/mmap regmux for it.
+This also improves debugging by adding the actual pin number
+in the debug message.
+
+Signed-off-by: Benedikt Niedermayr <benedikt.niedermayr@siemens.com>
+---
+ src/arm/siemens/iot2050.c | 30 ++++++++++++++++++------------
+ 1 file changed, 18 insertions(+), 12 deletions(-)
+
+diff --git a/src/arm/siemens/iot2050.c b/src/arm/siemens/iot2050.c
+index a5c5ebed7a2d..418cde3091b4 100644
+--- a/src/arm/siemens/iot2050.c
++++ b/src/arm/siemens/iot2050.c
+@@ -124,17 +124,17 @@ iot2050_get_regmux_by_pinmap(int pinmap)
+ }
+ 
+ static mraa_result_t
+-iot2050_mux_debugfs(const char *base_dir, const char *group, const char *function, mraa_gpio_mode_t gpio_mode)
++iot2050_mux_debugfs(int phy_pin, const char *base_dir, const char *group, const char *function, mraa_gpio_mode_t gpio_mode)
+ {
+     FILE *fd = NULL;
+     char p_pinmux[PATH_MAX];
+     char mux[MRAA_PIN_NAME_SIZE];
+     int ret;
+ 
+-    syslog(LOG_DEBUG, "iot2050: debugfs: enter\n");
++    syslog(LOG_DEBUG, "iot2050: debugfs (pin: %d): enter\n", phy_pin);
+ 
+     if (!base_dir || !group || !function) {
+-        syslog(LOG_ERR, "iot2050: debugfs: Invalid parameter base_dir=%s, group=%s, function=%s!\n", base_dir, group, function);
++        syslog(LOG_INFO, "iot2050: debugfs (pin: %d): Invalid parameter base_dir=%s, group=%s, function=%s!\n", phy_pin, base_dir, group, function);
+         return MRAA_ERROR_INVALID_PARAMETER;
+     }
+ 
+@@ -162,7 +162,7 @@ iot2050_mux_debugfs(const char *base_dir, const char *group, const char *functio
+             break;
+     }
+ 
+-    syslog(LOG_DEBUG, "iot2050: debugfs: group: %s, function: %s\n", mux, mux);
++    syslog(LOG_DEBUG, "iot2050: debugfs (pin: %d): group: %s, function: %s\n", phy_pin, mux, mux);
+ 
+     ret = fprintf(fd, "%s %s\n", mux, mux);
+     if (ret < 0) {
+@@ -176,7 +176,7 @@ iot2050_mux_debugfs(const char *base_dir, const char *group, const char *functio
+ err_close:
+     fclose(fd);
+ err:
+-    syslog(LOG_ERR, "iot2050: debugfs: Pinmux failed(%d)! group: %s, function: %s", ret, group, function);
++    syslog(LOG_ERR, "iot2050: debugfs (pin: %d): Pinmux failed(%d)! group: %s, function: %s", phy_pin, ret, group, function);
+     return ret;
+ }
+ 
+@@ -226,7 +226,7 @@ iot2050_mux_init_reg(int phy_pin, int mode)
+     int8_t mux_mode;
+     mraa_result_t ret;
+ 
+-    if((phy_pin < 0) || (phy_pin > MRAA_IOT2050_PINCOUNT))
++    if((phy_pin < 0) || (phy_pin > MRAA_IOT2050_PINCOUNT) || phy_pin == 20)
+         return MRAA_SUCCESS;
+     if((mode < 0) || (mode >= MAX_MUX_REGISTER_MODE)) {
+         return MRAA_ERROR_FEATURE_NOT_SUPPORTED;
+@@ -240,7 +240,7 @@ iot2050_mux_init_reg(int phy_pin, int mode)
+         return MRAA_ERROR_FEATURE_NOT_SUPPORTED;
+     }
+ 
+-    ret = iot2050_mux_debugfs(info->debugfs_path[mode], info->pmx_group[mode], info->pmx_function[mode], 0);
++    ret = iot2050_mux_debugfs(phy_pin, info->debugfs_path[mode], info->pmx_group[mode], info->pmx_function[mode], 0);
+     if (ret != MRAA_SUCCESS)
+         return iot2050_mux_mmap(phy_pin, mode, 0);
+     return ret;
+@@ -324,7 +324,7 @@ iot2050_gpio_mode_replace(mraa_gpio_context dev, mraa_gpio_mode_t mode)
+                 goto failed;
+             }
+             if(info) {
+-                ret = iot2050_mux_debugfs(info->debugfs_path[0], info->pmx_group[0], info->pmx_function[0], mode);
++                ret = iot2050_mux_debugfs(dev->phy_pin, info->debugfs_path[0], info->pmx_group[0], info->pmx_function[0], mode);
+                 if (ret != MRAA_SUCCESS)
+                     ret = iot2050_mux_mmap(dev->phy_pin, 0, mode);
+ 
+@@ -336,7 +336,7 @@ iot2050_gpio_mode_replace(mraa_gpio_context dev, mraa_gpio_mode_t mode)
+                 goto failed;
+             }
+             if(info) {
+-                ret = iot2050_mux_debugfs(info->debugfs_path[0], info->pmx_group[0], info->pmx_function[0], mode);
++                ret = iot2050_mux_debugfs(dev->phy_pin, info->debugfs_path[0], info->pmx_group[0], info->pmx_function[0], mode);
+                 if (ret != MRAA_SUCCESS)
+                     ret = iot2050_mux_mmap(dev->phy_pin, 0, mode);
+             }
+@@ -348,7 +348,7 @@ iot2050_gpio_mode_replace(mraa_gpio_context dev, mraa_gpio_mode_t mode)
+                 goto failed;
+             }
+             if(info) {
+-                ret = iot2050_mux_debugfs(info->debugfs_path[0], info->pmx_group[0], info->pmx_function[0], mode);
++                ret = iot2050_mux_debugfs(dev->phy_pin, info->debugfs_path[0], info->pmx_group[0], info->pmx_function[0], mode);
+                 if (ret != MRAA_SUCCESS)
+                     ret = iot2050_mux_mmap(dev->phy_pin, 0, mode);
+             }
+@@ -1834,7 +1834,10 @@ mraa_siemens_iot2050()
+                             -1,
+                             -1,
+                             wkup_gpio0_base+25,
+-                            {}
++                            {0},
++                            {0},
++                            {0},
++                            {0}
+                         });
+     iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 25, -1, -1, NULL, 0);
+     pin_index++;
+@@ -1915,7 +1918,10 @@ mraa_siemens_iot2050_sm()
+                             .group = -1,
+                             .index = -1,
+                             .pinmap = wkup_gpio0_base+25,
+-                            .mode = {}
++                            .mode = {0},
++                            .debugfs_path = {0},
++                            .pmx_function = {0},
++                            .pmx_group = {0},
+                         });
+     iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 25, -1, -1, NULL, 0);
+ 

--- a/recipes-app/mraa/files/20-mraa-permissions.rules
+++ b/recipes-app/mraa/files/20-mraa-permissions.rules
@@ -1,0 +1,15 @@
+# GPIO
+SUBSYSTEM=="gpio*", PROGRAM="/bin/sh -c 'find -L /sys/class/gpio/ -maxdepth 2 -exec chown root:gpio {} \; -exec chmod 770 {} \; || true;'"
+KERNEL=="gpiochip*", GROUP="gpio", MODE="0660", PROGRAM="/bin/sh -c 'chown -R root:pinctrl /sys/kernel/debug && chmod -R 770 /sys/kernel/debug'"
+
+# PWM
+SUBSYSTEM=="pwm", PROGRAM="/bin/sh -c 'find -L /sys/class/pwm/ -maxdepth 3 -not -path \"*device*\" -not -path \"*power*\" -exec chown root:pwm {} \; -exec chmod 770 {} \; || true;'"
+
+# SPI
+KERNEL=="spidev*", GROUP="spi", MODE="0660"
+
+# I2C
+KERNEL=="i2c-dev*", GROUP="i2c", MODE="0660"
+
+# IIO
+KERNEL=="iio:device0", GROUP="iio", MODE="0660", PROGRAM="/bin/sh -c 'chown -R root:iio /sys/bus/iio/devices/iio:device0/in_voltage*_raw && chmod -R 770 /sys/bus/iio/devices/iio:device0/in_voltage*_raw'"

--- a/recipes-app/mraa/mraa_2.2.0+git.bb
+++ b/recipes-app/mraa/mraa_2.2.0+git.bb
@@ -21,6 +21,7 @@ SRC_URI += "git://github.com/eclipse/mraa.git;protocol=https;branch=master \
             file://0007-gpio-chardev-fix-ressource-handling.patch \
             file://0008-iot2050-add-helper-function-to-convert-gpio-number-t.patch \
             file://0009-iot2050-add-support-for-gpio-chardev-interface.patch \
+            file://0010-iot2050-fix-pinmux-handling-of-user-pin.patch \
             file://20-mraa-permissions.rules \
             file://rules"
 SRCREV = "8b1c54934e80edc2d36abac9d9c96fe1e01cb669"

--- a/recipes-app/mraa/mraa_2.2.0+git.bb
+++ b/recipes-app/mraa/mraa_2.2.0+git.bb
@@ -16,6 +16,12 @@ SRC_URI += "git://github.com/eclipse/mraa.git;protocol=https;branch=master \
             file://0002-common-increase-pin-name-size.patch \
             file://0003-iot2050-add-debugfs-pinmux-support.patch \
             file://0004-iot2050-Add-support-for-the-new-IOT2050-SM-variant.patch \
+            file://0005-gpio-chardev-init-compatibility.patch \
+            file://0006-gpio-chardev-add-support-for-more-direction-flags.patch \
+            file://0007-gpio-chardev-fix-ressource-handling.patch \
+            file://0008-iot2050-add-helper-function-to-convert-gpio-number-t.patch \
+            file://0009-iot2050-add-support-for-gpio-chardev-interface.patch \
+            file://20-mraa-permissions.rules \
             file://rules"
 SRCREV = "8b1c54934e80edc2d36abac9d9c96fe1e01cb669"
 
@@ -37,5 +43,7 @@ do_prepare_build[cleandirs] += "${S}/debian"
 do_prepare_build() {
     deb_debianize
 
+    cp ${WORKDIR}/20-mraa-permissions.rules ${S}/debian/20-mraa-permissions.rules
+    echo "debian/20-mraa-permissions.rules etc/udev/rules.d" > ${S}/debian/install
     echo "usr/share/java/mraa.jar usr/share/java/mraa-${PV}.jar" > ${S}/debian/mraa.links
 }


### PR DESCRIPTION
This MR fixes some issues related the MRAA API access, as non-root user.
The following things have been changed/fixed:
1. Add gpio chardev support for MRAA (switch from sysfs to chardev)
2. Add udev rules that adjust permissions and assign required groups to all interfaces
3. The PWM pins require a more special handling and need to be pre-allocated during boot. This avoids
    timing problems when exporting those pins the first time via MRAA (see issue #29). 
4. Create an example (non-root) user that has been assigned to all required groups.
5. Fix MRAA pinmux handling for pin 20