### PR TITLE
linux-iot2050: Preserve bridge-adjusted CRTC timings

### DIFF
--- a/meta/recipes-kernel/linux/files/patches/0028-drm-tidss-Preserve-bridge-adjusted-CRTC-timings.patch
+++ b/meta/recipes-kernel/linux/files/patches/0028-drm-tidss-Preserve-bridge-adjusted-CRTC-timings.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Li Hua Qian <huaqian.li@siemens.com>
+Date: Tue, 4 Aug 2026 17:01:43 +0800
+Subject: [PATCH] drm/tidss: Preserve bridge-adjusted CRTC timings
+
+Only initialize crtc_* timing fields when they are not already available.
+Bridges such as tc358767 adjust adjusted_mode before the TIDSS CRTC check.
+
+Recomputing the fields unconditionally can overwrite bridge-prepared timing
+state and causes DisplayPort synchronization failures on IOT2050.
+
+Keep existing bridge adjustments while retaining a fallback for modes whose
+CRTC timing fields are still uninitialized.
+
+Signed-off-by: Li Hua Qian <huaqian.li@siemens.com>
+---
+ drivers/gpu/drm/tidss/tidss_crtc.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/tidss/tidss_crtc.c b/drivers/gpu/drm/tidss/tidss_crtc.c
+index 36c22d860852..377276106caf 100644
+--- a/drivers/gpu/drm/tidss/tidss_crtc.c
++++ b/drivers/gpu/drm/tidss/tidss_crtc.c
+@@ -108,7 +108,9 @@ static int tidss_crtc_atomic_check(struct drm_crtc *crtc,
+ 		return -EINVAL;
+ 	}
+ 
+-	if (drm_atomic_crtc_needs_modeset(crtc_state))
++	if (drm_atomic_crtc_needs_modeset(crtc_state) &&
++	    (!mode->crtc_clock || !mode->crtc_hdisplay ||
++	     !mode->crtc_vdisplay))
+ 		drm_mode_set_crtcinfo(mode, 0);
+ 
+ 	return dispc_vp_bus_check(dispc, hw_videoport, crtc_state);


### PR DESCRIPTION
## Summary

- Add a temporary IOT2050 workaround for DisplayPort synchronization loss.
- Preserve bridge-adjusted CRTC timing parameters in TIDSS.
- Will optimize and upstream with the existing TC358767 bridge-chain workaround.



## Background

IOT2050 DP output can report repeated:

```text
CRTC1 SYNC LOST
```

when the TIDSS adjusted-mode timing changes are enabled, confirming a regression in the
adjusted CRTC timing path.

## Root cause

On IOT2050, TC358767 adjusts the DRM `adjusted_mode` during atomic
checking. TIDSS then unconditionally reinitializes the `crtc_*` timing
fields, which can overwrite bridge-prepared timing state and cause
hardware VP `SYNC_LOST` during DisplayPort initialization.


## Change
Initialize `crtc_*` timing fields only when the essential fields are
not already available. This preserves bridge-adjusted timing values
while keeping a fallback for uninitialized modes.

```c
if (drm_atomic_crtc_needs_modeset(crtc_state) &&
    (!mode->crtc_clock ||
     !mode->crtc_hdisplay ||
     !mode->crtc_vdisplay))
        drm_mode_set_crtcinfo(mode, 0);
```

This prevents TIDSS from overwriting timing information prepared by the
TC358767 bridge during atomic checking.

## Validation
Tested on IOT2050 Advanced PG2 with:
- TC358767 DisplayPort bridge;
- 1920x1200 display mode;
- TIDSS VP2/DPI output;
- existing bridge-chain compatibility workaround.

The revert-only workaround restores DP output. This patch preserves the
adjusted-mode implementation while avoiding the observed synchronization loss.

## Scope

This is a temporary IOT2050-specific workaround. A complete upstream
solution should clarify ownership and initialization ordering of
adjusted CRTC timing fields in the DRM atomic pipeline.