### PR TITLE
fix(packages): introduce PR in the version string for mraa

### DIFF
--- a/recipes-app/mraa/mraa_2.2.0+git20220805.8b1c5493.bb
+++ b/recipes-app/mraa/mraa_2.2.0+git20220805.8b1c5493.bb
@@ -7,6 +7,9 @@
 # This file is subject to the terms and conditions of the MIT License.  See
 # COPYING.MIT file in the top-level directory.
 #
+
+PR = "1"
+
 inherit dpkg
 
 DESCRIPTION = "Low Level Skeleton Library for Communication on GNU/Linux platforms"
@@ -17,6 +20,8 @@ SRC_URI += "git://github.com/eclipse/mraa.git;protocol=https;branch=master \
             file://0003-iot2050-add-debugfs-pinmux-support.patch \
             file://0004-iot2050-Add-support-for-the-new-IOT2050-SM-variant.patch \
             file://rules"
+
+CHANGELOG_V = "${PV}-${PR}"
 SRCREV = "8b1c54934e80edc2d36abac9d9c96fe1e01cb669"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
The upstream mraa project does not seem to create versions/tags for the changes they make (version 2.2.0 was released in 2020 but the project has continued to receive updates since). We anyhow have our own set of patches on-top that we also need to version. Use CHANGELOG_V to include PR into the version string of our mraa package. PR should be incremented whenever we change the upstream revision (SRCREV) and/or update our patches. This will help with binary distributions of the package (e.g. for users needing to pull packages on their IOT2050 using apt).