### PR TITLE
meta: Force HTTPS for Debian snapshot premirror

### DIFF
--- a/meta/conf/distro/iot2050-debian.conf
+++ b/meta/conf/distro/iot2050-debian.conf
@@ -16,6 +16,13 @@ DISTRO_NAME = "IOT2050 Debian System"
 
 HOSTNAME ??= "iot2050-debian"
 
+# Use HTTPS for Debian snapshot mirror access in downstream builds to avoid
+# HTTP redirects that may be blocked in restricted build environments.
+DISTRO_APT_SNAPSHOT_PREMIRROR = " \
+	(http|https)://deb.debian.org/(debian-security)/? https://snapshot.debian.org/archive/\2/${@d.getVarFlag('ISAR_APT_SNAPSHOT_DATE_INTERNAL', 'security', expand=False)}\n \
+	(http|https)://deb.debian.org/(.*)/? https://snapshot.debian.org/archive/\2/${ISAR_APT_SNAPSHOT_DATE_INTERNAL}\n \
+"
+
 PREFERRED_VERSION_linux-iot2050 ?= "6.12.%"
 PREFERRED_VERSION_linux-iot2050-rt ?= "6.12.%"
 


### PR DESCRIPTION
Override DISTRO_APT_SNAPSHOT_PREMIRROR in iot2050-debian to use https://snapshot.debian.org for snapshot-based package downloads.

Some build environments forbid HTTP redirects during apt package fetching. When snapshot access is derived from the default Debian mirror configuration, package downloads may fail due to redirected HTTP URLs.