### PR TITLE
Update kas-container, Isar/CIP stack, snapshot, and fix mraa build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@
 # COPYING.MIT file in the top-level directory.
 #
 
-image: ghcr.io/siemens/kas/kas-isar:4.8.1
+image: ghcr.io/siemens/kas/kas-isar:5.3
 
 variables:
   GIT_STRATEGY: clone

--- a/kas-container
+++ b/kas-container
@@ -27,8 +27,9 @@
 
 set -e
 
-KAS_CONTAINER_SCRIPT_VERSION="4.8.1"
+KAS_CONTAINER_SCRIPT_VERSION="5.3"
 KAS_IMAGE_VERSION_DEFAULT="${KAS_CONTAINER_SCRIPT_VERSION}"
+KAS_CONTAINER_IMAGE_DISTRO_DEFAULT=""
 KAS_CONTAINER_IMAGE_PATH_DEFAULT="ghcr.io/siemens/kas"
 KAS_CONTAINER_IMAGE_NAME_DEFAULT="kas"
 KAS_CONTAINER_SELF_NAME="$(basename "$0")"
@@ -48,6 +49,7 @@ usage()
 	printf "%b" "\nPositional arguments:\n"
 	printf "%b" "build\t\t\tCheck out repositories and build target.\n"
 	printf "%b" "checkout\t\tCheck out repositories but do not build.\n"
+	printf "%b" "diff\t\t\tCompare two kas configurations.\n"
 	printf "%b" "dump\t\t\tCheck out repositories and write flat version\n"
 	printf "%b" "    \t\t\tof config to stdout.\n"
 	printf "%b" "lock\t\t\tCreate and update kas project lockfiles\n"
@@ -64,7 +66,8 @@ usage()
 	printf "%b" "menu\t\t\tProvide configuration menu and trigger " \
 		    "configured build.\n"
 	printf "%b" "\nOptional arguments:\n"
-	printf "%b" "--isar\t\t\tUse kas-isar container to build Isar image.\n"
+	printf "%b" "--isar\t\t\tUse kas-isar container to build Isar image. To force\n"
+	printf "%b" "      \t\t\tthe use of run0 over sudo, set KAS_SUDO_CMD=run0.\n"
 	printf "%b" "--with-loop-dev		Pass a loop device to the " \
 		    "container. Only required if\n"
 	printf "%b" "\t\t\tloop-mounting is used by recipes.\n"
@@ -78,6 +81,8 @@ usage()
 		    "container.\n"
 	printf "%b" "--ssh-agent\t\tForward ssh-agent socket to the container.\n"
 	printf "%b" "--aws-dir\t\tDirectory containing AWScli configuration.\n"
+	printf "%b" "\t\t\tAvoid \$HOME/.aws unless you fully trust the " \
+		    "container.\n"
 	printf "%b" "--git-credential-store\tFile path to the git credential " \
 		    "store\n"
 	printf "%b" "--no-proxy-from-env\tDo not inherit proxy settings from " \
@@ -117,6 +122,26 @@ trace()
 	"$@"
 }
 
+prepare_sudo_cmd()
+{
+	if [ -z "${KAS_SUDO_CMD}" ]; then
+		# Try to auto-detect a privileged executor
+		if command -v sudo >/dev/null; then
+			KAS_SUDO_CMD="sudo"
+		elif command -v run0 >/dev/null; then
+			KAS_SUDO_CMD="run0"
+		else
+			fatal_error "No privileged executor found, need sudo or run0."
+		fi
+	fi
+
+	case "$KAS_SUDO_CMD" in
+		sudo) _KAS_SUDO_CMD="sudo --preserve-env";;
+		run0) _KAS_SUDO_CMD="run0 --background= --unit=kas-container@$$";;
+		*) fatal_error "Unsupported KAS_SUDO_CMD ('${KAS_SUDO_CMD}'), use sudo or run0.";;
+	esac
+}
+
 enable_isar_mode()
 {
 	if [ -n "${ISAR_MODE}" ]; then
@@ -128,15 +153,18 @@ enable_isar_mode()
 	KAS_ISAR_ARGS="--privileged"
 
 	if [ "${KAS_CONTAINER_ENGINE}" = "podman" ]; then
+		prepare_sudo_cmd
 		# sudo is needed for a privileged podman container
-		KAS_CONTAINER_COMMAND="sudo --preserve-env ${KAS_CONTAINER_COMMAND}"
+		KAS_CONTAINER_COMMAND="${_KAS_SUDO_CMD} ${KAS_CONTAINER_COMMAND}"
 		# preserved user PATH may lack sbin needed by privileged podman
 		export PATH="${PATH}:/usr/sbin"
 	elif [ "${KAS_DOCKER_ROOTLESS}" = "1" ]; then
-		export DOCKER_HOST="${DOCKER_HOST:-unix:///var/run/docker.sock}"
-		debug "kas-isar does not support rootless docker. Using system docker"
+		prepare_sudo_cmd
+		DOCKER_HOST_DEFAULT="$(docker context inspect default --format '{{.Endpoints.docker.Host}}')"
+		export DOCKER_HOST="${DOCKER_HOST:-$DOCKER_HOST_DEFAULT}"
+		debug "kas-isar does not support rootless docker. Using system docker in $DOCKER_HOST"
 		# force use of well-known system docker socket
-		KAS_CONTAINER_COMMAND="sudo --preserve-env ${KAS_CONTAINER_COMMAND}"
+		KAS_CONTAINER_COMMAND="${_KAS_SUDO_CMD} ${KAS_CONTAINER_COMMAND}"
 		KAS_DOCKER_ROOTLESS=0
 	fi
 }
