### PR TITLE
Add support for loading rootfs from booted media

### DIFF
--- a/meta-example/recipes-bsp/patch-u-boot-env/files/patch-u-boot-env.config
+++ b/meta-example/recipes-bsp/patch-u-boot-env/files/patch-u-boot-env.config
@@ -1,3 +1,3 @@
 watchdog_timeout_ms=60000
 start_watchdog=if test ${watchdog_timeout_ms} -gt 0; then wdt dev watchdog@40610000 || wdt dev rti@40610000; wdt start ${watchdog_timeout_ms}; echo Watchdog started, timeout ${watchdog_timeout_ms} ms; fi
-bootcmd=setenv scan_dev_for_boot 'if test -e ${devtype} ${devnum}:${distro_bootpart} efi/boot/bootaa64.efi; then load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} efi/boot/bootaa64.efi; bootefi ${kernel_addr_r} ${fdtcontroladdr}; fi'; run start_watchdog; run distro_bootcmd
+bootcmd=setenv scan_dev_for_boot 'if test -e ${devtype} ${devnum}:${distro_bootpart} efi/boot/bootaa64.efi; then load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} efi/boot/bootaa64.efi; setenv -e -bs -rt IOT2050BootDevice ${devtype}${devnum}; bootefi ${kernel_addr_r} ${fdtcontroladdr}; fi'; run start_watchdog; run distro_bootcmd

--- a/meta-example/recipes-core/images/iot2050-image-example.bb
+++ b/meta-example/recipes-core/images/iot2050-image-example.bb
@@ -14,6 +14,13 @@ require recipes-core/images/iot2050-package-selections.inc
 
 DESCRIPTION = "IOT2050 Debian Example Image"
 
+WKS_FILE = "iot2050-example.wks.in"
+
+INITRAMFS_RECIPE = "iot2050-initramfs-example"
+
+IMAGE_INITRD = "${INITRAMFS_RECIPE}"
+do_image_wic[depends] += "${INITRAMFS_RECIPE}:do_build"
+
 IMAGE_PREINSTALL += " \
     ${IOT2050_DEBIAN_DEBUG_PACKAGES} \
     ${IOT2050_DEBIAN_WIFI_PACKAGES} \

--- a/meta-example/recipes-core/images/iot2050-image-swu-example.bb
+++ b/meta-example/recipes-core/images/iot2050-image-swu-example.bb
@@ -24,6 +24,12 @@ SWU_ROOTFS_TYPE:secureboot = "verity"
 
 SWU_HW_COMPAT = "IOT2050"
 
+ABROOTFS_IMAGE_RECIPE ?= "iot2050-image-swu-example"
+VERITY_IMAGE_RECIPE ?= "iot2050-image-swu-example"
+INITRAMFS_RECIPE ?= "iot2050-initramfs"
+ABROOTFS_PART_UUID_A ?= "fedcba98-7654-3210-cafe-5e0710000001"
+ABROOTFS_PART_UUID_B ?= "fedcba98-7654-3210-cafe-5e0710000002"
+
 IMAGE_INITRD = "${INITRAMFS_RECIPE}"
 do_image_wic[depends] += "${INITRAMFS_RECIPE}:do_build"
 

