### PR TITLE
Fix the base image building error due to missing dependency

### DIFF
--- a/meta/recipes-core/images/iot2050-image-base.bb
+++ b/meta/recipes-core/images/iot2050-image-base.bb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) Siemens AG, 2019-2023
+# Copyright (c) Siemens AG, 2019-2026
 #
 # Authors:
 #  Le Jin <le.jin@siemens.com>
@@ -12,6 +12,8 @@ require recipes-core/images/meta-packages.inc
 inherit image
 
 DESCRIPTION = "IOT2050 Debian Base Image"
+
+IMAGE_PREINSTALL += "sshd-regen-keys"
 
 IMAGE_INSTALL += "${IOT2050_META_PACKAGES}"
 


### PR DESCRIPTION
Original error message:

> WARNING: iot2050-image-base-1.0-r0 do_rootfs_postprocess: Looks like you have ssh host keys in the image but did  not install "sshd-regen-keys". This image should not be  deployed more than once.
> ERROR: iot2050-image-base-1.0-r0 do_rootfs_postprocess: Install the package or forcefully remove this check!
> ERROR: iot2050-image-base-1.0-r0 do_rootfs_postprocess: ExecutionError('/work/build/tmp/work/iot2050-debian-arm64/iot2050-image-base-iot2050/1.0-r0/temp/run.image_postprocess_sshd_key_regen.4785', 1, None, None)
> ERROR: Logfile of failure stored in: /work/build/tmp/work/iot2050-debian-arm64/iot2050-image-base-iot2050/1.0-r0/temp/log.do_rootfs_postprocess.4785
> ERROR: Task (/work/build/../../repo/meta/recipes-core/images/iot2050-image-base.bb:do_rootfs_postprocess) failed with exit code '1'
> NOTE: Tasks Summary: Attempted 201 tasks of which 194 didn't need to be rerun and 1 failed.