@@ -266,11 +294,18 @@ trap kas_container_cleanup EXIT INT TERM
 
 set_container_image_var()
 {
+	# if the image is explicitly set, use that
+	if [ -n "${KAS_CONTAINER_IMAGE}" ]; then
+		return
+	fi
 	KAS_IMAGE_VERSION="${KAS_IMAGE_VERSION:-${KAS_IMAGE_VERSION_DEFAULT}}"
+	KAS_CONTAINER_IMAGE_DISTRO="${KAS_CONTAINER_IMAGE_DISTRO:-${KAS_CONTAINER_IMAGE_DISTRO_DEFAULT}}"
 	KAS_CONTAINER_IMAGE_NAME="${KAS_CONTAINER_IMAGE_NAME:-${KAS_CONTAINER_IMAGE_NAME_DEFAULT}}"
 	KAS_CONTAINER_IMAGE_PATH="${KAS_CONTAINER_IMAGE_PATH:-${KAS_CONTAINER_IMAGE_PATH_DEFAULT}}"
-	KAS_CONTAINER_IMAGE_DEFAULT="${KAS_CONTAINER_IMAGE_PATH}/${KAS_CONTAINER_IMAGE_NAME}:${KAS_IMAGE_VERSION}"
-	KAS_CONTAINER_IMAGE="${KAS_CONTAINER_IMAGE:-${KAS_CONTAINER_IMAGE_DEFAULT}}"
+	KAS_CONTAINER_IMAGE="${KAS_CONTAINER_IMAGE_PATH}/${KAS_CONTAINER_IMAGE_NAME}:${KAS_IMAGE_VERSION}"
+	if [ -n "${KAS_CONTAINER_IMAGE_DISTRO}" ]; then
+		KAS_CONTAINER_IMAGE="${KAS_CONTAINER_IMAGE}-${KAS_CONTAINER_IMAGE_DISTRO}"
+	fi
 }
 
 # SC2034: DIR appears unused (ignore, as they are used inside eval)
@@ -283,27 +318,16 @@ setup_kas_dirs()
 	KAS_REPO_REF_DIR="$(check_and_expand KAS_REPO_REF_DIR required)"
 	DL_DIR="$(check_and_expand DL_DIR createrec)"
 	SSTATE_DIR="$(check_and_expand SSTATE_DIR createrec)"
+	KAS_BUILDTOOLS_DIR="$(check_and_expand KAS_BUILDTOOLS_DIR createrec)"
 }
 setup_kas_dirs
 
 KAS_CONTAINER_ENGINE="${KAS_CONTAINER_ENGINE:-${KAS_DOCKER_ENGINE}}"
 if [ -z "${KAS_CONTAINER_ENGINE}" ]; then
 	# Try to auto-detect a container engine
-	if command -v docker >/dev/null; then
-		case $(docker -v 2>/dev/null) in
-		podman*)
-			# The docker command is an alias for podman
-			KAS_CONTAINER_ENGINE=podman
-			;;
-		Docker*)
-			# The docker command is the real docker
-			KAS_CONTAINER_ENGINE=docker
-			;;
-		*)
-			# The docker command is an unknown engine
-			fatal_error "docker command found, but unknown engine detected"
-		esac
-	elif command -v podman >/dev/null; then
+	if command -v docker >/dev/null 2>&1 && docker -v 2>/dev/null | grep -q '^Docker'; then
+		KAS_CONTAINER_ENGINE=docker
+	elif command -v podman >/dev/null 2>&1; then
 		KAS_CONTAINER_ENGINE=podman
 	else
 		fatal_error "no container engine found, need docker or podman"
