### PR TITLE
fix(swupdate-config): install swupdate-config machine specific

### DIFF
--- a/recipes-core/images/iot2050-image-swu-example.bb
+++ b/recipes-core/images/iot2050-image-swu-example.bb
@@ -40,7 +40,7 @@ IMAGE_INSTALL:remove:secureboot = "expand-on-first-boot"
 # EFI Boot Guard is used instead
 IMAGE_INSTALL:remove = "u-boot-script"
 
-IMAGE_INSTALL += "swupdate-config"
+IMAGE_INSTALL += "swupdate-config-${MACHINE}"
 IMAGE_INSTALL += "swupdate-handler-roundrobin"
 IMAGE_INSTALL += "swupdate-complete-update-helper"
 IMAGE_INSTALL += "${@ 'iot2050-watchdog' if d.getVar('QEMU_IMAGE') != '1' else '' }"


### PR DESCRIPTION
Install correct swupdate-config package as per machine specific, this solve the below build issue for qemu image.

| DEBUG: Shell function rootfs_import_package_cache finished | DEBUG: Executing shell function rootfs_install_pkgs_download | Reading package lists...
| Building dependency tree...
| Reading state information...
| Package swupdate-config is a virtual package provided by:
|   swupdate-config-iot2050-qemu 0.2
|   swupdate-config-iot2050 0.2