### PR TITLE
fix base image build error due to unable to locate sshd-regen-keys

### DIFF
--- a/meta-example/recipes-core/images/iot2050-image-example.bb
+++ b/meta-example/recipes-core/images/iot2050-image-example.bb
@@ -28,6 +28,7 @@ IMAGE_PREINSTALL += "${@ ' \
 
 IMAGE_INSTALL += " \
     expand-on-first-boot \
+    ssh-root-login \
     sshd-regen-keys \
     install-on-emmc \
     iot2050-nm-settings \

--- a/meta/recipes-core/images/iot2050-image-base.bb
+++ b/meta/recipes-core/images/iot2050-image-base.bb
@@ -13,8 +13,6 @@ inherit image
 
 DESCRIPTION = "IOT2050 Debian Base Image"
 
-IMAGE_PREINSTALL += "sshd-regen-keys"
-
 IMAGE_INSTALL += "${IOT2050_META_PACKAGES}"
 
 IMAGE_PREINSTALL += "libubootenv-tool"

--- a/meta/recipes-core/images/meta-packages.inc
+++ b/meta/recipes-core/images/meta-packages.inc
@@ -14,7 +14,6 @@ IOT2050_META_PACKAGES ?= " \
     iot2050-firmware \
     iot2050-base-packages \
     regen-rootfs-uuid \
-    ssh-root-login \
     iot2050-status-led \
     iot2050-switchserialmode \
     "


### PR DESCRIPTION
Base image build failed with error:
> | DEBUG: Executing shell function rootfs_install_pkgs_download
> | Reading package lists...
> | Building dependency tree...
> | Reading state information...
> | E: Unable to locate package sshd-regen-keys
> | WARNING: exit code 100 from a shell command.
> | DEBUG: Executing shell function rootfs_do_umounts
> | DEBUG: Shell function rootfs_do_umounts finished
> | DEBUG: Python function do_rootfs_install finished

use IMAGE_INSTALL instead of IMAGE_PREINSTALL to fix the issue as sshd-regen-keys is provided by isar.