### PR TITLE
fix(firmware-update): explicitly set DPKG_ARCH to "any"

### DIFF
--- a/recipes-app/iot2050-firmware-update/iot2050-firmware-update_0.5.bb
+++ b/recipes-app/iot2050-firmware-update/iot2050-firmware-update_0.5.bb
@@ -18,6 +18,8 @@ SRC_URI = " \
 
 TEMPLATE_FILES = "update.conf.json.tmpl iot2050-firmware-update.tmpl"
 
+DPKG_ARCH = "any"
+
 inherit dpkg-raw
 
 DEBIAN_DEPENDS = "python3-progress, u-boot-tools"


### PR DESCRIPTION
Isar commit 0816ae6e97d15712f6b8eb873311464263f5df59 changed the default architecture for dpkg-raw from "any" to "all". Having a task that assumes the generated package file ends with "_arm64.deb" (not great btw), set DPKG_ARCH to "any".