### PR TITLE
chore: migrate custom ISAR helper includes to bbclasses

### DIFF
--- a/meta/recipes-bsp/optee-client/optee-client-iot2050_4.7.0.bb
+++ b/meta/recipes-bsp/optee-client/optee-client-iot2050_4.7.0.bb
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: MIT
 #
 
-require recipes-bsp/optee-client/optee-client-custom.inc
+inherit optee-client
 
 SRC_URI += "https://github.com/OP-TEE/optee_client/archive/${PV}.tar.gz;downloadfilename=optee_client-${PV}.tar.gz"
 SRC_URI[sha256sum] = "e6c6b93e2be417df57ceb05a2eb6505744e3fbdd3b2ae5e5bf79bf6028b6f84d"

--- a/meta/recipes-bsp/optee-ftpm/optee-ftpm-iot2050_4.7+v1.62r1-48-ge9fc7b8.bb
+++ b/meta/recipes-bsp/optee-ftpm/optee-ftpm-iot2050_4.7+v1.62r1-48-ge9fc7b8.bb
@@ -8,7 +8,7 @@
 
 PR="1"
 
-require recipes-bsp/optee-ftpm/optee-ftpm.inc
+inherit optee-ftpm
 
 SRC_URI += " \
     https://github.com/OP-TEE/optee_ftpm/archive/${SRCREV}.tar.gz;downloadfilename=optee_ftpm-${SRCREV}.tar.gz \

--- a/meta/recipes-bsp/optee-os/optee-os-iot2050_4.7.0.bb
+++ b/meta/recipes-bsp/optee-os/optee-os-iot2050_4.7.0.bb
@@ -8,7 +8,7 @@
 # This file is subject to the terms and conditions of the MIT License.  See
 # COPYING.MIT file in the top-level directory.
 #
-require recipes-bsp/optee-os/optee-os-custom.inc
+inherit optee-os
 require optee-os-iot2050_${PV}.inc
 
 OPTEE_BINARIES = "tee-raw.bin"

--- a/meta/recipes-bsp/optee-os/optee-os-tadevkit-iot2050_4.7.0.bb
+++ b/meta/recipes-bsp/optee-os/optee-os-tadevkit-iot2050_4.7.0.bb
@@ -8,5 +8,5 @@
 # COPYING.MIT file in the top-level directory.
 #
 
-require recipes-bsp/optee-os/optee-os-tadevkit-custom.inc
+inherit optee-os-tadevkit
 require optee-os-iot2050_${PV}.inc

--- a/meta/recipes-bsp/trusted-firmware-a/trusted-firmware-a-iot2050_2.8.35.bb
+++ b/meta/recipes-bsp/trusted-firmware-a/trusted-firmware-a-iot2050_2.8.35.bb
@@ -8,7 +8,7 @@
 # COPYING.MIT file in the top-level directory.
 #
 
-require recipes-bsp/trusted-firmware-a/trusted-firmware-a-custom.inc
+inherit trusted-firmware-a
 
 SRC_URI += "https://github.com/ARM-software/arm-trusted-firmware/archive/refs/tags/lts-v${PV}.tar.gz"
 SRC_URI[sha256sum] = "8fe5e74db3e15d447cb268d4965a46c93a81d1636ee326b5c4ec44cb31c0a2fc"

--- a/meta/recipes-bsp/u-boot/u-boot-iot2050.inc
+++ b/meta/recipes-bsp/u-boot/u-boot-iot2050.inc
@@ -9,7 +9,7 @@
 # COPYING.MIT file in the top-level directory.
 #
 
-require recipes-bsp/u-boot/u-boot-custom.inc
+inherit u-boot
 
 SRC_URI += " \
     file://rules.tmpl \

--- a/meta/recipes-kernel/linux/linux-iot2050-6.12.inc
+++ b/meta/recipes-kernel/linux/linux-iot2050-6.12.inc
@@ -5,7 +5,7 @@
 # COPYING.MIT file in the top-level directory.
 #
 
-require recipes-kernel/linux/linux-custom.inc
+inherit linux-kernel
 
 def get_patches(d, patchdir):
     import glob

--- a/meta/recipes-kernel/linux/linux-iot2050_6.x-upstream.bb
+++ b/meta/recipes-kernel/linux/linux-iot2050_6.x-upstream.bb
@@ -8,7 +8,7 @@
 # COPYING.MIT file in the top-level directory.
 #
 
-require recipes-kernel/linux/linux-custom.inc
+inherit linux-kernel
 
 SRC_URI += " \
     git://github.com/siemens/linux.git;protocol=https;branch=jan/iot2050 \


### PR DESCRIPTION
Replace deprecated recipe helper require includes with direct inherit usage for updated ISAR compatibility.

This removes the do_warn_custom_inc migration warnings introduced by the ISAR update.