### PR TITLE
ci: Check U-Boot and Linux patch format

### DIFF
--- a/.github/workflows/patch-check.yml
+++ b/.github/workflows/patch-check.yml
@@ -1,0 +1,82 @@
+name: Patch Check
+
+on:
+  push:
+    branches:
+      - master
+      - stable/V*
+    paths:
+      - 'meta/recipes-bsp/u-boot/**'
+      - 'meta/recipes-kernel/**'
+      - 'scripts/host/check-patch-format.sh'
+      - '.github/workflows/patch-check.yml'
+  pull_request:
+    branches:
+      - master
+      - stable/V*
+    paths:
+      - 'meta/recipes-bsp/u-boot/**'
+      - 'meta/recipes-kernel/**'
+      - 'scripts/host/check-patch-format.sh'
+      - '.github/workflows/patch-check.yml'
+  workflow_dispatch: {}
+
+jobs:
+  patch-format:
+    name: Check U-Boot and Linux patches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Find latest upstream tags
+        id: tags
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # The upstream master branches do not guarantee stable availability
+          # of the checkpatch scripts and their companion files. Use the
+          # latest stable tag instead.
+          uboot_tag=$(git ls-remote --tags --refs \
+            https://github.com/u-boot/u-boot.git 'v*' |
+            sed 's#.*refs/tags/##' |
+            grep -E '^v[0-9]{4}\.[0-9]{2}$' |
+            sort -V | tail -n 1)
+          linux_tag=$(git ls-remote --tags --refs \
+            https://gitlab.com/cip-project/cip-kernel/linux-cip.git 'v*' |
+            sed 's#.*refs/tags/##' |
+            grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-cip[0-9]+$' |
+            sort -V | tail -n 1)
+
+          test -n "$uboot_tag"
+          test -n "$linux_tag"
+          echo "U-Boot tag: $uboot_tag"
+          echo "Linux CIP tag: $linux_tag"
+          echo "uboot_tag=$uboot_tag" >> "$GITHUB_OUTPUT"
+          echo "linux_tag=$linux_tag" >> "$GITHUB_OUTPUT"
+      - name: Fetch U-Boot checkpatch
+        run: |
+          mkdir -p uboot-checkpatch
+          curl --fail --location --retry 3 \
+            "https://raw.githubusercontent.com/u-boot/u-boot/${{ steps.tags.outputs.uboot_tag }}/scripts/checkpatch.pl" \
+            --output uboot-checkpatch/checkpatch.pl
+          curl --fail --location --retry 3 \
+            "https://raw.githubusercontent.com/u-boot/u-boot/${{ steps.tags.outputs.uboot_tag }}/scripts/spelling.txt" \
+            --output uboot-checkpatch/spelling.txt
+          curl --fail --location --retry 3 \
+            "https://raw.githubusercontent.com/u-boot/u-boot/${{ steps.tags.outputs.uboot_tag }}/scripts/const_structs.checkpatch" \
+            --output uboot-checkpatch/const_structs.checkpatch
+      - name: Fetch Linux checkpatch
+        run: |
+          mkdir -p linux-checkpatch
+          curl --fail --location --retry 3 \
+            "https://gitlab.com/cip-project/cip-kernel/linux-cip/-/raw/${{ steps.tags.outputs.linux_tag }}/scripts/checkpatch.pl" \
+            --output linux-checkpatch/checkpatch.pl
+          curl --fail --location --retry 3 \
+            "https://gitlab.com/cip-project/cip-kernel/linux-cip/-/raw/${{ steps.tags.outputs.linux_tag }}/scripts/spelling.txt" \
+            --output linux-checkpatch/spelling.txt
+          curl --fail --location --retry 3 \
+            "https://gitlab.com/cip-project/cip-kernel/linux-cip/-/raw/${{ steps.tags.outputs.linux_tag }}/scripts/const_structs.checkpatch" \
+            --output linux-checkpatch/const_structs.checkpatch
+      - name: Validate patch format
+        run: bash scripts/host/check-patch-format.sh "$PWD/uboot-checkpatch/checkpatch.pl" "$PWD/linux-checkpatch/checkpatch.pl"

