### PR TITLE
fix(iot2050-firmware-update): Add missing package dependency

### DIFF
--- a/recipes-app/iot2050-firmware-update/iot2050-firmware-update_0.5.bb
+++ b/recipes-app/iot2050-firmware-update/iot2050-firmware-update_0.5.bb
@@ -20,7 +20,7 @@ TEMPLATE_FILES = "update.conf.json.tmpl iot2050-firmware-update.tmpl"
 
 inherit dpkg-raw
 
-DEBIAN_DEPENDS = "python3-progress"
+DEBIAN_DEPENDS = "python3-progress, u-boot-tools"
 
 do_install() {
     install -v -d ${D}/usr/sbin/


### PR DESCRIPTION
As some tools come from u-boot-tools package (e.g. mkenvimage) in iot2050-firmware-update script, its build recipe should include u-boot-tools package dependency. Otherwise, these necessary tools are not installed to image.