### PR TITLE
images: remove the unused code blocks

### DIFF
--- a/recipes-app/iot2050-firmware-update/iot2050-firmware-update_1.0.1.bb
+++ b/recipes-app/iot2050-firmware-update/iot2050-firmware-update_1.0.1.bb
@@ -9,7 +9,7 @@
 # COPYING.MIT file in the top-level directory.
 #
 
-PR = "2"
+PR = "3"
 
 DESCRIPTION = "OSPI Firmware Update Scripts"
 MAINTAINER = "chao.zeng@siemens.com"
@@ -33,9 +33,3 @@ do_install() {
     install -v -d ${D}/usr/share/iot2050/fwu
     install -v -m 644 ${WORKDIR}/update.conf.json ${D}/usr/share/iot2050/fwu/
 }
-
-do_deploy_deb:append() {
-    cp -f "${WORKDIR}/${PN}_${PV}_arm64.deb" "${DEPLOY_DIR_IMAGE}/"
-}
-
-do_deploy_deb[dirs] = "${DEPLOY_DIR_IMAGE}"

--- a/recipes-devtools/firmware-update-package/firmware-update-package_0.1.bb
+++ b/recipes-devtools/firmware-update-package/firmware-update-package_0.1.bb
@@ -10,6 +10,8 @@
 DESCRIPTION = "Generate The Firmware Update Package"
 MAINTAINER = "huaqian.li@siemens.com"
 
+PR = "2"
+
 SRC_URI = "file://iot2050-generate-fwu-tarball.sh \
            file://update.conf.json.tmpl"
 
@@ -32,10 +34,5 @@ do_install() {
     install -d ${D}/usr/share/iot2050/fwu
     install -m 644 ${DEPLOY_DIR_IMAGE}/IOT2050-FW-Update-PKG-$(${ISAR_RELEASE_CMD}).tar.xz \
     ${D}/usr/share/iot2050/fwu
+    rm -rf ${DEPLOY_DIR_IMAGE}/IOT2050-FW-Update-PKG-$(${ISAR_RELEASE_CMD}).tar.xz
 }
-
-do_deploy_deb:append() {
-    cp -f "${WORKDIR}/${PN}_${PV}_arm64.deb" "${DEPLOY_DIR_IMAGE}/"
-}
-
-do_deploy_deb[dirs] = "${DEPLOY_DIR_IMAGE}"


### PR DESCRIPTION
Clean up duplicate/unused code blocks that were causing <package>.deb and .tar.xz files to be kept in `DEPLOY_DIR_IMAGE` unnecessarily.

This commit removes the following files from DEPLOY_DIR_IMAGE:
* firmware-update-package_0.1_arm64.deb
* iot2050-firmware-update_0.5_arm64.deb
* iot2050-firmware-update_1.0.1_arm64.deb
* IOT2050-FW-Update-PKG-V01.05.01-48-g8d674cb.tar.xz