### PR TITLE
meta/images: fix missing dependency for iot2050-image-base

### DIFF
--- a/meta/recipes-core/ssh-root-login/ssh-root-login_1.0.0.bb
+++ b/meta/recipes-core/ssh-root-login/ssh-root-login_1.0.0.bb
@@ -8,13 +8,14 @@
 # COPYING.MIT file in the top-level directory.
 #
 
-PR = "1"
+PR = "2"
 
 inherit dpkg-raw
 
 DESCRIPTION = "Permit root login for ssh"
 
-DEBIAN_DEPENDS = "openssh-server"
+DEPENDS = "sshd-regen-keys"
+DEBIAN_DEPENDS = "openssh-server, sshd-regen-keys"
 
 SRC_URI = " \
     file://postinst \


### PR DESCRIPTION
Include the dependent package `sshd-regen-keys` in `iot2050-image-base` to fix the following build error during rootfs post-processing:

WARNING: iot2050-image-base-1.0-r0 do_rootfs_postprocess: Looks like you have ssh host keys in the image but did  not install "sshd-regen-keys". This image should not be  deployed more than once. ERROR: iot2050-image-base-1.0-r0 do_rootfs_postprocess: Install the package or forcefully remove this check!
ERROR: iot2050-image-base-1.0-r0 do_rootfs_postprocess: ExecutionError('/work /build/tmp/work/iot2050-debian-arm64/iot2050-image-base-iot2050/1.0-r0/temp/ run.image_postprocess_sshd_key_regen.171019', 1, None, None)