### PR TITLE
linux-iot2050: Add the missing kbuildtarget

### DIFF
--- a/conf/distro/iot2050-debian.conf
+++ b/conf/distro/iot2050-debian.conf
@@ -26,6 +26,8 @@ PREFERRED_VERSION_linux-iot2050-rt-kbuildtarget ?= "${PREFERRED_VERSION_linux-io
 
 KERNEL_NAME ?= "cip"
 
+BBMASK:append = " linux-iot2050_.+-upstream\.bb"
+
 PREFERRED_VERSION_customizations ?= "0.1-iot2050-debian"
 PREFERRED_VERSION_customizations-debug ?= "0.1-iot2050-debian"
 

--- a/conf/distro/iot2050-debian.conf
+++ b/conf/distro/iot2050-debian.conf
@@ -19,6 +19,11 @@ HOSTNAME ??= "iot2050-debian"
 PREFERRED_VERSION_linux-iot2050 ?= "6.1.%"
 PREFERRED_VERSION_linux-iot2050-rt ?= "6.1.%"
 
+PREFERRED_VERSION_linux-iot2050-native ?= "${PREFERRED_VERSION_linux-iot2050}"
+PREFERRED_VERSION_linux-iot2050-kbuildtarget ?= "${PREFERRED_VERSION_linux-iot2050}"
+PREFERRED_VERSION_linux-iot2050-rt-native ?= "${PREFERRED_VERSION_linux-iot2050-rt}"
+PREFERRED_VERSION_linux-iot2050-rt-kbuildtarget ?= "${PREFERRED_VERSION_linux-iot2050-rt}"
+
 KERNEL_NAME ?= "cip"
 
 PREFERRED_VERSION_customizations ?= "0.1-iot2050-debian"

--- a/kas/opt/upstream.yml
+++ b/kas/opt/upstream.yml
@@ -10,4 +10,5 @@ header:
 
 local_conf_header:
   upstream-versions: |
+    BBMASK:remove = "linux-iot2050_.+-upstream\.bb"
     PREFERRED_VERSION_linux-iot2050 = "6.x-upstream"


### PR DESCRIPTION
The kbuildtarget is not set in the iot2050-debian.conf, this is causing both the kernels (cip & upstream) are be parsed and generated in the build process, which causes the parsing stage is very slow when connecting to github is not good.