### PR TITLE
u-boot-iot2050: Add a temporary workaround for the SD Card issue

### DIFF
--- a/recipes-bsp/u-boot/files/0014-driver-iot2050-Add-a-temporary-workaround-for-the-SD.patch
+++ b/recipes-bsp/u-boot/files/0014-driver-iot2050-Add-a-temporary-workaround-for-the-SD.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Li Hua Qian <huaqian.li@siemens.com>
+Date: Fri, 8 Nov 2024 10:23:52 +0800
+Subject: [PATCH] driver: iot2050: Add a temporary workaround for the SD Card
+ issue
+
+After approximately 2 months of operation, the device may fail to detect
+the SD Card when rebooting. This commit provides a temporary workaround to
+bypass the SD Card issue.
+
+TODO: Implement a permanent solution for SD Card detection issues.
+
+Signed-off-by: Li Hua Qian <huaqian.li@siemens.com>
+---
+ drivers/mmc/mmc.c | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/mmc/mmc.c b/drivers/mmc/mmc.c
+index dff0ff89a801..99a92f44bef4 100644
+--- a/drivers/mmc/mmc.c
++++ b/drivers/mmc/mmc.c
+@@ -651,8 +651,16 @@ static int sd_send_op_cond(struct mmc *mmc, bool uhs_en)
+ 		if (cmd.response[0] & OCR_BUSY)
+ 			break;
+ 
+-		if (timeout-- <= 0)
+-			return -EOPNOTSUPP;
++		/*
++		 * TODO: Implement a permanent solution for the SD Card detection issues.
++		 * After approximately 2 months of operation, the device may fail to
++		 * detect the SD when rebooting. Here provides a temporary workaround
++		 * to bypass the issue.
++		 */
++		if (timeout-- <= 0) {
++			printf("mmc: SD Card is busy, continue booting\n");
++			break; //return -EOPNOTSUPP;
++		}
+ 
+ 		udelay(1000);
+ 	}

--- a/recipes-bsp/u-boot/u-boot-iot2050_2023.10.bb
+++ b/recipes-bsp/u-boot/u-boot-iot2050_2023.10.bb
@@ -25,6 +25,7 @@ SRC_URI += " \
     file://0011-arm-dts-iot2050-Disable-lock-step-mode-for-all-iot20.patch \
     file://0012-qspi-iot2050-Add-temporary-workaround-for-the-QSPI-i.patch \
     file://0013-driver-iot2050-Add-a-temporary-workaround-for-the-eMMC.patch \
+    file://0014-driver-iot2050-Add-a-temporary-workaround-for-the-SD.patch \
     "
 
 SRC_URI[sha256sum] = "e00e6c6f014e046101739d08d06f328811cebcf5ae101348f409cbbd55ce6900"


### PR DESCRIPTION
We have not yet reproduced this issue on an SD card, but we have observed the QSPI issue on a basic device that only has an SD card. Therefore, it is highly likely that the issue could also occur on an SD card. As a precaution, we have included this workaround.

After approximately 2 months of operation, the device may fail to detect the SD Card when rebooting. This commit provides a temporary workaround to bypass the SD Card issue.

TODO: Implement a permanent solution for SD Card detection issues.

Related to #440.