--- a/meta-example/recipes-initramfs/initramfs-efi-rootfs-hook/files/local-top-complete
+++ b/meta-example/recipes-initramfs/initramfs-efi-rootfs-hook/files/local-top-complete
@@ -1,0 +1,171 @@
+#!/bin/sh
+#
+# Copyright (c) Siemens AG, 2026
+#
+# SPDX-License-Identifier: MIT
+
+prereqs()
+{
+	# Run after the generic root-selection hooks so we can override an ambiguous
+	# PARTLABEL=rootfs choice with the rootfs on the same disk as the booted
+	# medium. U-Boot exports the selected EFI boot device via the
+	# IOT2050BootDevice EFI variable before launching the EFI payload.
+	for req in "${0%/*}"/*; do
+		script="${req##*/}"
+		if [ "$script" != "${0##*/}" ] && \
+		   [ "$script" != "cryptroot" ]; then
+			printf '%s\n' "$script"
+		fi
+	done
+}
+case $1 in
+prereqs)
+	prereqs
+	exit 0
+	;;
+esac
+
+. /scripts/functions
+
+log_efi_rootfs()
+{
+	message="efi-rootfs: $*"
+	echo "${message}" >&2
+}
+
+boot_device_from_efivar()
+{
+	mkdir -p /sys/firmware/efi/efivars
+	if ! /sbin/modprobe efivarfs 2>/dev/null; then
+		log_efi_rootfs "modprobe efivarfs failed"
+	fi
+	if ! mount -t efivarfs efivarfs /sys/firmware/efi/efivars 2>/dev/null; then
+		log_efi_rootfs "mount efivarfs failed"
+	fi
+
+	set -- /sys/firmware/efi/efivars/IOT2050BootDevice-*
+	if [ "$1" = "/sys/firmware/efi/efivars/IOT2050BootDevice-*" ]; then
+		log_efi_rootfs "IOT2050BootDevice efivar not visible"
+		return 1
+	fi
+
+	efivar="$1"
+	log_efi_rootfs "IOT2050BootDevice efivar=${efivar}"
+	dd if="${efivar}" bs=1 skip=4 2>/dev/null | tr -d '\000\r\n'
+}
+
+boot_disk_device()
+{
+	case "$1" in
+	mmc[0-9]*)
+		printf '/dev/mmcblk%s\n' "${1#mmc}"
+		return 0
+		;;
+	esac
+
+	return 1
+}
+
+default_rootfs_device()
+{
+	blkid --list-one --output device --match-token PARTLABEL=rootfs 2>/dev/null
+}
+
+rootfs_partition_on_boot_device()
+{
+	boot_disk="$(boot_disk_device "$1")"
+	if [ -z "${boot_disk}" ] || [ ! -b "${boot_disk}" ]; then
+		return 1
+	fi
+
+	ext4_candidate=""
+	for candidate in "${boot_disk}"p*; do
+		[ -b "${candidate}" ] || continue
+		partlabel="$(blkid -s PARTLABEL -o value "${candidate}" 2>/dev/null)"
+		label="$(blkid -s LABEL -o value "${candidate}" 2>/dev/null)"
+		fstype="$(blkid -s TYPE -o value "${candidate}" 2>/dev/null)"
+
+		if [ "${partlabel}" = "rootfs" ] || [ "${label}" = "rootfs" ]; then
+			printf '%s\n' "${candidate}"
+			return 0
+		fi
+
+		if [ "${fstype}" = "ext4" ] && [ -z "${ext4_candidate}" ]; then
+			ext4_candidate="${candidate}"
+		fi
+	done
+
+	if [ -n "${ext4_candidate}" ]; then
+		printf '%s\n' "${ext4_candidate}"
+		return 0
+	fi
+
+	return 1
+}
+
+wait_for_boot_device_rootfs()
+{
+	boot_device="$1"
+	timeout="${2:-10}"
+	count=0
+
+	while [ "${count}" -lt "${timeout}" ]; do
+		found_root="$(rootfs_partition_on_boot_device "${boot_device}")"
+		if [ -n "${found_root}" ]; then
+			printf '%s\n' "${found_root}"
+			return 0
+		fi
+		count=$((count + 1))
+		sleep 1
+	done
+
+	return 1
+}
+
+set_root()
+{
+	ROOT="$1"
+	export ROOT
+	echo "ROOT=${ROOT}" >/conf/param.conf
+	log_efi_rootfs "selected ROOT=${ROOT}"
+}
+
+fallback_root()
+{
+	found_root="$(default_rootfs_device)"
+	if [ -z "${found_root}" ]; then
+		return 1
+	fi
+
+	set_root "${found_root}"
+	return 0
+}
+
+wait_for_udev 10
+
+boot_device="$(boot_device_from_efivar || true)"
+log_efi_rootfs "IOT2050BootDevice=${boot_device:-<empty>}"
+
+if [ -z "${boot_device}" ]; then
+	log_efi_rootfs "no boot device, using fallback root"
+	fallback_root || exit 0
+	exit 0
+fi
+
+boot_disk="$(boot_disk_device "${boot_device}" || true)"
+log_efi_rootfs "boot disk=${boot_disk:-<empty>}"
+if [ -z "${boot_disk}" ]; then
+	log_efi_rootfs "boot disk unsupported, using fallback root"
+	fallback_root || exit 0
+	exit 0
+fi
+
+found_root="$(wait_for_boot_device_rootfs "${boot_device}" 10)"
+log_efi_rootfs "boot-device root candidate=${found_root:-<empty>}"
+if [ -z "${found_root}" ]; then
+	log_efi_rootfs "boot-device root not found, using fallback root"
+	fallback_root || exit 0
+	exit 0
+fi
+
+set_root "${found_root}"

