### PR TITLE
dtb: define default DTB_FILES in machine config

### DIFF
--- a/meta-sm/conf/layer.conf
+++ b/meta-sm/conf/layer.conf
@@ -14,7 +14,7 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
         ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-DTB_FILES += " \
+DTB_FILES:append = " \
     ti/k3-am6548-iot2050-advanced-sm.dtb \
     "
 

--- a/meta/conf/machine/iot2050.conf
+++ b/meta/conf/machine/iot2050.conf
@@ -15,7 +15,7 @@ PREFERRED_PROVIDER_u-boot-${MACHINE} ?= "u-boot-iot2050"
 PREFERRED_PROVIDER_u-boot-${MACHINE}-config ?= "u-boot-iot2050"
 
 KERNEL_NAME ?= "iot2050"
-DTB_FILES ?= " \
+DTB_FILES = " \
     ti/k3-am6528-iot2050-basic.dtb \
     ti/k3-am6528-iot2050-basic-pg2.dtb \
     ti/k3-am6548-iot2050-advanced.dtb \


### PR DESCRIPTION
DTB_FILES was previously assigned using the '?=' operator in the iot2050 machine configuration. Since DTB_FILES may already be defined by other layers, this caused the assignment to be skipped entirely, resulting in only downstream-appended DTBs being visible.

Define DTB_FILES explicitly in the iot2050 machine configuration and allow downstream layers to extend it using '+=' or ':append'.

This ensures that all base DTBs for the iot2050 platform are always included, while still allowing feature or product layers to add additional DTBs without overriding the base set.