### PR TITLE
u-boot-iot2050: Match kernel dts for bootefi issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   debian-example-image:
     name: Debian example image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
 
   debian-swupdate-image:
     name: Debian secure boot SWUpdate image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
 
   bootloaders:
     name: Bootloaders
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/recipes-bsp/u-boot/files/0018-arm-dts-iot2050-Enforce-DMA-isolation-for-devices-be.patch
+++ b/recipes-bsp/u-boot/files/0018-arm-dts-iot2050-Enforce-DMA-isolation-for-devices-be.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Li Hua Qian <huaqian.li@siemens.com>
+Date: Thu, 16 Jan 2025 17:48:28 +0800
+Subject: [PATCH] arm: dts: iot2050: Enforce DMA isolation for devices behind
+ PCI RC
+
+Reserve a 64M memory region below the top of 1G RAM (smallest RAM size
+across the series, space left for firmware carve-outs) and ensure that
+all PCI devices do their DMA only inside that region. This is configured
+via a restricted-dma-pool and enforced with the help of the first PVU.
+
+- The restricted-dma-pool is overlaid by U-Boot.
+- U-Boot DTS path:
+  arch/arm/dts/k3-am6548-iot2050-advanced-dma-isolation-overlay.dts
+
+Signed-off-by: Li Hua Qian <huaqian.li@siemens.com>
+---
+ arch/arm/dts/k3-am65-iot2050-common.dtsi | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/arch/arm/dts/k3-am65-iot2050-common.dtsi b/arch/arm/dts/k3-am65-iot2050-common.dtsi
+index f4f6aeba2586..85911fad2941 100644
+--- a/arch/arm/dts/k3-am65-iot2050-common.dtsi
++++ b/arch/arm/dts/k3-am65-iot2050-common.dtsi
+@@ -604,3 +604,24 @@
+ 	/* lock-step mode not supported on iot2050 boards */
+ 	ti,cluster-mode = <0>;
+ };
++
++&main_navss {
++        ti_pvu0: ti-pvu@30f80000 {
++                compatible = "ti,am654-pvu";
++                reg = <0 0x30f80000 0 0x1000>,
++                      <0 0x36000000 0 0x100000>;
++                reg-names = "cfg", "tlbif";
++                interrupts-extended = <&intr_main_navss 390>;
++                interrupt-names = "pvu";
++        };
++
++        ti_pvu1: ti-pvu@30f81000 {
++                compatible = "ti,am654-pvu";
++                reg = <0 0x30f81000 0 0x1000>,
++                      <0 0x36100000 0 0x100000>;
++                reg-names = "cfg", "tlbif";
++                interrupts-extended = <&intr_main_navss 389>;
++                interrupt-names = "pvu";
++                status = "disabled";
++        };
++};


### PR DESCRIPTION
The bootefi command leads to the kernel FDT being overwritten by the U-Boot FDT. Although the UKI's FDT ultimately takes precedence, this intermediate overwrite can cause the device to fail to apply the overlay.