### PR TITLE
iot2050-efivarfs-helper: include PR to track changes

### DIFF
--- a/recipes-app/iot2050-efivarfs-helper/iot2050-efivarfs-helper_1.0.0.bb
+++ b/recipes-app/iot2050-efivarfs-helper/iot2050-efivarfs-helper_1.0.0.bb
@@ -13,6 +13,7 @@ DESCRIPTION = "Efivarfs Helper"
 MAINTAINER = "baocheng.su@siemens.com"
 
 SRC_URI = "file://iot2050-efivarfs-helper.tmpl"
+PR = "1"
 
 TEMPLATE_FILES = "iot2050-efivarfs-helper.tmpl"
 


### PR DESCRIPTION
There have been modification in the iot2050-efivarfs-helper.tmpl but without any bump in the version (PV). This causes the downsteam projects to miss the changes when building with cached apt. Incldue PR in the recipe to show the modifications.