### PR TITLE
switchserialmode: suffix package with -iot2050

### DIFF
--- a/recipes-app/switchserialmode/switchserialmode_0.5.bb
+++ b/recipes-app/switchserialmode/switchserialmode_0.5.bb
@@ -18,8 +18,13 @@ SRC_URI = "file://src"
 
 S = "${WORKDIR}/src"
 
+PROVIDES := "${BPN}"
+DEBIAN_CONFLICTS := "${BPN}"
+DEBIAN_PROVIDES := "${BPN}"
+DEBIAN_REPLACES := "${BPN}"
 DEBIAN_BUILD_DEPENDS = "cmake, libusb-1.0-0-dev, libgpiod-dev"
 DEBIAN_DEPENDS = "\${shlibs:Depends}"
+PN := "iot2050-${BPN}"
 
 do_prepare_build[cleandirs] += "${S}/debian"
 

--- a/recipes-core/images/iot2050-image-example.bb
+++ b/recipes-core/images/iot2050-image-example.bb
@@ -33,7 +33,7 @@ IMAGE_INSTALL += " \
     regen-rootfs-uuid \
     install-on-emmc \
     customizations-example \
-    switchserialmode \
+    iot2050-switchserialmode \
     iot2050-firmware-update \
     tcf-agent \
     mraa \


### PR DESCRIPTION
Several Siemens products have a switchserialmode package. The version included in this repository is really designed for the IOT2050: note the hardware dependency in the name of the package by prefixing it with "iot2050-". The package uses a Provides clause for backward compatibility (both for Isar builds and for apt).