--- a/meta-example/recipes-initramfs/initramfs-efi-rootfs-hook/initramfs-efi-rootfs-hook_1.0.0.bb
+++ b/meta-example/recipes-initramfs/initramfs-efi-rootfs-hook/initramfs-efi-rootfs-hook_1.0.0.bb
@@ -1,0 +1,17 @@
+#
+# Copyright (c) Siemens AG, 2026
+#
+# SPDX-License-Identifier: MIT
+
+PR = "1"
+
+inherit initramfs-hook
+
+RDEPENDS += "initramfs-cip-functions"
+DEBIAN_DEPENDS .= ", coreutils, util-linux, initramfs-cip-functions"
+HOOK_ADD_MODULES = "efivarfs"
+
+SRC_URI += " \
+    file://local-top-complete"
+
+HOOK_COPY_EXECS = "blkid dd tr"

--- a/meta-example/recipes-initramfs/iot2050-initramfs/iot2050-initramfs-example_1.0.0.bb
+++ b/meta-example/recipes-initramfs/iot2050-initramfs/iot2050-initramfs-example_1.0.0.bb
@@ -1,0 +1,17 @@
+#
+# Copyright (c) Siemens AG, 2026
+#
+# SPDX-License-Identifier: MIT
+
+PR = "1"
+
+require recipes-initramfs/iot2050-initramfs/iot2050-initramfs_0.1.bb
+
+INITRAMFS_INSTALL:remove:secureboot = " \
+	initramfs-verity-hook \
+	initramfs-crypt-hook \
+	initramfs-tee-supplicant-hook \
+	initramfs-tee-ftpm-hook \
+	"
+
+INITRAMFS_INSTALL += " initramfs-efi-rootfs-hook"

--- a/meta-example/wic/iot2050-example.wks.in
+++ b/meta-example/wic/iot2050-example.wks.in
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Siemens AG, 2026
+#
+# Authors:
+#  Li Hua Qian <huaqian.li@siemens.com>
+#
+# This file is subject to the terms and conditions of the MIT License.  See
+# COPYING.MIT file in the top-level directory.
+#
+
+part --source efibootguard-efi --fixed-size 16M --label efi --align 1024 --part-type=EF00 --active
+part --source efibootguard-boot --fixed-size 128M --label BOOT --align 1024 --part-type=0700 --sourceparams "revision=1"
+part / --source rootfs --fstype ext4 --label rootfs --align 1024 --use-uuid
+
+bootloader --ptable gpt --timeout=0 --append "console=ttyS3,115200n8 earlycon=ns16550a,mmio32,0x02810000 root=PARTLABEL=rootfs rw rootwait ${EXTRA_KERNEL_PARAMS}"

--- a/meta/conf/distro/iot2050-debian.conf
+++ b/meta/conf/distro/iot2050-debian.conf
@@ -36,13 +36,6 @@ SDK_PREINSTALL += "zlib1g-dev:${DISTRO_ARCH} libjson-c-dev:${DISTRO_ARCH}"
 
 SDK_FORMATS = "tar.xz docker-archive"
 
-# used for SWUpdate boot
-ABROOTFS_IMAGE_RECIPE ?= "iot2050-image-swu-example"
-VERITY_IMAGE_RECIPE ?= "iot2050-image-swu-example"
-INITRAMFS_RECIPE ?= "iot2050-initramfs"
-ABROOTFS_PART_UUID_A ?= "fedcba98-7654-3210-cafe-5e0710000001"
-ABROOTFS_PART_UUID_B ?= "fedcba98-7654-3210-cafe-5e0710000002"
-
 PREFERRED_PROVIDER_secure-boot-secrets ?= "secure-boot-custmpk"
 PREFERRED_PROVIDER_swupdate-certificates-key ??= "swupdate-certificates-key-custmpk"
 PREFERRED_PROVIDER_swupdate-certificates ??= "swupdate-certificates-custmpk"

