### PR TITLE
iot2050-base-packages: use Debian libubootenv-tool package

### DIFF
--- a/meta/recipes-core/images/iot2050-image-base.bb
+++ b/meta/recipes-core/images/iot2050-image-base.bb
@@ -15,6 +15,8 @@ DESCRIPTION = "IOT2050 Debian Base Image"
 
 IMAGE_INSTALL += "${IOT2050_META_PACKAGES}"
 
+IMAGE_PREINSTALL += "libubootenv-tool"
+
 # Make the .wic.img symlink to the .wic file for better backward compatibility
 do_deploy() {
     echo "Linking wic img"

--- a/meta/recipes-core/images/meta-packages.inc
+++ b/meta/recipes-core/images/meta-packages.inc
@@ -13,7 +13,6 @@ IOT2050_META_PACKAGES ?= " \
     ${@ 'u-boot-${MACHINE}-config' if d.getVar('QEMU_IMAGE') != '1' else '' } \
     iot2050-firmware \
     iot2050-base-packages \
-    libubootenv-tool \
     regen-rootfs-uuid \
     ssh-root-login \
     iot2050-status-led \


### PR DESCRIPTION
Debian Trixie already includes libubootenv-tool version 0.3.5, which matches the version previously built locally. Switch to using the Debian-provided package instead.

The existing libubootenv 0.3.5 recipe from isar is primarily intended for Bookworm-based distributions and is no longer needed for Trixie.