### PR TITLE
recipes-kernel/linux/linux-iot2050-6.1: remove unwanted file path in …

### DIFF
--- a/recipes-kernel/linux/linux-iot2050-6.1.inc
+++ b/recipes-kernel/linux/linux-iot2050-6.1.inc
@@ -20,7 +20,6 @@ def get_patches(d, patchdir):
 SRC_URI += " \
     https://cdn.kernel.org/pub/linux/kernel/projects/cip/6.1/linux-cip-${PV}.tar.gz \
     ${@get_patches(d, 'patches-6.1')} \
-    file://patches-6.1/ \
     file://${KERNEL_DEFCONFIG} \
     file://iot2050_defconfig_extra.cfg"
 


### PR DESCRIPTION
…SRC_URI

All the patches for 6.1 kernels getting via "get_patches(d, 'patches-6.1')" function and there is no meaning to add "file://patches-6.1/" again in SRC_URI, hence remove that one.