--- a/meta/recipes-kernel/linux/files/patches/0027-arm64-dts-ti-iot2050-Disable-UHS-modes-on-sdhci1.patch
+++ b/meta/recipes-kernel/linux/files/patches/0027-arm64-dts-ti-iot2050-Disable-UHS-modes-on-sdhci1.patch
@@ -17,7 +17,7 @@ boot reliability.
 Signed-off-by: Li Hua Qian <huaqian.li@siemens.com>
 ---
  arch/arm64/boot/dts/ti/k3-am65-iot2050-common-pg2.dtsi | 8 +++++++-
- 1 file changed, 7 insertions(+), 1 deletion(-)
+ 1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050-common-pg2.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050-common-pg2.dtsi
 index b3c4c0eec3dc..149bc29ef356 100644

--- a/scripts/host/check-patch-format.sh
+++ b/scripts/host/check-patch-format.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Validate patches used by the U-Boot and Linux recipes.
+
+set -euo pipefail
+
+patch_dirs=(
+    meta/recipes-bsp/u-boot/files
+    meta/recipes-kernel/linux/files/patches
+)
+
+uboot_checkpatch=${1:?path to U-Boot checkpatch.pl is required}
+linux_checkpatch=${2:?path to Linux checkpatch.pl is required}
+
+check_patch_metadata() {
+    local patch=$1
+    local diffstat
+    local actual_stats
+
+    diffstat=$(awk '/^[[:space:]]*[0-9]+ files? changed, / { line = $0 } END { print line }' "$patch")
+    if [[ -z $diffstat ]]; then
+        printf '%s: missing diffstat summary\n' "$patch" >&2
+        return 1
+    fi
+
+    actual_stats=$(git apply --numstat "$patch" | awk '
+        $1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ {
+            files++
+            additions += $1
+            deletions += $2
+        }
+        $1 == "-" && $2 == "-" {
+            files++
+        }
+        END {
+            printf "%d %d %d\n", files, additions, deletions
+        }
+    ')
+    if ! grep -Eq '^[[:space:]]*[0-9]+ files? changed(, [0-9]+ insertions?\(\+\))?(, [0-9]+ deletions?\(-\))?[[:space:]]*$' <<< "$diffstat" &&
+        ! grep -Eq '^[[:space:]]*[0-9]+ files? changed, [0-9]+ deletions?\(-\)[[:space:]]*$' <<< "$diffstat"; then
+        printf '%s: invalid diffstat summary: %s\n' "$patch" "$diffstat" >&2
+        return 1
+    fi
+    expected_stats="$(sed -E 's/^[[:space:]]*([0-9]+) files? changed.*/\1/' <<< "$diffstat")"
+    additions=$(sed -nE 's/.*,[[:space:]]*([0-9]+) insertions?\(\+\).*/\1/p' <<< "$diffstat")
+    deletions=$(sed -nE 's/.*,[[:space:]]*([0-9]+) deletions?\(-\).*/\1/p' <<< "$diffstat")
+    expected_stats+=" ${additions:-0} ${deletions:-0}"
+    if [[ $actual_stats != "$expected_stats" ]]; then
+        printf '%s: diffstat does not match the actual diff (header: %s; actual: %s)\n' \
+            "$patch" "$expected_stats" "$actual_stats" >&2
+        return 1
+    fi
+
+    awk '
+        NR == 1 && $0 != "From " "0000000000000000000000000000000000000000" " Mon Sep 17 00:00:00 2001" {
+            print FILENAME ":1: patch is not generated with --zero-commit" > "/dev/stderr"
+            invalid = 1
+        }
+        /^Subject: \[PATCH [0-9]+\// {
+            print FILENAME ":" NR ": numbered patch series is not allowed; use --no-numbered" > "/dev/stderr"
+            invalid = 1
+        }
+        /^index / {
+            split($2, hashes, "\\.\\.")
+            if (length(hashes[1]) > 12 || length(hashes[2]) > 12) {
+                print FILENAME ":" NR ": index hash is longer than 12 characters; use --abbrev=12" > "/dev/stderr"
+                invalid = 1
+            }
+        }
+        /^-- $/ {
+            signature = 1
+        }
+        END {
+            if (signature) {
+                print FILENAME ": patch contains a git-format-patch signature; use --no-signature" > "/dev/stderr"
+                invalid = 1
+            }
+            if (!separator) {
+                print FILENAME ": missing format-patch separator" > "/dev/stderr"
+                invalid = 1
+            }
+            if (invalid)
+                exit 1
+        }
+        /^---$/ {
+            if (previous ~ /^[[:space:]]*$/) {
+                print FILENAME ":" NR ": blank line before the diffstat separator; use the format-patch output without an extra blank line" > "/dev/stderr"
+                invalid = 1
+            }
+            separator = 1
+            next
+        }
+        !separator && /^[[:space:]]+$/ {
+            print FILENAME ":" NR ": whitespace-only line in patch metadata" > "/dev/stderr"
+            invalid = 1
+        }
+        { previous = $0 }
+    ' "$patch"
+}
+
+mapfile -d '' patches < <(find "${patch_dirs[@]}" -type f -name '*.patch' -print0 | sort -z)
+if ((${#patches[@]} == 0)); then
+    echo 'No recipe patches found.' >&2
+    exit 1
+fi
+
+for patch in "${patches[@]}"; do
+    echo "Checking ${patch}"
+
+    # git mailinfo is the parser used by git-am.  This catches malformed
+    # format-patch mail without requiring the source tree the patch targets.
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT
+    git mailinfo "$tmpdir/message" "$tmpdir/content" < "$patch" >/dev/null
+
+    # Check the format-patch options required by CONTRIBUTING.md.  In
+    # particular, whitespace-only metadata lines were the defect fixed by
+    # PR #687.
+    check_patch_metadata "$patch"
+
+    # Use the component-maintainer checkpatch implementation.  Blank lines in
+    # unified diffs necessarily carry a trailing space, so that diagnostic is
+    # intentionally excluded; metadata whitespace is checked above.  Existing
+    # upstream patches may contain intentional long lines, so do not reject
+    # those style warnings in this format check.
+    if [[ $patch == meta/recipes-bsp/u-boot/* ]]; then
+        checkpatch=$uboot_checkpatch
+    else
+        checkpatch=$linux_checkpatch
+    fi
+    perl "$checkpatch" --no-tree --ignore TRAILING_WHITESPACE,LONG_LINE "$patch" >/dev/null
+
+    rm -rf "$tmpdir"
+    trap - EXIT
+done


### PR DESCRIPTION
## Summary

Add CI checks for the format of U-Boot and Linux kernel patches used by
the recipes.

The reusable checker is located at
[scripts/host/check-patch-format.sh](scripts/host/check-patch-format.sh),
and the GitHub Actions workflow is defined in
[.github/workflows/patch-check.yml](.github/workflows/patch-check.yml).

## Motivation

PR #687 showed that incorrectly generated patches can pass unnoticed
until review. In particular, whitespace-only metadata lines before the
diffstat separator are not produced by the documented `git format-patch`
command.

This change moves the validation into CI so that malformed patches are
detected before review or merge.

## Checks

The CI job performs the following checks:

- Parse each patch with `git mailinfo`, matching the parser used by
  `git am`.
- Require the zero commit ID generated by `--zero-commit`.
- Reject numbered patch subjects such as `[PATCH 1/2]`, matching
  `--no-numbered`.
- Reject diff index hashes longer than 12 characters, matching
  `--abbrev=12`.
- Reject Git patch signatures, matching `--no-signature`.
- Require the `format-patch` diffstat separator.
- Reject whitespace-only lines in patch metadata before the separator.
- Run the upstream U-Boot `checkpatch.pl` for U-Boot patches.
- Run the upstream Linux CIP `checkpatch.pl` for Linux patches.

Trailing whitespace diagnostics are ignored because blank lines in a
unified diff legitimately contain a leading space.

## Scope

The check covers patches in:

- `meta/recipes-bsp/u-boot/files/`
- `meta/recipes-kernel/linux/files/patches/`

The upstream `cleanpatch` utility was considered but is not included in
CI because it modifies patch files and is intended as a cleanup tool,
not as a read-only validation tool.

## Validation

- All existing U-Boot patches pass the new checks.
- All existing Linux kernel patches pass the new checks.
- U-Boot and Linux patches are checked with their respective upstream
  `checkpatch.pl` implementations.
- The workflow and shell script pass editor diagnostics.