### PR TITLE
fix(firmware-update): use semantic version comparison

### DIFF
--- a/recipes-app/iot2050-firmware-update/files/iot2050-firmware-update.tmpl
+++ b/recipes-app/iot2050-firmware-update/files/iot2050-firmware-update.tmpl
@@ -114,6 +114,7 @@ import time
 import tarfile
 import textwrap
 import tempfile
+from packaging import version
 from abc import ABC, abstractmethod
 from ctypes import *
 from enum import Enum
@@ -635,7 +636,9 @@ class FirmwareTarball(object):
 
     def __check_os(self, target_os, os_info) -> bool:
         for tos in target_os:
-            if tos.key in os_info and os_info[tos.key] >= (tos.min_version):
+            current_version = version.parse(os_info[tos.key])
+            required_version = version.parse(tos.min_version)
+            if current_version >= required_version:
                 return True
             print("\nFirmware requires a minimal version of ",
                   tos.min_version, ", the current OS has ",

--- a/recipes-app/iot2050-firmware-update/iot2050-firmware-update_1.0.0.bb
+++ b/recipes-app/iot2050-firmware-update/iot2050-firmware-update_1.0.0.bb
@@ -9,7 +9,7 @@
 # COPYING.MIT file in the top-level directory.
 #
 
-PR = "1"
+PR = "2"
 
 DESCRIPTION = "OSPI Firmware Update Scripts"
 MAINTAINER = "chao.zeng@siemens.com"
@@ -24,7 +24,7 @@ DPKG_ARCH = "any"
 
 inherit dpkg-raw
 
-DEBIAN_DEPENDS = "python3-progress, u-boot-tools"
+DEBIAN_DEPENDS = "python3-progress, python3-packaging, u-boot-tools"
 
 do_install() {
     install -v -d ${D}/usr/sbin/


### PR DESCRIPTION
Plain string comparison fails for versions like "4.10" vs "4.2", causing incorrect results. This patch uses `packaging.version` to ensure proper semantic version comparison.