### PR TITLE
[RFC]: patch-u-boot-env: optimize patch-u-boot-env service execution

### DIFF
--- a/recipes-bsp/patch-u-boot-env/files/patch-u-boot-env.service
+++ b/recipes-bsp/patch-u-boot-env/files/patch-u-boot-env.service
@@ -8,12 +8,14 @@
 
 [Unit]
 Description=update u-boot environment for swupdate
+After=multi-user.target
 Conflicts=shutdown.target
 Before=swupdate.service shutdown.target
+DefaultDependencies=no
 
 [Service]
 Type=oneshot
-ExecStart=sh -c '/usr/share/u-boot-env/patch-u-boot-env.sh watchdog_timeout_ms /usr/share/u-boot-env/patch-u-boot-env.config; fw_setenv watchdog_timeout_ms 60000'
+ExecStart=/usr/share/u-boot-env/patch-u-boot-env.sh watchdog_timeout_ms /usr/share/u-boot-env/patch-u-boot-env.config
 ExecStartPost=-/bin/systemctl disable patch-u-boot-env.service
 
 [Install]

--- a/recipes-bsp/patch-u-boot-env/files/patch-u-boot-env.sh
+++ b/recipes-bsp/patch-u-boot-env/files/patch-u-boot-env.sh
@@ -7,9 +7,14 @@
 #
 # SPDX-License-Identifier: MIT
 
-if [ -z "$(fw_printenv -n "$1")" ]; then
-    if ! fw_setenv -s "$2"; then
-        echo "$0: could not patch u-boot firmware"
+if ! fw_setenv -s "$2"; then
+        echo "$0: Failed to apply config file $2"
         exit 1
-    fi
+fi
+
+watchdog_timer="60000"
+current_value=$(fw_printenv -n "$1" 2>/dev/null || echo "")
+if [ "$current_value" != "$watchdog_timer" ]; then
+        echo "$0: Failed to set $1 to $expected_value (got $current_value)"
+        exit 1
 fi


### PR DESCRIPTION
Update patch-u-boot-env.service to set the U-Boot environment (e.g., watchdog_timeout_ms=60000) earlier and more reliably during boot.With the special case when watchdog_timeout_ms value set as '0' patch-u-boot-env.service ExecStart is not executing the 'fw_setenv watchdog_timeout_ms 60000' in this case patch-u-boot-env.service is getting failed in setting the watchdog_timeout_ms as 60000. Running the service after 'local-fs.target' and 'systemd-udev-settle.service' is letting the block device intialize ready to run the fw_setenv command.