### PR TITLE
fix: kernel: add patch for rt-kernel crashes due to preemt-rt

### DIFF
--- a/meta/recipes-kernel/linux/files/patches/0025-epoll-fix-eventpoll-read-lock-not-writer-fair-in-preemt-rt.patch
+++ b/meta/recipes-kernel/linux/files/patches/0025-epoll-fix-eventpoll-read-lock-not-writer-fair-in-preemt-rt.patch
@@ -1,0 +1,62 @@
+From: Frederic Weisbecker <frederic@kernel.org>
+Date: Wed, 25 Aug 2021 14:24:54 +0200
+Subject: [RFC PATCH -RT] epoll: Fix eventpoll read-lock not writer-fair in PREEMPT_RT
+
+The eventpoll lock has been converted to an rwlock some time ago with:
+
+	a218cc491420 (epoll: use rwlock in order to reduce ep_poll
+					callback() contention)
+
+Unfortunately this can result in scenarios where a high priority caller
+of epoll_wait() need to wait for the completion of lower priority wakers.
+
+The typical scenario is:
+
+1) epoll_wait() waits and sleeps for new events in the ep_poll() loop.
+
+2) new events arrive in ep_poll_callback(), the waiter is awaken while
+   ep->lock is read-acquired.
+
+3) The high priority waiter preempts the waker but it can't acquire the
+   write lock in epoll_wait() so it blocks waiting for the low prio waker
+   without priority inheritance.
+
+I guess making readlock writer fair is still not the plan so all I can
+propose is to make that rwlock build-conditional.
+
+Signed-off-by: Frederic Weisbecker <frederic@kernel.org>
+---
+ fs/eventpoll.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/fs/eventpoll.c b/fs/eventpoll.c
+index 1e596e1d0bba..c1fb4b01ea4f 100644
+--- a/fs/eventpoll.c
++++ b/fs/eventpoll.c
+@@ -1133,7 +1133,10 @@ static int ep_poll_callback(wait_queue_entry_t *wait, unsigned mode, int sync, v
+ 	unsigned long flags;
+ 	int ewake = 0;
+
+-	read_lock_irqsave(&ep->lock, flags);
++	if (!IS_ENABLED(CONFIG_PREEMPT_RT))
++		read_lock_irqsave(&ep->lock, flags);
++	else
++		write_lock_irqsave(&ep->lock, flags);
+
+ 	ep_set_busy_poll_napi_id(epi);
+
+@@ -1197,7 +1200,10 @@ static int ep_poll_callback(wait_queue_entry_t *wait, unsigned mode, int sync, v
+ 		pwake++;
+
+ out_unlock:
+-	read_unlock_irqrestore(&ep->lock, flags);
++	if (!IS_ENABLED(CONFIG_PREEMPT_RT))
++		read_unlock_irqrestore(&ep->lock, flags);
++	else
++		write_unlock_irqrestore(&ep->lock, flags);
+
+ 	/* We have to call this outside the lock */
+ 	if (pwake)
+--
+2.25.1
+


### PR DESCRIPTION
Stress-ng tests were executing on edge iot2050 OS and after 4 days, a kernel crash is observed:

> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: rcu: INFO: rcu_preempt self-detected stall on CPU
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: rcu:         3-...!: (5426 ticks this GP) idle=948c/0/0x1 softirq=0/0 fqs=1
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel:         (t=5250 jiffies g=42193573 q=28 ncpus=4)
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: rcu: rcu_preempt kthread timer wakeup didn't happen for 5247 jiffies! g42193573 f0x0 RCU_GP_WAIT_FQS(5) ->state=0x402
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: rcu:         Possible timer handling issue on cpu=3 timer-softirq=11616448
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: rcu: rcu_preempt kthread starved for 5248 jiffies! g42193573 f0x0 RCU_GP_WAIT_FQS(5) ->state=0x402 ->cpu=3
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: rcu:         Unless rcu_preempt kthread gets sufficient CPU time, OOM is now expected behavior.
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: rcu: RCU grace-period kthread stack dump:
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: task:rcu_preempt     state:I stack:0     pid:16    ppid:2      flags:0x00000008
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: Call trace:
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel:  __switch_to+0xdc/0x120
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel:  __schedule+0x2f8/0x7c4
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel:  schedule+0x5c/0x10c
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel:  schedule_timeout+0x8c/0x100
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel:  rcu_gp_fqs_loop+0x148/0x4b0
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel:  rcu_gp_kthread+0x13c/0x170
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel:  kthread+0x124/0x12c
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel:  ret_from_fork+0x10/0x20
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: rcu: Stack dump where RCU GP kthread last ran:
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: CPU: 3 PID: 0 Comm: swapper/3 Not tainted 6.1.134-cip41-rt22 #1
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: Hardware name: SIEMENS AG SIMATIC IOT2050/Unknown Product, BIOS 2023.10-V01.04.04_S01.01.01-0-ga6c5ae8 10/01/2023
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: pstate: 60000005 (nZCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: pc : arch_cpu_idle+0x18/0x2c
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: lr : arch_cpu_idle+0x14/0x2c
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: sp : ffff8000094b3e20
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: x29: ffff8000094b3e20 x28: 0000000000000000 x27: 0000000000000000
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: x26: 0000000000000000 x25: 0000000000000000 x24: 0000000000000000
> Nov 15 23:24:31 simatic-iot2050-ied-bc2164f4 kernel: x23: 0000000000000000 x22: ffff0000001a5e80 x21: ffff80000917bac0
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: x20: 0000000000000003 x19: ffff80000917b9a0 x18: ffff800009aa3d48
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: x17: ffff800009234fc8 x16: 00000000d9f50eeb x15: 00000000dcba71ef
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: x14: 00000000c245fa86 x13: 000000000000033e x12: 000000000000033e
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: x11: 0000000000000001 x10: 0000000000000b30 x9 : ffff8000094b3d90
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: x8 : ffff0000001a6a10 x7 : 00000000000000c0 x6 : ffff80000902a8d8
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: x5 : 4000000000000000 x4 : ffff800076b63000 x3 : 0000000000000000
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: x2 : 000000000a239489 x1 : ffff00007fb8d8d8 x0 : 00000000000000e0
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: Call trace:
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel:  arch_cpu_idle+0x18/0x2c
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel:  default_idle_call+0x30/0x78
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel:  do_idle+0xd8/0x150
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel:  cpu_startup_entry+0x38/0x40
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel:  secondary_start_kernel+0x124/0x150
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel:  __secondary_switched+0xb0/0xb4
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: CPU: 3 PID: 0 Comm: swapper/3 Not tainted 6.1.134-cip41-rt22 #1
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: Hardware name: SIEMENS AG SIMATIC IOT2050/Unknown Product, BIOS 2023.10-V01.04.04_S01.01.01-0-ga6c5ae8 10/01/2023
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: pstate: 60000005 (nZCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: pc : arch_cpu_idle+0x18/0x2c
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: lr : arch_cpu_idle+0x14/0x2c
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: sp : ffff8000094b3e20
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: x29: ffff8000094b3e20 x28: 0000000000000000 x27: 0000000000000000
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: x26: 0000000000000000 x25: 0000000000000000 x24: 0000000000000000
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: x23: 0000000000000000 x22: ffff0000001a5e80 x21: ffff80000917bac0
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: x20: 0000000000000003 x19: ffff80000917b9a0 x18: ffff800009aa3d48
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: x17: ffff800009234fc8 x16: 00000000d9f50eeb x15: 00000000dcba71ef
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: x14: 00000000c245fa86 x13: 000000000000033e x12: 000000000000033e
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: x11: 0000000000000001 x10: 0000000000000b30 x9 : ffff8000094b3d90
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: x8 : ffff0000001a6a10 x7 : 00000000000000c0 x6 : ffff80000902a8d8
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: x5 : 4000000000000000 x4 : ffff800076b63000 x3 : 0000000000000000
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: x2 : 000000000a239489 x1 : ffff00007fb8d8d8 x0 : 00000000000000e0
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel: Call trace:
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel:  arch_cpu_idle+0x18/0x2c
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel:  default_idle_call+0x30/0x78
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel:  do_idle+0xd8/0x150
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel:  cpu_startup_entry+0x38/0x40
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel:  secondary_start_kernel+0x124/0x150
> Nov 15 23:24:32 simatic-iot2050-ied-bc2164f4 kernel:  __secondary_switched+0xb0/0xb4
> Nov 15 23:24:47 simatic-iot2050-ied-bc2164f4 swupdate.sh[4795]: [TRACE] : SWUPDATE running :  [start_suricatta] : Suricatta awakened.
> Nov 15 23:25:13 simatic-iot2050-ied-bc2164f4 systemd[1]: systemd-logind.service: Watchdog timeout (limit 3min)!
> Nov 15 23:25:13 simatic-iot2050-ied-bc2164f4 systemd[1]: systemd-logind.service: Killing process 684 (systemd-logind) with signal SIGABRT.
> Nov 15 23:25:34 simatic-iot2050-ied-bc2164f4 kernel: rcu: INFO: rcu_preempt detected stalls on CPUs/tasks:
> Nov 15 23:25:34 simatic-iot2050-ied-bc2164f4 kernel: rcu:         Tasks blocked on level-0 rcu_node (CPUs 0-3): P4110/3:b..l P4019/9:b..l
> Nov 15 23:25:34 simatic-iot2050-ied-bc2164f4 kernel:         (detected by 2, t=21005 jiffies, g=42193573, q=214 ncpus=4)

A patch on x86 is already implemented and tested for this kind of problem. Porting it for iot2050.