@@ -338,6 +362,10 @@ while [ $# -gt 0 ]; do
 		if ! KAS_LOOP_DEV=$(/sbin/losetup -f 2>/dev/null); then
 			if [ "$(id -u)" -eq 0 ]; then
 				fatal_error "loop device not available!"
+			fi
+			prepare_sudo_cmd
+			if ! [ "$KAS_SUDO_CMD" = "sudo" ]; then
+				fatal_error '--with-loop-dev requires sudo for device setup.'
 			fi
 			sudo_command="/sbin/losetup -f"
 			sudo_message="[sudo] enter password to setup loop"
@@ -454,6 +482,7 @@ done
 [ -n "${KAS_CMD}" ] || usage
 
 KAS_EXTRA_BITBAKE_ARGS=0
+KAS_FILES=
 
 # parse kas sub-command options
 while [ $# -gt 0 ] && [ $KAS_EXTRA_BITBAKE_ARGS -eq 0 ]; do
@@ -592,6 +621,7 @@ forward_dir KAS_BUILD_DIR "/build" "rw"
 forward_dir DL_DIR "/downloads" "rw"
 forward_dir KAS_REPO_REF_DIR "/repo-ref" "rw"
 forward_dir SSTATE_DIR "/sstate" "rw"
+forward_dir KAS_BUILDTOOLS_DIR "/buildtools" "rw"
 
 if git_com_dir=$(git -C "${KAS_REPO_DIR}" rev-parse --git-common-dir 2>/dev/null) \
 	&& [ "$git_com_dir" != "$(git -C "${KAS_REPO_DIR}" rev-parse --git-dir)" ]; then
@@ -686,12 +716,9 @@ if [ -n "${SSTATE_MIRRORS}" ]; then
 	set -- "$@" -e "SSTATE_MIRRORS=${SSTATE_MIRRORS}"
 fi
 
-# propagate timezone information
-if [ -f "/etc/localtime" ]; then
-	set -- "$@" -v "$(realpath -e "/etc/localtime")":/etc/localtime:ro
-fi
-if [ -f "/etc/timezone" ]; then
-	set -- "$@" -v "$(realpath -e "/etc/timezone")":/etc/timezone:ro
+# propagate timezone information to entrypoint (requires systemd 239)
+if command -v timedatectl >/dev/null; then
+	set -- "$@" -e "KAS_HOST_TZ=$(timedatectl show -p Timezone --value 2>/dev/null)"
 fi
 
 for var in TERM KAS_DISTRO KAS_MACHINE KAS_TARGET KAS_TASK KAS_CLONE_DEPTH \

--- a/kas/iot2050.yml
+++ b/kas/iot2050.yml
@@ -31,17 +31,18 @@ repos:
 
   isar:
     url: https://github.com/ilbers/isar
-    commit: 33ca03c711e34d38d303ca38c1259cb6c5fe55ef
+    commit: cc5a5d98a89ca19049575b94b71a0beeafa61c71
     layers:
       meta:
 
   cip-core:
     url: https://gitlab.com/cip-project/cip-core/isar-cip-core.git
-    commit: 3cfd7f0c89155419551f6bf430033c5d1ddd80a7
+    commit: 185b390af944e095d803c82d434bd51e74c999fd
 
 local_conf_header:
   standard: |
     CONF_VERSION = "1"
+    MAINTAINER = "Li Hua Qian <huaqian.li@siemens.com>"
   crossbuild: |
     ISAR_CROSS_COMPILE = "1"
   ccache: |

--- a/kas/opt/package-lock.yml
+++ b/kas/opt/package-lock.yml
@@ -13,6 +13,6 @@ header:
 
 local_conf_header:
   package-lock: |
-    # 2026-03-17 23:33:45 UTC
-    ISAR_APT_SNAPSHOT_TIMESTAMP = "1773761625"
+    # 2026-06-09 08:23:08 UTC
+    ISAR_APT_SNAPSHOT_TIMESTAMP = "1780964588"
     ISAR_USE_APT_SNAPSHOT = "1"

--- a/meta/recipes-app/mraa/mraa_2.2.0+git20220805.8b1c5493.bb
+++ b/meta/recipes-app/mraa/mraa_2.2.0+git20220805.8b1c5493.bb
@@ -8,7 +8,7 @@
 # COPYING.MIT file in the top-level directory.
 #
 
-PR = "4"
+PR = "5"
 
 inherit dpkg
 
@@ -42,8 +42,8 @@ DEBIAN_BUILD_DEPENDS = " \
     cmake, \
     swig, \
     libpython3-dev, \
-    nodejs, \
-    libnode-dev, \
+    nodejs:native, \
+    libnode-dev:native, \
     libjson-c-dev, \
     default-jdk:native"
 


### PR DESCRIPTION
## Summary

This PR updates the build infrastructure to kas-container 5.3, refreshes the Isar/CIP core stack, and fixes a cross-compilation dependency resolution failure in `mraa`.

## Changes

### kas-container: Update to version 5.3
- Bump kas-container script and CI image from 4.8.1 → 5.3

### kas: Update Debian snapshot to 2026-06-09 08:23:08
- Refresh Debian snapshot in `package-lock.yml`

### kas: Update Isar/CIP stack and set MAINTAINER
- Update isar commit to `cc5a5d98a89ca19049575b94b71a0beeafa61c71`
- Update cip-core commit to `185b390af944e095d803c82d434bd51e74c999fd`
- Set `MAINTAINER` to `Li Hua Qian <huaqian.li@siemens.com>` to eliminate `@example.com` warnings from `debianize.bbclass`

### meta: Fix mraa build dependencies for cross-compilation
- Use `nodejs:native` and `libnode-dev:native` instead of target-arch (`arm64`) variants
- Fixes unsatisfiable apt dependency resolution in sbuild cross-build (circular `nodejs` ↔ `node-corepack` ↔ `node-acorn` chain)
- Bump PR to 5 to trigger rebuild

## Testing

- [x] Build completed successfully with `kas-container --isar`
- [x] No more `@example.com` maintainer warnings
- [x] `mraa` `do_dpkg_build` passes without dependency resolution errors