### PR TITLE
recipes-bsp/optee-ftpm: optee-ftpm package needs to be cross compiled

### DIFF
--- a/recipes-bsp/optee-ftpm/optee-ftpm-iot2050_0~231017+git.bb
+++ b/recipes-bsp/optee-ftpm/optee-ftpm-iot2050_0~231017+git.bb
@@ -7,6 +7,9 @@
 #
 require recipes-bsp/optee-ftpm/optee-ftpm.inc
 
+# crossbuild
+ISAR_CROSS_COMPILE = "1"
+
 SRC_URI += " \
     https://github.com/Microsoft/ms-tpm-20-ref/archive/${SRCREV}.tar.gz \
     https://github.com/wolfSSL/wolfssl/archive/${SRCREV-wolfssl}.tar.gz;name=wolfssl \


### PR DESCRIPTION
optee-ftpm builds successfully only in cross-compilation mode; therefore, setting the recipe to default to cross-compilation can resolve the following build error.

make[2]: Entering directory '/<<PKGBUILDDIR>>/Samples/ARM32-FirmwareTPM/optee_ta' /usr/bin/make -C fTPM CROSS_COMPILE=
make[3]: Entering directory '/<<PKGBUILDDIR>>/Samples/ARM32-FirmwareTPM/optee_ta/fTPM'
Checking symlink to the TPM folder: /<<PKGBUILDDIR>>
Checking symlink to the WolfSSL folder: /<<PKGBUILDDIR>>/external/wolfssl Establishing symlink.
Establishing symlink.
  CC      ../out/fTPM/platform/AdminPPI.o
  CC      ../out/fTPM/platform/Cancel.o
make[3]: *** No rule to make target 'lib/wolf/wolf_symlink/wolfcrypt/src/aes.c', needed by '../out/fTPM/./lib/wolf/wolf_symlink/wolfcrypt/src/aes.o'.  Stop.
make[3]: *** Waiting for unfinished jobs....
  CC      ../out/fTPM/platform/Clock.o
  CC      ../out/fTPM/platform/Entropy.o
  CC      ../out/fTPM/platform/LocalityPlat.o
  CC      ../out/fTPM/platform/NvAdmin.o
  CC      ../out/fTPM/platform/NVMem.o
  CC      ../out/fTPM/platform/PowerPlat.o
  CC      ../out/fTPM/platform/PlatformData.o
  CC      ../out/fTPM/platform/PPPlat.o
  CC      ../out/fTPM/platform/RunCommand.o
  CC      ../out/fTPM/platform/Unique.o
  CC      ../out/fTPM/platform/EPS.o
  CC      ../out/fTPM/platform/PlatformACT.o
  CC      ../out/fTPM/reference/RuntimeSupport.o
  CC      ../out/fTPM/platform/fTPM_helpers.o
  CC      ../out/fTPM/fTPM.o
make[3]: Leaving directory '/<<PKGBUILDDIR>>/Samples/ARM32-FirmwareTPM/optee_ta/fTPM'
make[2]: *** [Makefile:6: all] Error 2