--- a/meta/recipes-bsp/u-boot/files/efi-boot.cfg
+++ b/meta/recipes-bsp/u-boot/files/efi-boot.cfg
@@ -1,3 +1,4 @@
 ### EFI boot config
 CONFIG_USE_BOOTCOMMAND=y
-CONFIG_BOOTCOMMAND="setenv scan_dev_for_boot 'if test -e ${devtype} ${devnum}:${distro_bootpart} efi/boot/bootaa64.efi; then load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} efi/boot/bootaa64.efi; bootefi ${kernel_addr_r} ${fdtcontroladdr}; fi'; run start_watchdog; run distro_bootcmd"
+CONFIG_CMD_NVEDIT_EFI=y
+CONFIG_BOOTCOMMAND="setenv scan_dev_for_boot 'if test -e ${devtype} ${devnum}:${distro_bootpart} efi/boot/bootaa64.efi; then load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} efi/boot/bootaa64.efi; setenv -e -bs -rt IOT2050BootDevice ${devtype}${devnum}; bootefi ${kernel_addr_r} ${fdtcontroladdr}; fi'; run start_watchdog; run distro_bootcmd"

--- a/meta/recipes-bsp/u-boot/files/secure-boot.cfg
+++ b/meta/recipes-bsp/u-boot/files/secure-boot.cfg
@@ -4,7 +4,9 @@ CONFIG_ENV_VARS_UBOOT_CONFIG=y
 CONFIG_SPL_FIT_SIGNATURE=y
 CONFIG_SHA512=y
 CONFIG_BOOTDELAY=-2
-CONFIG_BOOTCOMMAND="setenv scan_dev_for_boot 'if test -e ${devtype} ${devnum}:${distro_bootpart} efi/boot/bootaa64.efi; then load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} efi/boot/bootaa64.efi; bootefi ${kernel_addr_r} ${fdtcontroladdr}; fi'; run start_watchdog; run distro_bootcmd; echo 'EFI Boot failed!'; led status-led-green off; led status-led-red on; sleep 1000; reset"
+CONFIG_USE_BOOTCOMMAND=y
+CONFIG_CMD_NVEDIT_EFI=y
+CONFIG_BOOTCOMMAND="setenv scan_dev_for_boot 'if test -e ${devtype} ${devnum}:${distro_bootpart} efi/boot/bootaa64.efi; then load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} efi/boot/bootaa64.efi; setenv -e -bs -rt IOT2050BootDevice ${devtype}${devnum}; bootefi ${kernel_addr_r} ${fdtcontroladdr}; fi'; run start_watchdog; run distro_bootcmd; echo 'EFI Boot failed!'; led status-led-green off; led status-led-red on; sleep 1000; reset"
 CONFIG_HUSH_PARSER=y
 # CONFIG_CMD_BOOTD is not set
 # CONFIG_CMD_BOOTI is not set

--- a/meta/recipes-bsp/u-boot/u-boot-iot2050.inc
+++ b/meta/recipes-bsp/u-boot/u-boot-iot2050.inc
@@ -75,7 +75,9 @@ U_BOOT_CONFIG_PACKAGE = "1"
 do_prepare_build:append() {
     ln -f ${WORKDIR}/prebuild/* ${S}
     ln -sf /lib/firmware/k3-rti-wdt.fw ${S}
-    cat ${WORKDIR}/efi-boot.cfg >> ${S}/configs/${U_BOOT_CONFIG}
+    if [ "${SB_SIGN}" = "0" ]; then
+        cat ${WORKDIR}/efi-boot.cfg >> ${S}/configs/${U_BOOT_CONFIG}
+    fi
     echo "flash-pg1.bin /usr/lib/u-boot/${MACHINE}" > \
         ${S}/debian/u-boot-${MACHINE}.install
     echo "flash-pg2.bin /usr/lib/u-boot/${MACHINE}" >> \


### PR DESCRIPTION
meta-example: Add example-only EFI rootfs hook
u-boot-iot2050: Export the selected EFI boot device
meta-example: Keep SWUpdate configs in image recipe