### PR TITLE
fix(qemu): remove firmware-update-package from QEMU

### DIFF
--- a/conf/machine/iot2050-qemu.conf
+++ b/conf/machine/iot2050-qemu.conf
@@ -17,3 +17,5 @@ CONSOLE_KERNEL_PARAMS = ""
 QEMU_IMAGE = "1"
 
 PREFERRED_PROVIDER_u-boot-${MACHINE} = "u-boot-qemu-arm64"
+
+IMAGE_INSTALL:remove = "firmware-update-package"


### PR DESCRIPTION
The `firmware-update-package` was being included in QEMU image builds as a part of `iot2050-image-example` image and causes a provider conflict due to pulling other varient of U-Boot recipe (u-boot-iot2050). This resolves the multiple provider conflict and ensures only the appropriate U-Boot recipe is built for QEMU.