### PR TITLE
[master]node-red: disable service by default

### DIFF
--- a/meta-node-red/recipes-app/node-red/files/99-node-red.preset
+++ b/meta-node-red/recipes-app/node-red/files/99-node-red.preset
@@ -1,0 +1,1 @@
+disable node-red.service

--- a/meta-node-red/recipes-app/node-red/node-red_4.0.9.bb
+++ b/meta-node-red/recipes-app/node-red/node-red_4.0.9.bb
@@ -22,12 +22,24 @@ DESCRIPTION = "A visual tool for wiring the Internet of Things"
 PRESERVE_PERMS = "usr/lib/node_modules/node-red/red.js"
 DEBIAN_DEPENDS = "nodejs"
 
-SRC_URI += "file://node-red.service.tmpl"
+SRC_URI += "file://node-red.service.tmpl \
+            file://99-node-red.preset"
 
 TEMPLATE_FILES = "node-red.service.tmpl"
 TEMPLATE_VARS  = "NODE_RED_HOME_DIR"
 
+do_prepare_build:append() {
+    cat <<EOF >> ${S}/debian/rules
+
+override_dh_installsystemd:
+	dh_installsystemd --no-start
+EOF
+}
+
 do_install:append() {
     install -v -d ${D}/usr/lib/systemd/system/
     install -v -m 644 ${WORKDIR}/node-red.service ${D}/usr/lib/systemd/system/
+
+    install -v -d ${D}/usr/lib/systemd/system-preset/
+    install -v -m 644 ${WORKDIR}/99-node-red.preset ${D}/usr/lib/systemd/system-preset/
 }


### PR DESCRIPTION
Do not enable or start Node-RED during package installation.

Not every system needs Node-RED at boot, and it currently runs with root privileges. Keep it installed, but require users to start or enable it explicitly when needed.