### PR TITLE
Rework Arduino IO hardware

### DIFF
--- a/meta-example/recipes-app/board-conf-tools/files/board-conf-tools/board-bootup-conf.py
+++ b/meta-example/recipes-app/board-conf-tools/files/board-conf-tools/board-bootup-conf.py
@@ -59,11 +59,15 @@ def preAllocatePwm():
         This is required for non-root access to PWM pins.
     """
     for i in [4, 5, 6, 7, 8, 9]:
+        if board_conf.getArduinoIoDoNotTouch(i):
+            continue
         p = mraa.Pwm(i, owner=False)
         p.close()
 
 def initAruinoPins():
     for i in range(0, 20):
+        if board_conf.getArduinoIoDoNotTouch(i):
+            continue
         pinmux = board_conf.getArduinoPinmuxCfg(i)
         if pinmux in board_conf.arduinoPinmuxMap(i):
             setPinmux(i, pinmux)

--- a/meta-example/recipes-app/board-conf-tools/files/board-conf-tools/iot2050setup.py
+++ b/meta-example/recipes-app/board-conf-tools/files/board-conf-tools/iot2050setup.py
@@ -343,6 +343,7 @@ class ArduinoIoMode(BoardConfigurationUtility):
                                                     title='Configure Arduino I/O',
                                                     text=ioInfor,
                                                     items=[('Arduino Pinout', self.show_arduino_pinout),
+                                                           ('Configure Do Not Touch', self.configureArduinoDoNotTouch),
                                                            ('Enable GPIO', self.configureArduinoGpio),
                                                            ('Enable I2C on IO18 & IO19', self.configureArduinoI2c),
                                                            ('Enable SPI on IO10-IO13', self.configureArduinoSpi),
@@ -354,6 +355,34 @@ class ArduinoIoMode(BoardConfigurationUtility):
             if action == 'back':
                 return
             selection()
+
+    def configureArduinoDoNotTouch(self):
+        helpText = Label('Checked IOs are not configured during boot.\n'
+                         'Current Mux settings are preserved.\n'
+                         'The APP is responsible for configuring them.\n'
+                         'Changes take effect after the next reboot.')
+        doNotTouchTree = CheckboxTree(height=10, scroll=1)
+        for i in range(0, 20):
+            doNotTouchTree.append(text='IO' + str(i),
+                                  item=i,
+                                  selected=self.getArduinoIoDoNotTouch(i))
+
+        buttonbar = ButtonBar(screen=self.topmenu.gscreen,
+                              buttonlist=[('Ok', 'ok'), ('Cancel', 'cancel', 'ESC')])
+        g = GridForm(self.topmenu.gscreen,
+                     'Configure Do Not Touch',
+                     1, 3)
+        g.add(helpText, 0, 0)
+        g.add(doNotTouchTree, 0, 1)
+        g.add(buttonbar, 0, 2)
+        result = g.runOnce()
+        if buttonbar.buttonPressed(result) == 'cancel':
+            return
+
+        selected = doNotTouchTree.getSelection()
+        for i in range(0, 20):
+            self.setArduinoIoDoNotTouch(i, i in selected)
+        self.__saveConfig()
 
     def resetPinDefault(self, pinmux):
         for i in range(0, 20):
@@ -687,7 +716,7 @@ class PeripheralsMenu:
         menuItems = [('Configure External COM Ports', ExternalSerialMode(self.topmenu))]
         if self.topmenu.boardType != 'IOT2050 Advanced SM':
             menuItems.append(('Configure Arduino I/O', ArduinoIoMode(self.topmenu)))
-        if self.topmenu.boardType == 'IOT2050 Advanced M2':
+        if self.topmenu.boardType.startswith('IOT2050 Advanced M2'):
             menuItems.append(('Configure M.2 Connector', M2Connector(self.topmenu)))
 
         while True:

--- a/meta-example/recipes-app/board-conf-tools/files/board-conf-tools/json_ops/board-configuration.json
+++ b/meta-example/recipes-app/board-conf-tools/files/board-conf-tools/json_ops/board-configuration.json
@@ -26,6 +26,28 @@
         "IO18_MUX": "GPIO_Input",
         "IO19_MUX": "GPIO_Input"
     },
+    "Arduino_io_do_not_touch": {
+        "IO0_DO_NOT_TOUCH": false,
+        "IO1_DO_NOT_TOUCH": false,
+        "IO2_DO_NOT_TOUCH": false,
+        "IO3_DO_NOT_TOUCH": false,
+        "IO4_DO_NOT_TOUCH": false,
+        "IO5_DO_NOT_TOUCH": false,
+        "IO6_DO_NOT_TOUCH": false,
+        "IO7_DO_NOT_TOUCH": false,
+        "IO8_DO_NOT_TOUCH": false,
+        "IO9_DO_NOT_TOUCH": false,
+        "IO10_DO_NOT_TOUCH": false,
+        "IO11_DO_NOT_TOUCH": false,
+        "IO12_DO_NOT_TOUCH": false,
+        "IO13_DO_NOT_TOUCH": false,
+        "IO14_DO_NOT_TOUCH": false,
+        "IO15_DO_NOT_TOUCH": false,
+        "IO16_DO_NOT_TOUCH": false,
+        "IO17_DO_NOT_TOUCH": false,
+        "IO18_DO_NOT_TOUCH": false,
+        "IO19_DO_NOT_TOUCH": false
+    },
     "Arduino_io_pull_mode":{
         "IO0_PULL_MODE": "Hiz",
         "IO1_PULL_MODE": "Hiz",

--- a/meta-example/recipes-app/board-conf-tools/files/board-conf-tools/json_ops/json_ops.py
+++ b/meta-example/recipes-app/board-conf-tools/files/board-conf-tools/json_ops/json_ops.py
@@ -18,6 +18,9 @@ class BoardConfigurationUtility:
         self.config = self.getConfig()
         self.arduino_pinmux_map = self.config['Arduino_pinmux_map']
         self.arduino_io_mux = self.config['Arduino_io_mux']
+        self.arduino_io_do_not_touch = self.config.setdefault(
+            'Arduino_io_do_not_touch',
+            OrderedDict(('IO' + str(i) + '_DO_NOT_TOUCH', False) for i in range(0, 20)))
         self.arduino_io_pull_mode = self.config['Arduino_io_pull_mode']
         self.external_db9_serial_config = self.config['External_db9_serial']
 
@@ -53,6 +56,12 @@ class BoardConfigurationUtility:
 
     def getArduinoPinmuxCfg(self, index):
         return self.arduino_io_mux['IO' + str(index) + '_MUX']
+
+    def getArduinoIoDoNotTouch(self, index):
+        return self.arduino_io_do_not_touch['IO' + str(index) + '_DO_NOT_TOUCH']
+
+    def setArduinoIoDoNotTouch(self, index, do_not_touch):
+        self.arduino_io_do_not_touch['IO' + str(index) + '_DO_NOT_TOUCH'] = do_not_touch
 
     def _setPinmuxOfUserConfig(self, pinmux, index):
         self.arduino_io_mux['IO' + str(index) + '_MUX'] = pinmux

--- a/meta-example/recipes-app/iot2050-firmware-update/files/iot2050_firmware_update.py
+++ b/meta-example/recipes-app/iot2050-firmware-update/files/iot2050_firmware_update.py
@@ -78,9 +78,9 @@ mandatory `target_boards` inside the `firmware` node. Possible target boards:
   - PG2 Basic:
       "SIMATIC IOT2050 Basic PG2"
   - PG2 Advanced:
-      "SIMATIC IOT2050 Advanced PG2"
+      "SIMATIC IOT2050 Advanced PG2", "SIMATIC IOT2050 Advanced PG2 Rev"
   - M2 Variant:
-      "SIMATIC IOT2050 Advanced M2"
+      "SIMATIC IOT2050 Advanced M2", "SIMATIC IOT2050 Advanced M2 Rev"
 
 To indicate which OS the firmware could be updated upon, use either the
 `target_os` inside the `firmware` node as a local configuration, or use

--- a/meta-example/recipes-devtools/firmware-update-package/files/update.conf.json.tmpl
+++ b/meta-example/recipes-devtools/firmware-update-package/files/update.conf.json.tmpl
@@ -20,7 +20,9 @@
             "target_boards": [
                 "SIMATIC IOT2050 Basic PG2",
                 "SIMATIC IOT2050 Advanced PG2",
+                "SIMATIC IOT2050 Advanced PG2 Rev",
                 "SIMATIC IOT2050 Advanced M2",
+                "SIMATIC IOT2050 Advanced M2 Rev",
                 "SIMATIC IOT2050 Advanced SM"
             ]
         }

--- a/meta/conf/machine/iot2050.conf
+++ b/meta/conf/machine/iot2050.conf
@@ -20,7 +20,9 @@ DTB_FILES = " \
     ti/k3-am6528-iot2050-basic-pg2.dtb \
     ti/k3-am6548-iot2050-advanced.dtb \
     ti/k3-am6548-iot2050-advanced-pg2.dtb \
+    ti/k3-am6548-iot2050-advanced-pg2-rev.dtb \
     ti/k3-am6548-iot2050-advanced-m2.dtb \
+    ti/k3-am6548-iot2050-advanced-m2-rev.dtb \
     "
 
 IMAGE_FSTYPES ?= "wic"

--- a/meta/recipes-app/mraa/files/0016-gpio-add-GPIO-character-device-v2-support.patch
+++ b/meta/recipes-app/mraa/files/0016-gpio-add-GPIO-character-device-v2-support.patch
@@ -1,0 +1,1655 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Baocheng Su <baocheng.su@siemens.com>
+Date: Mon, 6 Jul 2026 19:55:19 +0800
+Subject: [PATCH] gpio: add GPIO character device v2 support
+
+Add GPIO character device v2 support, including line discovery,
+line requests, line reconfiguration, and GPIO value access.
+
+Track the character device API version in platform metadata and
+integrate v2 line groups into the common GPIO initialization and
+cleanup paths while preserving compatibility with the v1 interface.
+
+Signed-off-by: Baocheng Su <baocheng.su@siemens.com>
+---
+ include/gpio/gpio_chardev_v2.h        |  31 ++
+ include/linux/gpio.h                  |  98 ++++
+ include/mraa_internal_types.h         |   7 +-
+ src/CMakeLists.txt                    |   1 +
+ src/arm/96boards.c                    |  12 +-
+ src/arm/rockpi4.c                     |   2 +-
+ src/gpio/gpio.c                       | 717 ++++++++++++++++++--------
+ src/gpio/gpio_chardev.c               |   4 +
+ src/gpio/gpio_chardev_v2.c            | 185 +++++++
+ src/mraa.c                            |  12 +-
+ src/x86/adlink-ipi.c                  |   2 +-
+ src/x86/iei_tank.c                    |   2 +-
+ src/x86/intel_ilk.c                   |   2 +-
+ src/x86/intel_joule_expansion.c       |   2 +-
+ src/x86/intel_minnow_byt_compatible.c |   2 +-
+ src/x86/up2.c                         |   2 +-
+ src/x86/up_xtreme.c                   |   2 +-
+ 17 files changed, 858 insertions(+), 225 deletions(-)
+ create mode 100644 include/gpio/gpio_chardev_v2.h
+ create mode 100644 src/gpio/gpio_chardev_v2.c
+
+diff --git a/include/gpio/gpio_chardev_v2.h b/include/gpio/gpio_chardev_v2.h
+new file mode 100644
+index 000000000000..74e1d80bf445
+--- /dev/null
++++ b/include/gpio/gpio_chardev_v2.h
+@@ -0,0 +1,31 @@
++/*
++ * Author: Baocheng Su <baocheng.su@siemens.com>
++ * Copyright (c) 2026 Siemens AG
++ *
++ * SPDX-License-Identifier: MIT
++ */
++
++#pragma once
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++#include "gpio_chardev.h"
++#include "linux/gpio.h"
++#include "mraa_internal.h"
++
++int mraa_gpiod_get_lines_request(int chip_fd, unsigned int line_offsets[], unsigned num_lines);
++int mraa_gpiod_get_line_name(int chip_fd, unsigned line_offset, char* name, size_t name_size);
++int mraa_gpiod_get_line_flags(int chip_fd, unsigned line_offset, unsigned long* flag);
++
++int mraa_gpiod_find_gpio_line_by_name(const char* name, unsigned* chip_number, unsigned* line_number);
++
++int mraa_gpiod_reconfig_lines(int line_req_fd, unsigned long flag);
++
++int mraa_gpiod_get_values(int line_req_fd, unsigned num_lines, unsigned char line_values[]);
++int mraa_gpiod_set_values(int line_req_fd, unsigned num_lines, unsigned char line_values[]);
++
++#ifdef __cplusplus
++}
++#endif
+diff --git a/include/linux/gpio.h b/include/linux/gpio.h
+index 8451032c6703..452a42058ceb 100644
+--- a/include/linux/gpio.h
++++ b/include/linux/gpio.h
+@@ -78,4 +78,102 @@ struct gpioevent_data {
+ #define GPIO_GET_LINEHANDLE_IOCTL _IOWR(0xB4, 0x03, struct gpiohandle_request)
+ #define GPIO_GET_LINEEVENT_IOCTL _IOWR(0xB4, 0x04, struct gpioevent_request)
+ 
++/**
++ * V2 API
++ */
++#define GPIO_V2_LINES_MAX 64
++#define GPIO_MAX_NAME_SIZE 32
++#define GPIO_V2_LINE_NUM_ATTRS_MAX 10
++
++enum gpio_v2_line_flag {
++    GPIO_V2_LINE_FLAG_USED = 1 << 0,
++    GPIO_V2_LINE_FLAG_ACTIVE_LOW = 1 << 1,
++    GPIO_V2_LINE_FLAG_INPUT = 1 << 2,
++    GPIO_V2_LINE_FLAG_OUTPUT = 1 << 3,
++    GPIO_V2_LINE_FLAG_EDGE_RISING = 1 << 4,
++    GPIO_V2_LINE_FLAG_EDGE_FALLING = 1 << 5,
++    GPIO_V2_LINE_FLAG_OPEN_DRAIN = 1 << 6,
++    GPIO_V2_LINE_FLAG_OPEN_SOURCE = 1 << 7,
++    GPIO_V2_LINE_FLAG_BIAS_PULL_UP = 1 << 8,
++    GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN = 1 << 9,
++    GPIO_V2_LINE_FLAG_BIAS_DISABLED = 1 << 10,
++    GPIO_V2_LINE_FLAG_EVENT_CLOCK_REALTIME = 1 << 11,
++    GPIO_V2_LINE_FLAG_EVENT_CLOCK_HTE = 1 << 12,
++};
++
++struct gpio_v2_line_attribute {
++	__u32 id;
++	__u32 padding;
++	union {
++		__aligned_u64 flags;
++		__aligned_u64 values;
++		__u32 debounce_period_us;
++	};
++};
++
++struct gpio_v2_line_config_attribute {
++	struct gpio_v2_line_attribute attr;
++	__aligned_u64 mask;
++};
++
++struct gpio_v2_line_config {
++	__aligned_u64 flags;
++	__u32 num_attrs;
++	/* Pad to fill implicit padding and reserve space for future use. */
++	__u32 padding[5];
++	struct gpio_v2_line_config_attribute attrs[GPIO_V2_LINE_NUM_ATTRS_MAX];
++};
++
++struct gpio_v2_line_request {
++	__u32 offsets[GPIO_V2_LINES_MAX];
++	char consumer[GPIO_MAX_NAME_SIZE];
++	struct gpio_v2_line_config config;
++	__u32 num_lines;
++	__u32 event_buffer_size;
++	/* Pad to fill implicit padding and reserve space for future use. */
++	__u32 padding[5];
++	__s32 fd;
++};
++
++struct gpio_v2_line_info {
++    char name[GPIO_MAX_NAME_SIZE];
++    char consumer[GPIO_MAX_NAME_SIZE];
++    __u32 offset;
++    __u32 num_attrs;
++    __aligned_u64 flags;
++    struct gpio_v2_line_attribute attrs[GPIO_V2_LINE_NUM_ATTRS_MAX];
++    /* Space reserved for future use. */
++    __u32 padding[4];
++};
++
++struct gpio_v2_line_values {
++    __aligned_u64 bits;
++    __aligned_u64 mask;
++};
++
++enum gpio_v2_line_event_id {
++    GPIO_V2_LINE_EVENT_RISING_EDGE = 1,
++    GPIO_V2_LINE_EVENT_FALLING_EDGE = 2,
++};
++
++struct gpio_v2_line_event {
++    __aligned_u64 timestamp_ns;
++    __u32 id;
++    __u32 offset;
++    __u32 seqno;
++    __u32 line_seqno;
++    /* Space reserved for future use. */
++    __u32 padding[6];
++};
++
++/*
++ * v2 ioctl()s
++ */
++#define GPIO_V2_GET_LINEINFO_IOCTL _IOWR(0xB4, 0x05, struct gpio_v2_line_info)
++#define GPIO_V2_GET_LINEINFO_WATCH_IOCTL _IOWR(0xB4, 0x06, struct gpio_v2_line_info)
++#define GPIO_V2_GET_LINE_IOCTL _IOWR(0xB4, 0x07, struct gpio_v2_line_request)
++#define GPIO_V2_LINE_SET_CONFIG_IOCTL _IOWR(0xB4, 0x0D, struct gpio_v2_line_config)
++#define GPIO_V2_LINE_GET_VALUES_IOCTL _IOWR(0xB4, 0x0E, struct gpio_v2_line_values)
++#define GPIO_V2_LINE_SET_VALUES_IOCTL _IOWR(0xB4, 0x0F, struct gpio_v2_line_values)
++
+ #endif /* _GPIO_H_ */
+diff --git a/include/mraa_internal_types.h b/include/mraa_internal_types.h
+index 63f2b94fef2f..52634a018f91 100644
+--- a/include/mraa_internal_types.h
++++ b/include/mraa_internal_types.h
+@@ -94,7 +94,10 @@ struct _firmata {
+ struct _gpio_group {
+     int is_required;
+     int dev_fd;
+-    int gpiod_handle;
++    union {
++        int gpiod_handle;
++        int line_request_fd;
++    };
+     unsigned int gpio_chip;
+     /* We can have multiple lines in a gpio group. */
+     unsigned int num_gpio_lines;
+@@ -499,7 +502,7 @@ typedef struct _board_t {
+     mraa_pininfo_t* pins;     /**< Pointer to pin array */
+     mraa_adv_func_t* adv_func;    /**< Pointer to advanced function disptach table */
+     struct _board_t* sub_platform;     /**< Pointer to sub platform */
+-    mraa_boolean_t chardev_capable;  /**< Decide what interface is being used: old sysfs or new char device*/
++    unsigned int chardev_ver;  /**< Decide what interface is being used: 0 for old sysfs, 1 for chardev V1, 2 for chardev V2 */
+     mraa_led_dev_t led_dev[MAX_LED_COUNT]; /**< Array of LED devices */
+     unsigned int led_dev_count; /**< Total onboard LED device count */
+     /*@}*/
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 8146eb674ef9..5c4922ff283a 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -24,6 +24,7 @@ set (mraa_LIB_SRCS_NOAUTO
+   ${PROJECT_SOURCE_DIR}/src/mraa.c
+   ${PROJECT_SOURCE_DIR}/src/gpio/gpio.c
+   ${PROJECT_SOURCE_DIR}/src/gpio/gpio_chardev.c
++  ${PROJECT_SOURCE_DIR}/src/gpio/gpio_chardev_v2.c
+   ${PROJECT_SOURCE_DIR}/src/i2c/i2c.c
+   ${PROJECT_SOURCE_DIR}/src/pwm/pwm.c
+   ${PROJECT_SOURCE_DIR}/src/spi/spi.c
+diff --git a/src/arm/96boards.c b/src/arm/96boards.c
+index ebaabae9690a..95c456fbbb88 100644
+--- a/src/arm/96boards.c
++++ b/src/arm/96boards.c
+@@ -266,41 +266,41 @@ mraa_96boards()
+             b->led_dev[5].name = (char*) db410c_led[5];
+             b->led_dev_count = MRAA_96BOARDS_LED_COUNT;
+             b->adv_func->gpio_mmap_setup = &mraa_db410c_mmap_setup;
+-            b->chardev_capable = 1;
++            b->chardev_ver = 1;
+         } else if (mraa_file_contains(DT_BASE "/model", "Qualcomm Technologies, Inc. DB820c")) {
+             b->platform_name = PLATFORM_NAME_DB820C;
+             ls_gpio_pins = db820c_ls_gpio_pins;
+             chardev_map = &db820c_chardev_map;
+             b->uart_dev[0].device_path = (char*) db820c_serialdev[0];
+             b->uart_dev[1].device_path = (char*) db820c_serialdev[1];
+-            b->chardev_capable = 1;
++            b->chardev_ver = 1;
+         } else if (mraa_file_contains(DT_BASE "/model", "HiKey Development Board")) {
+             b->platform_name = PLATFORM_NAME_HIKEY;
+             ls_gpio_pins = hikey_ls_gpio_pins;
+             chardev_map = &hikey_chardev_map;
+             b->uart_dev[0].device_path = (char*) hikey_serialdev[0];
+             b->uart_dev[1].device_path = (char*) hikey_serialdev[1];
+-            b->chardev_capable = 1;
++            b->chardev_ver = 1;
+         } else if (mraa_file_contains(DT_BASE "/model", "HiKey960")) {
+             b->platform_name = PLATFORM_NAME_HIKEY960;
+             chardev_map = &hikey960_chardev_map;
+             b->uart_dev[0].device_path = (char*) hikey960_serialdev[0];
+             b->uart_dev[1].device_path = (char*) hikey960_serialdev[1];
+-            b->chardev_capable = 1;
++            b->chardev_ver = 1;
+         } else if (mraa_file_contains(DT_BASE "/model", "ROCK960")) {
+             b->platform_name = PLATFORM_NAME_ROCK960;
+             ls_gpio_pins = rock960_ls_gpio_pins;
+             chardev_map = &rock960_chardev_map;
+             b->uart_dev[0].device_path = (char*) rock960_serialdev[0];
+             b->uart_dev[1].device_path = (char*) rock960_serialdev[1];
+-            b->chardev_capable = 1;
++            b->chardev_ver = 1;
+         } else if ((mraa_file_contains(DT_BASE "/model", "ZynqMP ZCU100 RevC")) ||
+                    (mraa_file_contains(DT_BASE "/model", "Avnet Ultra96 Rev1"))) {
+             b->platform_name = PLATFORM_NAME_ULTRA96;
+             chardev_map = &ultra96_chardev_map;
+             b->uart_dev[0].device_path = (char*) ultra96_serialdev[0];
+             b->uart_dev[1].device_path = (char*) ultra96_serialdev[1];
+-            b->chardev_capable = 1;
++            b->chardev_ver = 1;
+         }
+     }
+ 
+diff --git a/src/arm/rockpi4.c b/src/arm/rockpi4.c
+index dfa39a85ab21..7499521288bb 100644
+--- a/src/arm/rockpi4.c
++++ b/src/arm/rockpi4.c
+@@ -123,7 +123,7 @@ mraa_rockpi4()
+     b->adc_supported = 10;
+     b->aio_dev[0].pin = 26;
+     b->aio_non_seq = 1;
+-    b->chardev_capable = 1;
++    b->chardev_ver = 1;
+ 
+     mraa_rockpi4_pininfo(b, 0,   -1, (mraa_pincapabilities_t){0,0,0,0,0,0,0,0}, "INVALID");
+     mraa_rockpi4_pininfo(b, 1,   -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "3V3");
+diff --git a/src/gpio/gpio.c b/src/gpio/gpio.c
+index 5ea1c4b53a91..7708a3c4e4e3 100644
+--- a/src/gpio/gpio.c
++++ b/src/gpio/gpio.c
+@@ -7,6 +7,7 @@
+  */
+ #include "gpio.h"
+ #include "gpio/gpio_chardev.h"
++#include "gpio/gpio_chardev_v2.h"
+ #include "linux/gpio.h"
+ #include "mraa_internal.h"
+ 
+@@ -50,14 +51,17 @@ mraa_gpio_close_event_handles_sysfs(int fds[], int num_fds)
+         return;
+     }
+ 
+-    for (int i = 0; i < num_fds; ++i) {
+-        // Check required to avoid closing stdin and of an uninitialized fd
+-        if (fds[i] != 0) {
+-            close(fds[i]);
++    if (plat->chardev_ver != 2) {
++        // Do nothing for V2, as the line_request_fd is closed in _mraa_free_gpio_groups
++        for (int i = 0; i < num_fds; ++i) {
++            // Check required to avoid closing stdin and of an uninitialized fd
++            if (fds[i] != 0) {
++                close(fds[i]);
++            }
+         }
+-    }
+ 
+-    free(fds);
++        free(fds);
++    }
+ }
+ 
+ static mraa_gpio_context
+@@ -100,7 +104,7 @@ mraa_gpio_init_internal(mraa_adv_func_t* func_table, int pin)
+     dev->isr_thread_terminating = 0;
+     dev->phy_pin = -1;
+ 
+-    if ((plat != NULL) && (!plat->chardev_capable)) {
++    if ((plat != NULL) && (!plat->chardev_ver)) {
+         char bu[MAX_SIZE];
+         int length;
+ 
+@@ -149,24 +153,46 @@ init_internal_cleanup:
+ mraa_gpio_context
+ mraa_gpio_init_by_name(char* name)
+ {
+-    mraa_board_t* board = plat;
++    unsigned int chardev_api_ver = plat->chardev_ver;
++    unsigned chip_number, line_offset;
+     mraa_gpio_context dev;
+-    mraa_gpiod_group_t gpio_group;
+-    mraa_gpiod_line_info* linfo = NULL;
+-    mraa_gpiod_chip_info* cinfo;
+-    mraa_gpiod_chip_info** cinfos = NULL;
+-    int i, line_found, line_offset, chip_fd;
++    int chip_fd, ret;
+ 
+     if (name == NULL) {
+         syslog(LOG_ERR, "[GPIOD_INTERFACE]: Gpio name not valid");
+         return NULL;
+     }
+ 
+-    if (!board->chardev_capable) {
++    if (!chardev_api_ver) {
+         syslog(LOG_ERR, "[GPIOD_INTERFACE]: gpio_init_by_name not available for this platform!");
+         return NULL;
+     }
+ 
++    switch (chardev_api_ver) {
++        case 1:
++            ret = mraa_find_gpio_line_by_name(name, &chip_number, &line_offset);
++            break;
++        case 2:
++            ret = mraa_gpiod_find_gpio_line_by_name(name, &chip_number, &line_offset);
++            break;
++        default:
++            syslog(LOG_ERR, "[GPIOD_INTERFACE]: Invalid chardev_api_ver value: %d", chardev_api_ver);
++            return NULL;
++    }
++
++    if (ret < 0) {
++        syslog(LOG_ERR, "[GPIOD_INTERFACE]: Gpio name not found");
++        return NULL;
++    }
++
++    mraa_gpiod_chip_info* cinfo = mraa_get_chip_info_by_number(chip_number);
++    if (cinfo == NULL) {
++        syslog(LOG_ERR, "[GPIOD_INTERFACE]: Failed to get chip info for chip number %u", chip_number);
++        return NULL;
++    }
++    chip_fd = cinfo->chip_fd;
++    free(cinfo);
++
+     dev = (mraa_gpio_context) calloc(1, sizeof(struct _gpio));
+     if (dev == NULL) {
+         syslog(LOG_CRIT, "[GPIOD_INTERFACE]: Failed to allocate memory for context");
+@@ -180,86 +206,51 @@ mraa_gpio_init_by_name(char* name)
+         return NULL;
+     }
+ 
+-    dev->num_chips = mraa_get_chip_infos(&cinfos);
+-    if (dev->num_chips <= 0) {
+-        mraa_gpio_close(dev);
+-        return NULL;
+-    }
+-
+     /* We are dealing with a single GPIO */
++    dev->num_chips = 1;
+     dev->num_pins = 1;
+ 
+-    gpio_group = calloc(dev->num_chips, sizeof(struct _gpio_group));
+-    if (gpio_group == NULL) {
++    dev->gpio_group = calloc(1, sizeof(struct _gpio_group));
++    if (dev->gpio_group == NULL) {
+         syslog(LOG_CRIT, "[GPIOD_INTERFACE]: Failed to allocate memory for internal member");
+-        for_each_gpio_chip(cinfo, cinfos, dev->num_chips) {
+-            if (cinfo) close(cinfo->chip_fd);
+-        }
+-        free(cinfos);
+         mraa_gpio_close(dev);
+         return NULL;
+     }
+ 
+-    dev->gpio_group = gpio_group;
+-    for (i = 0; i < dev->num_chips; ++i) {
+-        gpio_group[i].gpio_chip = i;
+-        gpio_group[i].gpio_lines = NULL;
+-    }
+-
+-    /* Iterate over all gpiochips in the platform to find the requested line */
+-    for_each_gpio_chip(cinfo, cinfos, dev->num_chips)
+-    {
+-        for (i = 0; i < cinfo->chip_info.lines; i++) {
+-            linfo = mraa_get_line_info_by_chip_name(cinfo->chip_info.name, i);
+-            if (!strncmp(linfo->name, name, 32)) {
+-                /* idx is coming from `for_each_gpio_chip` definition */
+-                syslog(LOG_DEBUG, "[GPIOD_INTERFACE]: Chip: %d Line: %d", idx, i);
+-                if (!gpio_group[idx].is_required) {
+-                    gpio_group[idx].dev_fd = cinfo->chip_fd;
+-                    gpio_group[idx].is_required = 1;
+-                    gpio_group[idx].gpiod_handle = -1;
+-                    chip_fd = gpio_group[idx].dev_fd;
+-                }
+-
+-                /* Map pin to _gpio_group structure. */
+-                dev->pin_to_gpio_table[0] = idx;
+-                gpio_group[idx].gpio_lines = realloc(gpio_group[idx].gpio_lines, sizeof(unsigned int));
+-                gpio_group[idx].gpio_lines[0] = i;
+-                gpio_group[idx].num_gpio_lines++;
+-
+-                line_found = 1;
+-                line_offset = i;
+-
+-                free(linfo);
+-                break;
+-            }
+-            free(linfo);
+-        }
+-    }
+-
+-    for_each_gpio_chip(cinfo, cinfos, dev->num_chips) {
+-        if (!line_found || cinfo->chip_fd != chip_fd) {
+-            close(cinfo->chip_fd);
+-        }
+-    }
+-    free(cinfos);
+-
+-    if (!line_found) {
+-        syslog(LOG_ERR, "[GPIOD_INTERFACE]: Gpio not found!");
++    dev->gpio_group->is_required = 1;
++    dev->gpio_group->dev_fd = chip_fd;
++    dev->gpio_group->gpio_chip = chip_number;
++    dev->gpio_group->gpio_lines = calloc(1, sizeof(unsigned int));
++    if (dev->gpio_group->gpio_lines == NULL) {
++        syslog(LOG_CRIT, "[GPIOD_INTERFACE]: Failed to allocate memory for internal member");
+         mraa_gpio_close(dev);
+         return NULL;
+     }
++    *dev->gpio_group->gpio_lines = line_offset;
++    dev->gpio_group->num_gpio_lines = 1;
+ 
+-    /* Initialize rw_values for read / write multiple functions */
+-    for (i = 0; i < dev->num_chips; ++i) {
+-        gpio_group[i].rw_values = calloc(gpio_group[i].num_gpio_lines, sizeof(unsigned char));
+-        if (gpio_group[i].rw_values == NULL) {
+-            syslog(LOG_CRIT, "[GPIOD_INTERFACE]: Failed to allocate memory for internal member");
++    if (chardev_api_ver == 1) {
++        dev->gpio_group->gpiod_handle = -1;
++        dev->gpio_group->event_handles = NULL;
++    } else {
++        int line_request_fd = mraa_gpiod_get_lines_request(chip_fd, dev->gpio_group->gpio_lines, 1);
++        if (line_request_fd < 0) {
++            syslog(LOG_ERR, "[GPIOD_INTERFACE]: error requesting lines for chip %d", chip_number);
+             mraa_gpio_close(dev);
+             return NULL;
+         }
+ 
+-        gpio_group[i].event_handles = NULL;
++        dev->gpio_group->line_request_fd = line_request_fd;
++    }
++
++    dev->pin_to_gpio_table[0] = 0; /* Map the single pin to the first (and only) gpio group */
++
++    /* Initialize rw_values for read / write multiple functions */
++    dev->gpio_group->rw_values = calloc(1, sizeof(unsigned char));
++    if (dev->gpio_group->rw_values == NULL) {
++        syslog(LOG_CRIT, "[GPIOD_INTERFACE]: Failed to allocate memory for internal member");
++        mraa_gpio_close(dev);
++        return NULL;
+     }
+ 
+     /* Save the provided array from the user to our internal structure. */
+@@ -305,7 +296,7 @@ mraa_gpio_init(int pin)
+         pin = mraa_get_sub_platform_index(pin);
+     }
+ 
+-    if (board->chardev_capable) {
++    if (board->chardev_ver) {
+         int pins[1] = { pin };
+         return mraa_gpio_init_multi(pins, 1);
+     }
+@@ -351,7 +342,7 @@ mraa_gpio_init(int pin)
+ }
+ 
+ mraa_gpio_context
+-mraa_gpio_chardev_init(int pins[], int num_pins)
++mraa_gpio_chardev_init(int pins[], int num_pins, unsigned int chardev_ver)
+ {
+     int chip_id, line_offset;
+     mraa_gpio_context dev;
+@@ -451,7 +442,9 @@ mraa_gpio_chardev_init(int pins[], int num_pins)
+ 
+             gpio_group[chip_id].dev_fd = cinfo->chip_fd;
+             gpio_group[chip_id].is_required = 1;
+-            gpio_group[chip_id].gpiod_handle = -1;
++            if (chardev_ver == 1) {
++                gpio_group[chip_id].gpiod_handle = -1;
++            }
+ 
+             free(cinfo);
+         }
+@@ -470,6 +463,23 @@ mraa_gpio_chardev_init(int pins[], int num_pins)
+         gpio_group[chip_id].num_gpio_lines++;
+     }
+ 
++    if (chardev_ver == 2) {
++        for (int i = 0; i < dev->num_chips; ++i) {
++            if (gpio_group[i].is_required) {
++                int line_request_fd =
++                mraa_gpiod_get_lines_request(gpio_group[i].dev_fd, gpio_group[i].gpio_lines,
++                                             gpio_group[i].num_gpio_lines);
++                if (line_request_fd < 0) {
++                    syslog(LOG_ERR, "[GPIOD_INTERFACE]: error requesting lines for chip %d", gpio_group[i].gpio_chip);
++                    mraa_gpio_close(dev);
++                    return NULL;
++                }
++
++                gpio_group[i].line_request_fd = line_request_fd;
++            }
++        }
++    }
++
+     /* Initialize rw_values for read / write multiple functions.
+      * Also, allocate memory for inverse map: */
+     for (int i = 0; i < dev->num_chips; ++i) {
+@@ -543,8 +553,8 @@ mraa_gpio_init_multi(int pins[], int num_pins)
+         return NULL;
+     }
+ 
+-    if (board->chardev_capable)
+-        return mraa_gpio_chardev_init(pins, num_pins);
++    if (board->chardev_ver)
++        return mraa_gpio_chardev_init(pins, num_pins, board->chardev_ver);
+ 
+     /* Fallback to legacy interface. */
+     mraa_gpio_context head = NULL, current, tmp;
+@@ -652,13 +662,18 @@ mraa_gpio_wait_interrupt(int fds[],
+ static mraa_result_t
+ mraa_gpio_chardev_wait_interrupt(int fds[], int num_fds, mraa_gpio_events_t events)
+ {
+-    struct pollfd pfd[num_fds];
+-    struct gpioevent_data event_data;
+-
+     if (!fds) {
+         return MRAA_ERROR_INVALID_PARAMETER;
+     }
+ 
++    struct gpio_v2_line_event event_v2;
++    struct gpioevent_data event_v1;
++    struct pollfd pfd[num_fds];
++    int ret;
++
++    memset(&event_v2, 0, sizeof(event_v2));
++    memset(&event_v1, 0, sizeof(event_v1));
++
+     for (int i = 0; i < num_fds; ++i) {
+         pfd[i].fd = fds[i];
+         pfd[i].events = POLLIN;
+@@ -670,11 +685,26 @@ mraa_gpio_chardev_wait_interrupt(int fds[], int num_fds, mraa_gpio_events_t even
+ 
+     for (int i = 0; i < num_fds; ++i) {
+         if (pfd[i].revents & POLLIN) {
+-            read(fds[i], &event_data, sizeof(event_data));
++            void* event_buf;
++            size_t event_buf_size;
++            if (plat->chardev_ver == 2) {
++                event_buf = &event_v2;
++                event_buf_size = sizeof(event_v2);
++            } else {
++                event_buf = &event_v1;
++                event_buf_size = sizeof(event_v1);
++            }
++
++            ret = read(fds[i], event_buf, event_buf_size);
+             events[i].id = i;
+-            events[i].timestamp = event_data.timestamp;
+-        } else
++            if (plat->chardev_ver == 2) {
++                events[i].timestamp = event_v2.timestamp_ns;
++            } else {
++                events[i].timestamp = event_v1.timestamp;
++            }
++        } else {
+             events[i].id = -1;
++        }
+     }
+ 
+     return MRAA_SUCCESS;
+@@ -690,7 +720,7 @@ mraa_gpio_get_events(mraa_gpio_context dev)
+ 
+     unsigned int event_idx = 0;
+ 
+-    if (plat->chardev_capable) {
++    if (plat->chardev_ver) {
+         unsigned int pin_idx;
+         mraa_gpiod_group_t gpio_iter;
+ 
+@@ -746,14 +776,18 @@ mraa_gpio_interrupt_handler(void* arg)
+     /* Is this pin on a subplatform? Do nothing... */
+     if (mraa_is_sub_platform_id(dev->pin)) {
+     }
+-    /* Is the platform chardev_capable? */
+-    else if (plat->chardev_capable) {
++    /* Is the platform chardev_ver? */
++    else if (plat->chardev_ver) {
+         mraa_gpiod_group_t gpio_group;
+ 
+         for_each_gpio_group(gpio_group, dev)
+         {
+-            for (int i = 0; i < gpio_group->num_gpio_lines; ++i) {
+-                fps[idx++] = gpio_group->event_handles[i];
++            if (plat->chardev_ver == 2) {
++                fps[idx++] = gpio_group->line_request_fd;
++            } else {
++                for (int i = 0; i < gpio_group->num_gpio_lines; ++i) {
++                    fps[idx++] = gpio_group->event_handles[i];
++                }
+             }
+         }
+     }
+@@ -800,7 +834,7 @@ mraa_gpio_interrupt_handler(void* arg)
+         if (IS_FUNC_DEFINED(dev, gpio_wait_interrupt_replace)) {
+             ret = dev->advance_func->gpio_wait_interrupt_replace(dev);
+         } else {
+-            if (plat->chardev_capable) {
++            if (plat->chardev_ver) {
+                 ret = mraa_gpio_chardev_wait_interrupt(fps, idx, dev->events);
+             } else {
+                 ret = mraa_gpio_wait_interrupt(fps, idx
+@@ -852,7 +886,7 @@ mraa_gpio_chardev_edge_mode(mraa_gpio_context dev, mraa_gpio_edge_t mode)
+         return MRAA_ERROR_INVALID_HANDLE;
+     }
+ 
+-    if (!plat->chardev_capable) {
++    if (!plat->chardev_ver) {
+         syslog(LOG_ERR, "mraa_gpio_chardev_edge_mode() not supported for old sysfs interface");
+         return MRAA_ERROR_FEATURE_NOT_IMPLEMENTED;
+     }
+@@ -860,48 +894,114 @@ mraa_gpio_chardev_edge_mode(mraa_gpio_context dev, mraa_gpio_edge_t mode)
+     int status;
+     mraa_gpiod_group_t gpio_group;
+ 
+-    struct gpioevent_request req;
++    if (plat->chardev_ver == 2) {
++        for_each_gpio_group(gpio_group, dev)
++        {
++            unsigned long flags = 0;
+ 
+-    switch (mode) {
+-        case MRAA_GPIO_EDGE_BOTH:
+-            req.eventflags = GPIOEVENT_REQUEST_BOTH_EDGES;
+-            break;
+-        case MRAA_GPIO_EDGE_RISING:
+-            req.eventflags = GPIOEVENT_REQUEST_RISING_EDGE;
+-            break;
+-        case MRAA_GPIO_EDGE_FALLING:
+-            req.eventflags = GPIOEVENT_REQUEST_FALLING_EDGE;
+-            break;
+-        /* Chardev interface doesn't handle EDGE_NONE. */
+-        case MRAA_GPIO_EDGE_NONE:
+-        default:
+-            return MRAA_ERROR_FEATURE_NOT_IMPLEMENTED;
+-    }
++            int ret = mraa_gpiod_get_line_flags(gpio_group->dev_fd, gpio_group->gpio_lines[0], &flags);
++            if (ret != 0) {
++                syslog(LOG_ERR, "[GPIOD_INTERFACE]: error getting line flags");
++                return MRAA_ERROR_INVALID_RESOURCE;
++            }
+ 
+-    for_each_gpio_group(gpio_group, dev)
+-    {
+-        if (gpio_group->gpiod_handle != -1) {
+-            close(gpio_group->gpiod_handle);
+-            gpio_group->gpiod_handle = -1;
++            flags &= ~GPIO_V2_LINE_FLAG_USED;
++
++            if ((flags & GPIO_V2_LINE_FLAG_INPUT) == 0) {
++                syslog(LOG_ERR, "[GPIOD_INTERFACE]: error setting line input mode. Line is not "
++                                "configured as input.");
++                return MRAA_ERROR_INVALID_RESOURCE;
++            }
++
++            switch (mode) {
++                case MRAA_GPIO_EDGE_BOTH:
++                    if ((flags & GPIO_V2_LINE_FLAG_EDGE_RISING) && (flags & GPIO_V2_LINE_FLAG_EDGE_FALLING)) {
++                        syslog(LOG_DEBUG,
++                               "[GPIOD_INTERFACE]: line already configured for both edges");
++                        return MRAA_SUCCESS;
++                    }
++                    flags |= (GPIO_V2_LINE_FLAG_EDGE_RISING | GPIO_V2_LINE_FLAG_EDGE_FALLING);
++                    break;
++                case MRAA_GPIO_EDGE_RISING:
++                    if ((flags & GPIO_V2_LINE_FLAG_EDGE_RISING) && !(flags & GPIO_V2_LINE_FLAG_EDGE_FALLING)) {
++                        syslog(LOG_DEBUG,
++                               "[GPIOD_INTERFACE]: line already configured for rising edge");
++                        return MRAA_SUCCESS;
++                    }
++                    flags |= GPIO_V2_LINE_FLAG_EDGE_RISING;
++                    flags &= ~GPIO_V2_LINE_FLAG_EDGE_FALLING;
++                    break;
++                case MRAA_GPIO_EDGE_FALLING:
++                    if ((flags & GPIO_V2_LINE_FLAG_EDGE_FALLING) && !(flags & GPIO_V2_LINE_FLAG_EDGE_RISING)) {
++                        syslog(LOG_DEBUG,
++                               "[GPIOD_INTERFACE]: line already configured for falling edge");
++                        return MRAA_SUCCESS;
++                    }
++                    flags |= GPIO_V2_LINE_FLAG_EDGE_FALLING;
++                    flags &= ~GPIO_V2_LINE_FLAG_EDGE_RISING;
++                    break;
++                case MRAA_GPIO_EDGE_NONE:
++                    if (!(flags & GPIO_V2_LINE_FLAG_EDGE_RISING) && !(flags & GPIO_V2_LINE_FLAG_EDGE_FALLING)) {
++                        syslog(LOG_DEBUG,
++                               "[GPIOD_INTERFACE]: line already configured for no edge detection");
++                        return MRAA_SUCCESS;
++                    }
++                    flags &= ~(GPIO_V2_LINE_FLAG_EDGE_RISING | GPIO_V2_LINE_FLAG_EDGE_FALLING);
++                    break;
++                default:
++                    return MRAA_ERROR_FEATURE_NOT_IMPLEMENTED;
++            }
++
++            ret = mraa_gpiod_reconfig_lines(gpio_group->line_request_fd, flags);
++            if (ret != 0) {
++                syslog(LOG_ERR, "[GPIOD_INTERFACE]: error reconfiguring line flags: %d", ret);
++                return MRAA_ERROR_INVALID_RESOURCE;
++            }
+         }
++    } else {
++        struct gpioevent_request req;
+ 
+-        gpio_group->event_handles = malloc(gpio_group->num_gpio_lines * sizeof(int));
+-        if (!gpio_group->event_handles) {
+-            syslog(LOG_ERR, "mraa_gpio_chardev_edge_mode(): malloc error!");
+-            return MRAA_ERROR_NO_RESOURCES;
++        switch (mode) {
++            case MRAA_GPIO_EDGE_BOTH:
++                req.eventflags = GPIOEVENT_REQUEST_BOTH_EDGES;
++                break;
++            case MRAA_GPIO_EDGE_RISING:
++                req.eventflags = GPIOEVENT_REQUEST_RISING_EDGE;
++                break;
++            case MRAA_GPIO_EDGE_FALLING:
++                req.eventflags = GPIOEVENT_REQUEST_FALLING_EDGE;
++                break;
++            /* Chardev interface doesn't handle EDGE_NONE. */
++            case MRAA_GPIO_EDGE_NONE:
++            default:
++                return MRAA_ERROR_FEATURE_NOT_IMPLEMENTED;
+         }
+ 
+-        for (int i = 0; i < gpio_group->num_gpio_lines; ++i) {
+-            req.lineoffset = gpio_group->gpio_lines[i];
+-            req.handleflags = GPIOHANDLE_REQUEST_INPUT;
++        for_each_gpio_group(gpio_group, dev)
++        {
++            if (gpio_group->gpiod_handle != -1) {
++                close(gpio_group->gpiod_handle);
++                gpio_group->gpiod_handle = -1;
++            }
+ 
+-            status = _mraa_gpiod_ioctl(gpio_group->dev_fd, GPIO_GET_LINEEVENT_IOCTL, &req);
+-            if (status < 0) {
+-                syslog(LOG_ERR, "error getting line event handle for line %i", gpio_group->gpio_lines[i]);
+-                return MRAA_ERROR_INVALID_RESOURCE;
++            gpio_group->event_handles = malloc(gpio_group->num_gpio_lines * sizeof(int));
++            if (!gpio_group->event_handles) {
++                syslog(LOG_ERR, "mraa_gpio_chardev_edge_mode(): malloc error!");
++                return MRAA_ERROR_NO_RESOURCES;
+             }
+ 
+-            gpio_group->event_handles[i] = req.fd;
++            for (int i = 0; i < gpio_group->num_gpio_lines; ++i) {
++                req.lineoffset = gpio_group->gpio_lines[i];
++                req.handleflags = GPIOHANDLE_REQUEST_INPUT;
++
++                status = _mraa_gpiod_ioctl(gpio_group->dev_fd, GPIO_GET_LINEEVENT_IOCTL, &req);
++                if (status < 0) {
++                    syslog(LOG_ERR, "error getting line event handle for line %i", gpio_group->gpio_lines[i]);
++                    return MRAA_ERROR_INVALID_RESOURCE;
++                }
++
++                gpio_group->event_handles[i] = req.fd;
++            }
+         }
+     }
+ 
+@@ -932,7 +1032,7 @@ mraa_gpio_edge_mode(mraa_gpio_context dev, mraa_gpio_edge_t mode)
+         }
+     }
+ 
+-    if (plat->chardev_capable)
++    if (plat->chardev_ver)
+         return mraa_gpio_chardev_edge_mode(dev, mode);
+ 
+     mraa_gpio_context it = dev;
+@@ -1051,7 +1151,7 @@ mraa_gpio_isr_exit(mraa_gpio_context dev)
+     dev->isr_thread_terminating = 1;
+ 
+     // stop isr being useful
+-    if (plat && (plat->chardev_capable))
++    if (plat && (plat->chardev_ver))
+         _mraa_close_gpio_event_handles(dev);
+     else
+         ret = mraa_gpio_edge_mode(dev, MRAA_GPIO_EDGE_NONE);
+@@ -1101,8 +1201,8 @@ mraa_gpio_mode(mraa_gpio_context dev, mraa_gpio_mode_t mode)
+             return pre_ret;
+     }
+ 
+-    if (plat->chardev_capable) {
+-        unsigned flags = 0;
++    if (plat->chardev_ver) {
++        unsigned long flags = 0;
+         int line_handle;
+         mraa_gpiod_group_t gpio_iter;
+ 
+@@ -1111,44 +1211,87 @@ mraa_gpio_mode(mraa_gpio_context dev, mraa_gpio_mode_t mode)
+         /* We save flag values from the first valid line. */
+         for_each_gpio_group(gpio_iter, dev)
+         {
+-            mraa_gpiod_line_info* linfo =
+-            mraa_get_line_info_by_chip_number(gpio_iter->gpio_chip, gpio_iter->gpio_lines[0]);
+-            if (!linfo) {
+-                syslog(LOG_ERR, "[GPIOD_INTERFACE]: error getting line info");
+-                return MRAA_ERROR_UNSPECIFIED;
++            if (plat->chardev_ver == 2) {
++                int ret = mraa_gpiod_get_line_flags(gpio_iter->dev_fd, gpio_iter->gpio_lines[0], &flags);
++                if (ret != 0) {
++                    syslog(LOG_ERR, "[GPIOD_INTERFACE]: error getting line flags");
++                    return MRAA_ERROR_INVALID_RESOURCE;
++                }
++                flags &= ~GPIO_V2_LINE_FLAG_USED;
++            } else {
++                mraa_gpiod_line_info* linfo =
++                mraa_get_line_info_by_chip_number(gpio_iter->gpio_chip, gpio_iter->gpio_lines[0]);
++                if (!linfo) {
++                    syslog(LOG_ERR, "[GPIOD_INTERFACE]: error getting line info");
++                    return MRAA_ERROR_UNSPECIFIED;
++                }
++                flags = linfo->flags;
++                free(linfo);
+             }
+-            flags = linfo->flags;
+-            free(linfo);
+ 
+             /* We don't need to iterate any further. */
+             break;
+         }
+ 
+         /* Without changing the API, for now, we can request only one mode per call. */
+-        switch (mode) {
+-            case MRAA_GPIOD_ACTIVE_LOW:
+-                flags |= GPIOHANDLE_REQUEST_ACTIVE_LOW;
+-                break;
+-            case MRAA_GPIOD_OPEN_DRAIN:
+-                flags |= GPIOHANDLE_REQUEST_OPEN_DRAIN;
+-                break;
+-            case MRAA_GPIOD_OPEN_SOURCE:
+-                flags |= GPIOHANDLE_REQUEST_OPEN_SOURCE;
+-                break;
+-            default:
+-                return MRAA_ERROR_FEATURE_NOT_IMPLEMENTED;
++        if (plat->chardev_ver == 2) {
++            switch (mode) {
++                case MRAA_GPIO_PULLUP:
++                    flags |= GPIO_V2_LINE_FLAG_BIAS_PULL_UP;
++                    break;
++                case MRAA_GPIO_PULLDOWN:
++                    flags |= GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN;
++                    break;
++                case MRAA_GPIO_STRONG:
++                case MRAA_GPIO_HIZ:
++                    flags |= GPIO_V2_LINE_FLAG_BIAS_DISABLED;
++                    break;
++                case MRAA_GPIOD_ACTIVE_LOW:
++                    flags |= GPIO_V2_LINE_FLAG_ACTIVE_LOW;
++                    break;
++                case MRAA_GPIOD_OPEN_DRAIN:
++                    flags |= GPIO_V2_LINE_FLAG_OPEN_DRAIN;
++                    break;
++                case MRAA_GPIOD_OPEN_SOURCE:
++                    flags |= GPIO_V2_LINE_FLAG_OPEN_SOURCE;
++                    break;
++                default:
++                    return MRAA_ERROR_FEATURE_NOT_IMPLEMENTED;
++            }
++        } else {
++            switch (mode) {
++                case MRAA_GPIOD_ACTIVE_LOW:
++                    flags |= GPIOHANDLE_REQUEST_ACTIVE_LOW;
++                    break;
++                case MRAA_GPIOD_OPEN_DRAIN:
++                    flags |= GPIOHANDLE_REQUEST_OPEN_DRAIN;
++                    break;
++                case MRAA_GPIOD_OPEN_SOURCE:
++                    flags |= GPIOHANDLE_REQUEST_OPEN_SOURCE;
++                    break;
++                default:
++                    return MRAA_ERROR_FEATURE_NOT_IMPLEMENTED;
++            }
+         }
+ 
+         for_each_gpio_group(gpio_iter, dev)
+         {
+-            line_handle = mraa_get_lines_handle(gpio_iter->dev_fd, gpio_iter->gpio_lines,
+-                                                gpio_iter->num_gpio_lines, flags, 0);
+-            if (line_handle <= 0) {
+-                syslog(LOG_ERR, "[GPIOD_INTERFACE]: error getting line handle");
+-                return MRAA_ERROR_INVALID_RESOURCE;
+-            }
++            if (plat->chardev_ver == 2) {
++                int ret = mraa_gpiod_reconfig_lines(gpio_iter->line_request_fd, flags);
++                if (ret != 0) {
++                    syslog(LOG_ERR, "[GPIOD_INTERFACE]: error reconfiguring line flags: %d", ret);
++                    return MRAA_ERROR_INVALID_RESOURCE;
++                }
++            } else {
++                line_handle = mraa_get_lines_handle(gpio_iter->dev_fd, gpio_iter->gpio_lines,
++                                                    gpio_iter->num_gpio_lines, flags, 0);
++                if (line_handle <= 0) {
++                    syslog(LOG_ERR, "[GPIOD_INTERFACE]: error getting line handle");
++                    return MRAA_ERROR_INVALID_RESOURCE;
++                }
+ 
+-            gpio_iter->gpiod_handle = line_handle;
++                gpio_iter->gpiod_handle = line_handle;
++            }
+         }
+     } else {
+ 
+@@ -1200,8 +1343,8 @@ mraa_gpio_mode(mraa_gpio_context dev, mraa_gpio_mode_t mode)
+     return MRAA_SUCCESS;
+ }
+ 
+-mraa_result_t
+-mraa_gpio_chardev_dir(mraa_gpio_context dev, mraa_gpio_dir_t dir)
++static mraa_result_t
++mraa_gpio_chardev_dir_v1(mraa_gpio_context dev, mraa_gpio_dir_t dir)
+ {
+     int line_handle;
+     unsigned flags = 0;
+@@ -1266,6 +1409,81 @@ mraa_gpio_chardev_dir(mraa_gpio_context dev, mraa_gpio_dir_t dir)
+     return MRAA_SUCCESS;
+ }
+ 
++static mraa_result_t
++mraa_gpio_chardev_dir_v2(mraa_gpio_context dev, mraa_gpio_dir_t dir)
++{
++    unsigned long flags = 0;
++    struct _gpio_group* gpio_iter;
++
++    for_each_gpio_group(gpio_iter, dev)
++    {
++        int ret = mraa_gpiod_get_line_flags(gpio_iter->dev_fd, gpio_iter->gpio_lines[0], &flags);
++        if (ret != 0) {
++            syslog(LOG_ERR, "[GPIOD_INTERFACE]: error getting line flags");
++            return MRAA_ERROR_INVALID_RESOURCE;
++        }
++
++        int need_reconfig = 1;
++
++        switch (dir) {
++            case MRAA_GPIO_OUT_HIGH:
++            case MRAA_GPIO_OUT_LOW:
++            case MRAA_GPIO_OUT:
++                if (flags & GPIO_V2_LINE_FLAG_OUTPUT) {
++                    syslog(LOG_DEBUG, "[GPIOD_INTERFACE]: line already configured as output");
++                    need_reconfig = 0;
++                    break;
++                }
++                flags |= GPIO_V2_LINE_FLAG_OUTPUT;
++                flags &= ~GPIO_V2_LINE_FLAG_INPUT;
++                break;
++            case MRAA_GPIO_IN:
++                if (flags & GPIO_V2_LINE_FLAG_INPUT) {
++                    syslog(LOG_DEBUG, "[GPIOD_INTERFACE]: line already configured as input");
++                    need_reconfig = 0;
++                    break;
++                }
++                flags |= GPIO_V2_LINE_FLAG_INPUT;
++                flags &= ~GPIO_V2_LINE_FLAG_OUTPUT;
++                break;
++            default:
++                return MRAA_ERROR_FEATURE_NOT_IMPLEMENTED;
++        }
++
++        if (need_reconfig) {
++            flags &= ~GPIO_V2_LINE_FLAG_USED;
++            ret = mraa_gpiod_reconfig_lines(gpio_iter->line_request_fd, flags);
++            if (ret != 0) {
++                syslog(LOG_ERR, "[GPIOD_INTERFACE]: error reconfiguring line flags: %d", ret);
++                return MRAA_ERROR_INVALID_RESOURCE;
++            }
++        }
++
++        if ((dir == MRAA_GPIO_OUT_LOW) || (dir == MRAA_GPIO_OUT_HIGH)) {
++            unsigned char* values = (unsigned char*) calloc(gpio_iter->num_gpio_lines, sizeof(unsigned char));
++            if (!values) {
++                syslog(LOG_ERR, "[GPIOD_INTERFACE]: error allocating memory for values");
++                return MRAA_ERROR_NO_RESOURCES;
++            }
++
++            if (dir == MRAA_GPIO_OUT_LOW) {
++                memset(values, 0, gpio_iter->num_gpio_lines);
++            } else {
++                memset(values, 1, gpio_iter->num_gpio_lines);
++            }
++
++            ret = mraa_gpiod_set_values(gpio_iter->line_request_fd, gpio_iter->num_gpio_lines, values);
++            free(values);
++            if (ret != 0) {
++                syslog(LOG_ERR, "[GPIOD_INTERFACE]: error setting line values: %d", ret);
++                return MRAA_ERROR_INVALID_RESOURCE;
++            }
++        }
++    }
++
++    return MRAA_SUCCESS;
++}
++
+ static mraa_result_t
+ gpio_sysfs_read_dir(mraa_gpio_context dev, int dir_fd, mraa_gpio_dir_t *dir)
+ {
+@@ -1310,8 +1528,9 @@ mraa_gpio_dir(mraa_gpio_context dev, mraa_gpio_dir_t dir)
+         }
+     }
+ 
+-    if (plat->chardev_capable)
+-        return mraa_gpio_chardev_dir(dev, dir);
++    if (plat->chardev_ver)
++        return plat->chardev_ver == 2 ? mraa_gpio_chardev_dir_v2(dev, dir) :
++                                            mraa_gpio_chardev_dir_v1(dev, dir);
+ 
+     mraa_gpio_context it = dev;
+ 
+@@ -1390,36 +1609,51 @@ mraa_gpio_read_dir(mraa_gpio_context dev, mraa_gpio_dir_t* dir)
+     mraa_result_t result = MRAA_SUCCESS;
+ 
+     /* Initialize with 'unusable'. */
+-    unsigned flags = GPIOLINE_FLAG_KERNEL;
++    unsigned long flags = GPIOLINE_FLAG_KERNEL;
++
++    if (plat->chardev_ver == 2)
++        flags = 0;
+ 
+     if (IS_FUNC_DEFINED(dev, gpio_read_dir_replace)) {
+         return dev->advance_func->gpio_read_dir_replace(dev, dir);
+     }
+ 
+-    if (plat->chardev_capable) {
++    if (plat->chardev_ver) {
+         mraa_gpiod_group_t gpio_iter;
+ 
+         for_each_gpio_group(gpio_iter, dev)
+         {
+-            mraa_gpiod_line_info* linfo =
+-            mraa_get_line_info_by_chip_number(gpio_iter->gpio_chip, gpio_iter->gpio_lines[0]);
+-            if (!linfo) {
+-                syslog(LOG_ERR, "[GPIOD_INTERFACE]: error getting line info");
+-                return MRAA_ERROR_UNSPECIFIED;
++            if (plat->chardev_ver == 2) {
++                int ret = mraa_gpiod_get_line_flags(gpio_iter->dev_fd, gpio_iter->gpio_lines[0], &flags);
++                if (ret != 0) {
++                    syslog(LOG_ERR, "[GPIOD_INTERFACE]: error getting line flags");
++                    return MRAA_ERROR_INVALID_RESOURCE;
++                }
++            } else {
++                mraa_gpiod_line_info* linfo =
++                mraa_get_line_info_by_chip_number(gpio_iter->gpio_chip, gpio_iter->gpio_lines[0]);
++                if (!linfo) {
++                    syslog(LOG_ERR, "[GPIOD_INTERFACE]: error getting line info");
++                    return MRAA_ERROR_UNSPECIFIED;
++                }
++                flags = linfo->flags;
++                free(linfo);
+             }
+-            flags = linfo->flags;
+-            free(linfo);
+ 
+             /* We don't need to iterate further. */
+             break;
+         }
+ 
+-        if (flags & GPIOLINE_FLAG_KERNEL) {
++        if ((plat->chardev_ver != 2) && (flags & GPIOLINE_FLAG_KERNEL)) {
+             syslog(LOG_ERR, "[GPIOD_INTERFACE]: cannot read gpio direction. Line used by kernel.");
+             return MRAA_ERROR_UNSPECIFIED;
+         }
+ 
+-        *dir = flags & GPIOLINE_FLAG_IS_OUT ? MRAA_GPIO_OUT : MRAA_GPIO_IN;
++        if (plat->chardev_ver == 2) {
++            *dir = flags & GPIO_V2_LINE_FLAG_OUTPUT ? MRAA_GPIO_OUT : MRAA_GPIO_IN;
++        } else {
++            *dir = flags & GPIOLINE_FLAG_IS_OUT ? MRAA_GPIO_OUT : MRAA_GPIO_IN;
++        }
+     } else {
+         char filepath[MAX_SIZE];
+         int fd;
+@@ -1461,7 +1695,7 @@ mraa_gpio_read(mraa_gpio_context dev)
+         return dev->advance_func->gpio_read_replace(dev);
+     }
+ 
+-    if (plat->chardev_capable) {
++    if (plat->chardev_ver) {
+         int output_values[1] = { 0 };
+ 
+         if (mraa_gpio_read_multi(dev, output_values) != MRAA_SUCCESS)
+@@ -1501,7 +1735,7 @@ mraa_gpio_read_multi(mraa_gpio_context dev, int output_values[])
+         return -1;
+     }
+ 
+-    if (plat->chardev_capable) {
++    if (plat->chardev_ver) {
+         memset(output_values, 0, dev->num_pins * sizeof(int));
+ 
+         mraa_gpiod_group_t gpio_iter;
+@@ -1509,22 +1743,32 @@ mraa_gpio_read_multi(mraa_gpio_context dev, int output_values[])
+         for_each_gpio_group(gpio_iter, dev)
+         {
+             int status;
+-            unsigned flags = GPIOHANDLE_REQUEST_INPUT;
+ 
+-            if (gpio_iter->gpiod_handle <= 0) {
+-                gpio_iter->gpiod_handle = mraa_get_lines_handle(gpio_iter->dev_fd, gpio_iter->gpio_lines,
+-                                                                gpio_iter->num_gpio_lines, flags, 0);
++            if (plat->chardev_ver == 2) {
++                status = mraa_gpiod_get_values(gpio_iter->line_request_fd,
++                                               gpio_iter->num_gpio_lines, gpio_iter->rw_values);
++                if (status < 0) {
++                    syslog(LOG_ERR, "[GPIOD_INTERFACE]: error reading gpio");
++                    return MRAA_ERROR_INVALID_RESOURCE;
++                }
++            } else {
++                unsigned flags = GPIOHANDLE_REQUEST_INPUT;
++
+                 if (gpio_iter->gpiod_handle <= 0) {
+-                    syslog(LOG_ERR, "[GPIOD_INTERFACE]: error getting gpio line handle");
+-                    return MRAA_ERROR_INVALID_HANDLE;
++                    gpio_iter->gpiod_handle = mraa_get_lines_handle(gpio_iter->dev_fd, gpio_iter->gpio_lines,
++                                                                    gpio_iter->num_gpio_lines, flags, 0);
++                    if (gpio_iter->gpiod_handle <= 0) {
++                        syslog(LOG_ERR, "[GPIOD_INTERFACE]: error getting gpio line handle");
++                        return MRAA_ERROR_INVALID_HANDLE;
++                    }
+                 }
+-            }
+ 
+-            status =
+-            mraa_get_line_values(gpio_iter->gpiod_handle, gpio_iter->num_gpio_lines, gpio_iter->rw_values);
+-            if (status < 0) {
+-                syslog(LOG_ERR, "[GPIOD_INTERFACE]: error writing gpio");
+-                return MRAA_ERROR_INVALID_RESOURCE;
++                status = mraa_get_line_values(gpio_iter->gpiod_handle, gpio_iter->num_gpio_lines,
++                                              gpio_iter->rw_values);
++                if (status < 0) {
++                    syslog(LOG_ERR, "[GPIOD_INTERFACE]: error writing gpio");
++                    return MRAA_ERROR_INVALID_RESOURCE;
++                }
+             }
+ 
+             /* Write values back to the user provided array. */
+@@ -1571,7 +1815,7 @@ mraa_gpio_write(mraa_gpio_context dev, int value)
+         return dev->advance_func->gpio_write_replace(dev, value);
+     }
+ 
+-    if (plat->chardev_capable) {
++    if (plat->chardev_ver) {
+         int input_values[1] = { value };
+ 
+         return mraa_gpio_write_multi(dev, input_values);
+@@ -1614,7 +1858,7 @@ mraa_gpio_write_multi(mraa_gpio_context dev, int input_values[])
+         return MRAA_ERROR_INVALID_HANDLE;
+     }
+ 
+-    if (plat->chardev_capable) {
++    if (plat->chardev_ver) {
+         mraa_gpiod_group_t gpio_iter;
+ 
+         int* counters = calloc(dev->num_chips, sizeof(int));
+@@ -1634,22 +1878,31 @@ mraa_gpio_write_multi(mraa_gpio_context dev, int input_values[])
+         for_each_gpio_group(gpio_iter, dev)
+         {
+             int status;
+-            unsigned flags = GPIOHANDLE_REQUEST_OUTPUT;
++            if (plat->chardev_ver == 2) {
++                status = mraa_gpiod_set_values(gpio_iter->line_request_fd,
++                                               gpio_iter->num_gpio_lines, gpio_iter->rw_values);
++                if (status < 0) {
++                    syslog(LOG_ERR, "[GPIOD_INTERFACE]: error writing gpio");
++                    return MRAA_ERROR_INVALID_RESOURCE;
++                }
++            } else {
++                unsigned flags = GPIOHANDLE_REQUEST_OUTPUT;
+ 
+-            if (gpio_iter->gpiod_handle <= 0) {
+-                gpio_iter->gpiod_handle = mraa_get_lines_handle(gpio_iter->dev_fd, gpio_iter->gpio_lines,
+-                                                                gpio_iter->num_gpio_lines, flags, 0);
+                 if (gpio_iter->gpiod_handle <= 0) {
+-                    syslog(LOG_ERR, "[GPIOD_INTERFACE]: error getting gpio line handle");
+-                    return MRAA_ERROR_INVALID_HANDLE;
++                    gpio_iter->gpiod_handle = mraa_get_lines_handle(gpio_iter->dev_fd, gpio_iter->gpio_lines,
++                                                                    gpio_iter->num_gpio_lines, flags, 0);
++                    if (gpio_iter->gpiod_handle <= 0) {
++                        syslog(LOG_ERR, "[GPIOD_INTERFACE]: error getting gpio line handle");
++                        return MRAA_ERROR_INVALID_HANDLE;
++                    }
+                 }
+-            }
+ 
+-            status =
+-            mraa_set_line_values(gpio_iter->gpiod_handle, gpio_iter->num_gpio_lines, gpio_iter->rw_values);
+-            if (status < 0) {
+-                syslog(LOG_ERR, "[GPIOD_INTERFACE]: error writing gpio");
+-                return MRAA_ERROR_INVALID_RESOURCE;
++                status = mraa_set_line_values(gpio_iter->gpiod_handle, gpio_iter->num_gpio_lines,
++                                              gpio_iter->rw_values);
++                if (status < 0) {
++                    syslog(LOG_ERR, "[GPIOD_INTERFACE]: error writing gpio");
++                    return MRAA_ERROR_INVALID_RESOURCE;
++                }
+             }
+         }
+     } else {
+@@ -1754,7 +2007,7 @@ mraa_gpio_close(mraa_gpio_context dev)
+     /* Free any ISRs */
+     mraa_gpio_isr_exit(dev);
+ 
+-    if (plat && plat->chardev_capable) {
++    if (plat && plat->chardev_ver) {
+         _mraa_free_gpio_groups(dev);
+ 
+         free(dev);
+@@ -1832,6 +2085,60 @@ mraa_gpio_get_pin_raw(mraa_gpio_context dev)
+     return dev->pin;
+ }
+ 
++mraa_result_t
++mraa_gpio_input_mode_chardev(mraa_gpio_context dev, mraa_gpio_input_mode_t mode)
++{
++    mraa_gpiod_group_t gpio_group;
++    unsigned long flags = 0;
++    int ret;
++
++    for_each_gpio_group(gpio_group, dev)
++    {
++        ret = mraa_gpiod_get_line_flags(gpio_group->dev_fd, gpio_group->gpio_lines[0], &flags);
++        if (ret != 0) {
++            syslog(LOG_ERR, "[GPIOD_INTERFACE]: error getting line flags");
++            return MRAA_ERROR_INVALID_RESOURCE;
++        }
++
++        if ((flags & GPIO_V2_LINE_FLAG_INPUT) == 0) {
++            syslog(LOG_ERR, "[GPIOD_INTERFACE]: error setting line input mode. Line is not "
++                            "configured as input.");
++            return MRAA_ERROR_INVALID_RESOURCE;
++        }
++
++        switch (mode) {
++            case MRAA_GPIO_ACTIVE_HIGH:
++                if ((flags & GPIO_V2_LINE_FLAG_ACTIVE_LOW) == 0) {
++                    syslog(LOG_DEBUG, "[GPIOD_INTERFACE]: Line is already active high.");
++                    return MRAA_SUCCESS;
++                }
++                flags &= ~GPIO_V2_LINE_FLAG_ACTIVE_LOW;
++                break;
++            case MRAA_GPIO_ACTIVE_LOW:
++                if (flags & GPIO_V2_LINE_FLAG_ACTIVE_LOW) {
++                    syslog(LOG_DEBUG, "[GPIOD_INTERFACE]: Line is already active low.");
++                    return MRAA_SUCCESS;
++                }
++                flags |= GPIO_V2_LINE_FLAG_ACTIVE_LOW;
++                break;
++            default:
++                return MRAA_ERROR_FEATURE_NOT_IMPLEMENTED;
++        }
++
++        flags &= ~GPIO_V2_LINE_FLAG_USED;
++
++        ret = mraa_gpiod_reconfig_lines(gpio_group->line_request_fd, flags);
++        if (ret != 0) {
++            syslog(LOG_ERR, "[GPIOD_INTERFACE]: error reconfiguring line flags: %d", ret);
++            return MRAA_ERROR_INVALID_RESOURCE;
++        }
++
++        break;
++    }
++
++    return MRAA_SUCCESS;
++}
++
+ mraa_result_t
+ mraa_gpio_input_mode(mraa_gpio_context dev, mraa_gpio_input_mode_t mode)
+ {
+@@ -1840,6 +2147,10 @@ mraa_gpio_input_mode(mraa_gpio_context dev, mraa_gpio_input_mode_t mode)
+         return MRAA_ERROR_INVALID_HANDLE;
+     }
+ 
++    if (plat->chardev_ver == 2) {
++        return mraa_gpio_input_mode_chardev(dev, mode);
++    }
++
+     char filepath[MAX_SIZE];
+     snprintf(filepath, MAX_SIZE, SYSFS_CLASS_GPIO "/gpio%d/active_low", dev->pin);
+ 
+diff --git a/src/gpio/gpio_chardev.c b/src/gpio/gpio_chardev.c
+index 0c4636ea0701..a3e8882eddb4 100644
+--- a/src/gpio/gpio_chardev.c
++++ b/src/gpio/gpio_chardev.c
+@@ -109,6 +109,10 @@ _mraa_close_gpio_desc(mraa_gpio_context dev)
+ {
+     mraa_gpiod_group_t gpio_iter;
+ 
++    if (plat->chardev_ver == 2) {
++        return;
++    }
++
+     for_each_gpio_group(gpio_iter, dev)
+     {
+         if (gpio_iter->gpiod_handle != -1) {
+diff --git a/src/gpio/gpio_chardev_v2.c b/src/gpio/gpio_chardev_v2.c
+new file mode 100644
+index 000000000000..d1d4defbb894
+--- /dev/null
++++ b/src/gpio/gpio_chardev_v2.c
+@@ -0,0 +1,185 @@
++/*
++ * Author: Baocheng Su <baocheng.su@siemens.com>
++ * Copyright (c) 2026 Siemens AG
++ *
++ * SPDX-License-Identifier: MIT
++ */
++
++#include "gpio/gpio_chardev_v2.h"
++#include "linux/gpio.h"
++#include "mraa_internal.h"
++
++#include <string.h>
++
++int
++mraa_gpiod_get_lines_request(int chip_fd, unsigned int line_offsets[], unsigned num_lines)
++{
++    struct gpio_v2_line_config config;
++    struct gpio_v2_line_request req;
++
++    memset(&config, 0, sizeof(config));
++    memset(&req, 0, sizeof(req));
++    req.config = config;
++    strcpy(req.consumer, "mraa");
++    req.num_lines = num_lines;
++    memcpy(req.offsets, line_offsets, num_lines * sizeof(unsigned int));
++
++    int status = _mraa_gpiod_ioctl(chip_fd, GPIO_V2_GET_LINE_IOCTL, &req);
++    if (status < 0) {
++        syslog(LOG_ERR, "gpiod: ioctl() GPIO_V2_GET_LINE_IOCTL fail");
++        return status;
++    }
++
++    return req.fd;
++}
++
++int
++mraa_gpiod_get_line_name(int chip_fd, unsigned line_offset, char* name, size_t name_size)
++{
++    struct gpio_v2_line_info info;
++
++    memset(&info, 0, sizeof(info));
++    info.offset = line_offset;
++
++    int status = _mraa_gpiod_ioctl(chip_fd, GPIO_V2_GET_LINEINFO_IOCTL, &info);
++    if (status < 0) {
++        syslog(LOG_ERR, "[GPIOD_INTERFACE]: ioctl() GPIO_V2_GET_LINEINFO_IOCTL fail");
++        return status;
++    }
++
++    strncpy(name, info.name, name_size);
++    name[name_size - 1] = '\0';
++
++    return status;
++}
++
++int
++mraa_gpiod_get_line_flags(int chip_fd, unsigned line_offset, unsigned long* flag)
++{
++    struct gpio_v2_line_info info;
++
++    memset(&info, 0, sizeof(info));
++    info.offset = line_offset;
++
++    int status = _mraa_gpiod_ioctl(chip_fd, GPIO_V2_GET_LINEINFO_IOCTL, &info);
++    if (status < 0) {
++        syslog(LOG_ERR, "[GPIOD_INTERFACE]: ioctl() GPIO_V2_GET_LINEINFO_IOCTL fail");
++    }
++
++    *flag = info.flags;
++
++    return status;
++}
++
++
++int
++mraa_gpiod_find_gpio_line_by_name(const char* name, unsigned* chip_number, unsigned* line_number)
++{
++    char line_name[GPIO_MAX_NAME_SIZE];
++    mraa_gpiod_chip_info** cinfos;
++    mraa_gpiod_chip_info* cinfo;
++    int ret = -1;
++
++    int num_chips = mraa_get_chip_infos(&cinfos);
++    if (num_chips < 0) {
++        return -1;
++    }
++
++    for_each_gpio_chip(cinfo, cinfos, num_chips)
++    {
++        for (int i = 0; i < cinfo->chip_info.lines; i++) {
++            ret = mraa_gpiod_get_line_name(cinfo->chip_fd, i, line_name, GPIO_MAX_NAME_SIZE);
++            if (ret < 0) {
++                syslog(LOG_ERR, "[GPIOD_INTERFACE]: error getting line name for chip %d line %d", idx, i);
++                continue;
++            }
++
++            if (!strncmp(line_name, name, GPIO_MAX_NAME_SIZE)) {
++                if (chip_number) {
++                    /* idx is coming from `for_each_gpio_chip` definition */
++                    *chip_number = idx;
++                }
++
++                if (line_number) {
++                    *line_number = i;
++                }
++
++                ret = 0;
++                goto out;
++            }
++
++        }
++    }
++
++out:
++    for_each_gpio_chip(cinfo, cinfos, num_chips)
++    {
++        if (cinfo)
++            close(cinfo->chip_fd);
++    }
++    free(cinfos);
++    return ret;
++}
++
++int
++mraa_gpiod_get_values(int line_req_fd, unsigned num_lines, unsigned char line_values[])
++{
++    struct gpio_v2_line_values values;
++
++    memset(&values, 0, sizeof(values));
++
++    for (unsigned i = 0; i < num_lines; i++) {
++        values.mask |= (1ULL << i);
++    }
++
++    int status = _mraa_gpiod_ioctl(line_req_fd, GPIO_V2_LINE_GET_VALUES_IOCTL, &values);
++    if (status < 0) {
++        syslog(LOG_ERR, "[GPIOD_INTERFACE]: ioctl() GPIO_V2_LINE_GET_VALUES_IOCTL fail");
++        return status;
++    }
++
++    for (unsigned i = 0; i < num_lines; i++) {
++        line_values[i] = (values.bits & (1ULL << i)) ? 1 : 0;
++    }
++
++    return status;
++}
++
++int
++mraa_gpiod_set_values(int line_req_fd, unsigned num_lines, unsigned char line_values[])
++{
++    struct gpio_v2_line_values values;
++
++    memset(&values, 0, sizeof(values));
++    for (unsigned i = 0; i < num_lines; i++) {
++        if (line_values[i]) {
++            values.bits |= (1ULL << i);
++        }
++        values.mask |= (1ULL << i);
++    }
++
++    int status = _mraa_gpiod_ioctl(line_req_fd, GPIO_V2_LINE_SET_VALUES_IOCTL, &values);
++    if (status < 0) {
++        syslog(LOG_ERR, "[GPIOD_INTERFACE]: ioctl() GPIO_V2_LINE_SET_VALUES_IOCTL fail");
++        return status;
++    }
++
++    return status;
++}
++
++int
++mraa_gpiod_reconfig_lines(int line_req_fd, unsigned long flag)
++{
++    struct gpio_v2_line_config config;
++
++    memset(&config, 0, sizeof(config));
++    config.flags = flag;
++
++    int status = _mraa_gpiod_ioctl(line_req_fd, GPIO_V2_LINE_SET_CONFIG_IOCTL, &config);
++    if (status < 0) {
++        syslog(LOG_ERR, "[GPIOD_INTERFACE]: ioctl() GPIO_V2_LINE_SET_CONFIG_IOCTL fail");
++        return status;
++    }
++
++    return status;
++}
+diff --git a/src/mraa.c b/src/mraa.c
+index 927d9ab4af9b..fb7ee96d2452 100644
+--- a/src/mraa.c
++++ b/src/mraa.c
+@@ -95,11 +95,11 @@ mraa_is_kernel_chardev_interface_compatible()
+     return 1;
+ }
+ 
+-mraa_boolean_t
+-mraa_is_platform_chardev_interface_capable()
++static mraa_boolean_t
++mraa_check_chardev_ver()
+ {
+-    if ((plat != NULL) && (plat->chardev_capable)) {
+-        return mraa_is_kernel_chardev_interface_compatible();
++    if ((plat != NULL) && (plat->chardev_ver)) {
++        return (mraa_is_kernel_chardev_interface_compatible()) ? plat->chardev_ver : 0;
+     }
+ 
+     syslog(LOG_NOTICE, "gpio: platform doesn't support chardev, falling back to sysfs");
+@@ -229,8 +229,8 @@ imraa_init()
+         return MRAA_ERROR_NO_RESOURCES;
+     }
+ 
+-    plat->chardev_capable = mraa_is_platform_chardev_interface_capable();
+-    if (plat->chardev_capable) {
++    plat->chardev_ver = mraa_check_chardev_ver();
++    if (plat->chardev_ver) {
+         syslog(LOG_NOTICE, "gpio: support for chardev interface is activated");
+     }
+ 
+diff --git a/src/x86/adlink-ipi.c b/src/x86/adlink-ipi.c
+index 849c463d3388..858f1e5f1e63 100644
+--- a/src/x86/adlink-ipi.c
++++ b/src/x86/adlink-ipi.c
+@@ -860,7 +860,7 @@ mraa_board_t* mraa_lec_al_board()
+ 
+ 	b->phy_pin_count = MRAA_LEC_AL_PINCOUNT;
+ 	b->gpio_count = MRAA_LEC_AL_GPIOCOUNT;
+-	b->chardev_capable = 0;
++	b->chardev_ver = 0;
+ 
+ 	b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * MRAA_LEC_AL_PINCOUNT);
+ 	if (b->pins == NULL) {
+diff --git a/src/x86/iei_tank.c b/src/x86/iei_tank.c
+index 0eee4b723bf0..a2117ef6ce47 100644
+--- a/src/x86/iei_tank.c
++++ b/src/x86/iei_tank.c
+@@ -26,7 +26,7 @@ mraa_iei_tank()
+ 
+     b->platform_name = PLATFORM_NAME;
+     b->phy_pin_count = MRAA_IEI_TANK_PINCOUNT;
+-    b->chardev_capable = 1;
++    b->chardev_ver = 1;
+ 
+     b->adv_func = (mraa_adv_func_t*) calloc(1, sizeof(mraa_adv_func_t));
+     if (b->adv_func == NULL) {
+diff --git a/src/x86/intel_ilk.c b/src/x86/intel_ilk.c
+index e71817d91535..dc9409bd5782 100644
+--- a/src/x86/intel_ilk.c
++++ b/src/x86/intel_ilk.c
+@@ -48,7 +48,7 @@ mraa_intel_ilk()
+         goto error;
+     }
+ 
+-    b->chardev_capable = 1;
++    b->chardev_ver = 1;
+ 
+     // UART-1
+     b->uart_dev_count = 1;
+diff --git a/src/x86/intel_joule_expansion.c b/src/x86/intel_joule_expansion.c
+index 99d747716898..92c0067ef269 100644
+--- a/src/x86/intel_joule_expansion.c
++++ b/src/x86/intel_joule_expansion.c
+@@ -26,7 +26,7 @@ mraa_joule_expansion_board()
+ 
+     b->platform_name = PLATFORM_NAME;
+     b->phy_pin_count = MRAA_INTEL_JOULE_EXPANSION_PINCOUNT;
+-    b->chardev_capable = 1;
++    b->chardev_ver = 1;
+     b->aio_count = 0;
+     b->adc_raw = 0;
+     b->adc_supported = 0;
+diff --git a/src/x86/intel_minnow_byt_compatible.c b/src/x86/intel_minnow_byt_compatible.c
+index 6b61cf22d50a..dc6867842295 100644
+--- a/src/x86/intel_minnow_byt_compatible.c
++++ b/src/x86/intel_minnow_byt_compatible.c
+@@ -87,7 +87,7 @@ mraa_intel_minnowboard_byt_compatible(mraa_boolean_t turbot)
+         b->platform_version = "Ax";
+         b->gpio_count = b->phy_pin_count = MRAA_INTEL_MINNOW_MAX_PINCOUNT;
+     }
+-    b->chardev_capable = 1;
++    b->chardev_ver = 1;
+ 
+     b->pins = (mraa_pininfo_t*) calloc((size_t) b->phy_pin_count, sizeof(mraa_pininfo_t));
+     if (b->pins == NULL) {
+diff --git a/src/x86/up2.c b/src/x86/up2.c
+index f27068723f83..347438a616ed 100644
+--- a/src/x86/up2.c
++++ b/src/x86/up2.c
+@@ -101,7 +101,7 @@ mraa_up2_board()
+     b->platform_version = PLATFORM_VERSION;
+     b->phy_pin_count = MRAA_UP2_PINCOUNT;
+     b->gpio_count = MRAA_UP2_GPIOCOUNT;
+-    b->chardev_capable = 1;
++    b->chardev_ver = 1;
+ 
+     b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * MRAA_UP2_PINCOUNT);
+     if (b->pins == NULL) {
+diff --git a/src/x86/up_xtreme.c b/src/x86/up_xtreme.c
+index f1408f9c00bb..8acc4afce263 100644
+--- a/src/x86/up_xtreme.c
++++ b/src/x86/up_xtreme.c
+@@ -120,7 +120,7 @@ mraa_upxtreme_board()
+     b->platform_version = PLATFORM_VERSION;
+     b->phy_pin_count = MRAA_UPXTREME_PINCOUNT;
+     b->gpio_count = MRAA_UPXTREME_GPIOCOUNT;
+-    b->chardev_capable = 0;
++    b->chardev_ver = 0;
+ 
+     b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * MRAA_UPXTREME_PINCOUNT);
+     if (b->pins == NULL) {

--- a/meta/recipes-app/mraa/files/0017-iot2050-add-GPIO-chardev-v2-and-revision-aware-pinmu.patch
+++ b/meta/recipes-app/mraa/files/0017-iot2050-add-GPIO-chardev-v2-and-revision-aware-pinmu.patch
@@ -1,0 +1,2176 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Baocheng Su <baocheng.su@siemens.com>
+Date: Thu, 9 Jul 2026 16:33:52 +0800
+Subject: [PATCH] iot2050: add GPIO chardev v2 and revision-aware pinmux
+ support
+
+Add GPIO character device v2 support for IOT2050 GPIO and IO
+expander handling.
+
+Replace the fixed pinmux table with board-specific pin mappings,
+support revision-dependent pinmux configuration, and configure GPIO
+bias modes through the GPIO chardev v2 interface.
+
+Signed-off-by: Baocheng Su <baocheng.su@siemens.com>
+---
+ src/arm/siemens/iot2050.c | 1857 ++++++++++++++-----------------------
+ 1 file changed, 683 insertions(+), 1174 deletions(-)
+
+diff --git a/src/arm/siemens/iot2050.c b/src/arm/siemens/iot2050.c
+index df60ed0e51e0..4431110493fe 100644
+--- a/src/arm/siemens/iot2050.c
++++ b/src/arm/siemens/iot2050.c
+@@ -21,24 +21,26 @@
+  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  */
++#include <errno.h>
++#include <limits.h>
++#include <mraa/types.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <sys/ioctl.h>
+ #include <sys/mman.h>
+-#include <limits.h>
+-#include <mraa/types.h>
+ 
+-#include "common.h"
+-#include "gpio/gpio_chardev.h"
+ #include "arm/siemens/iot2050.h"
+ #include "arm/siemens/platform.h"
++#include "common.h"
++#include "gpio/gpio_chardev.h"
++#include "gpio/gpio_chardev_v2.h"
+ 
+ #define PINMUX_GROUP_MAIN       (0)
+ #define PINMUX_GROUP_WAKUP      (1)
+ 
+ typedef struct {
+     uint8_t     group;
+-    uint16_t    index;
+-    uint16_t    pinmap;
++    uint16_t index;
+     int8_t      mode[MAX_MUX_REGISTER_MODE];
+     const char *debugfs_path[MAX_MUX_REGISTER_MODE];
+     const char *pmx_function[MAX_MUX_REGISTER_MODE];
+@@ -46,7 +48,134 @@ typedef struct {
+ }regmux_info_t;
+ 
+ static void *pinmux_instance = NULL;
+-static regmux_info_t pinmux_info[MRAA_IOT2050_PINCOUNT];
++static regmux_info_t* pinmux_info[MRAA_IOT2050_PINCOUNT] = {
++    [0] = &(regmux_info_t) { PINMUX_GROUP_WAKUP,
++                             17,
++                             { 7, 4, -1, -1, -1 },
++                             { "4301c000.pinctrl-pinctrl-single", "4301c000.pinctrl-pinctrl-single", NULL, NULL, NULL },
++                             { "d0-gpio", "d0-uart0-rxd", NULL, NULL, NULL },
++                             { "d0-gpio", "d0-uart0-rxd", NULL, NULL, NULL } },
++    [1] = &(regmux_info_t) { PINMUX_GROUP_WAKUP,
++                             18,
++                             { 7, 4, -1, -1, -1 },
++                             { "4301c000.pinctrl-pinctrl-single", "4301c000.pinctrl-pinctrl-single", NULL, NULL, NULL },
++                             { "d1-gpio", "d1-uart0-txd", NULL, NULL, NULL },
++                             { "d1-gpio", "d1-uart0-txd", NULL, NULL, NULL } },
++    [2] = &(regmux_info_t) { PINMUX_GROUP_WAKUP,
++                             19,
++                             { 7, 4, -1, -1, -1 },
++                             { "4301c000.pinctrl-pinctrl-single", "4301c000.pinctrl-pinctrl-single", NULL, NULL, NULL },
++                             { "d2-gpio", "d2-uart0-ctsn", NULL, NULL, NULL },
++                             { "d2-gpio", "d2-uart0-ctsn", NULL, NULL, NULL } },
++    [3] = &(regmux_info_t) { PINMUX_GROUP_WAKUP,
++                             21,
++                             { 7, 4, -1, -1, -1 },
++                             { "4301c000.pinctrl-pinctrl-single", "4301c000.pinctrl-pinctrl-single", NULL, NULL, NULL },
++                             { "d3-gpio", "d3-uart0-rtsn", NULL, NULL, NULL },
++                             { "d3-gpio", "d3-uart0-rtsn", NULL, NULL, NULL } },
++    [4] = &(regmux_info_t) { PINMUX_GROUP_MAIN,
++                             33,
++                             { 7, 5, -1, -1, -1 },
++                             { "11c000.pinctrl-pinctrl-single", "11c000.pinctrl-pinctrl-single", NULL, NULL, NULL },
++                             { "d4-gpio", "d4-ehrpwm0-a", NULL, NULL, NULL },
++                             { "d4-gpio", "d4-ehrpwm0-a", NULL, NULL, NULL } },
++    [5] = &(regmux_info_t) { PINMUX_GROUP_MAIN,
++                             35,
++                             { 7, 5, -1, -1, -1 },
++                             { "11c000.pinctrl-pinctrl-single", "11c000.pinctrl-pinctrl-single", NULL, NULL, NULL },
++                             { "d5-gpio", "d5-ehrpwm1-a", NULL, NULL, NULL },
++                             { "d5-gpio", "d5-ehrpwm1-a", NULL, NULL, NULL } },
++    [6] = &(regmux_info_t) { PINMUX_GROUP_MAIN,
++                             38,
++                             { 7, 5, -1, -1, -1 },
++                             { "11c000.pinctrl-pinctrl-single", "11c000.pinctrl-pinctrl-single", NULL, NULL, NULL },
++                             { "d6-gpio", "d6-ehrpwm2-a", NULL, NULL, NULL },
++                             { "d6-gpio", "d6-ehrpwm2-a", NULL, NULL, NULL } },
++    [7] = &(regmux_info_t) { PINMUX_GROUP_MAIN,
++                             43,
++                             { 7, 5, -1, -1, -1 },
++                             { "11c000.pinctrl-pinctrl-single", "11c000.pinctrl-pinctrl-single", NULL, NULL, NULL },
++                             { "d7-gpio", "d7-ehrpwm3-a", NULL, NULL, NULL },
++                             { "d7-gpio", "d7-ehrpwm3-a", NULL, NULL, NULL } },
++    [8] = &(regmux_info_t) { PINMUX_GROUP_MAIN,
++                             48,
++                             { 7, 5, -1, -1, -1 },
++                             { "11c000.pinctrl-pinctrl-single", "11c000.pinctrl-pinctrl-single", NULL, NULL, NULL },
++                             { "d8-gpio", "d8-ehrpwm4-a", NULL, NULL, NULL },
++                             { "d8-gpio", "d8-ehrpwm4-a", NULL, NULL, NULL } },
++    [9] = &(regmux_info_t) { PINMUX_GROUP_MAIN,
++                             51,
++                             { 7, 5, -1, -1, -1 },
++                             { "11c000.pinctrl-pinctrl-single", "11c000.pinctrl-pinctrl-single", NULL, NULL, NULL },
++                             { "d9-gpio", "d9-ehrpwm5-a", NULL, NULL, NULL },
++                             { "d9-gpio", "d9-ehrpwm5-a", NULL, NULL, NULL } },
++    [10] = &(regmux_info_t) { PINMUX_GROUP_WAKUP,
++                              39,
++                              { 7, 0, -1, -1, -1 },
++                              { "4301c000.pinctrl-pinctrl-single",
++                                "4301c000.pinctrl-pinctrl-single", NULL, NULL, NULL },
++                              { "d10-gpio", "d10-spi0-cs0", NULL, NULL, NULL },
++                              { "d10-gpio", "d10-spi0-cs0", NULL, NULL, NULL } },
++    [11] = &(regmux_info_t) { PINMUX_GROUP_WAKUP,
++                              37,
++                              { 7, 0, -1, -1, -1 },
++                              { "4301c000.pinctrl-pinctrl-single",
++                                "4301c000.pinctrl-pinctrl-single", NULL, NULL, NULL },
++                              { "d11-gpio", "d11-spi0-d0", NULL, NULL, NULL },
++                              { "d11-gpio", "d11-spi0-d0", NULL, NULL, NULL } },
++    [12] = &(regmux_info_t) { PINMUX_GROUP_WAKUP,
++                              38,
++                              { 7, 0, -1, -1, -1 },
++                              { "4301c000.pinctrl-pinctrl-single",
++                                "4301c000.pinctrl-pinctrl-single", NULL, NULL, NULL },
++                              { "d12-gpio", "d12-spi0-d1", NULL, NULL, NULL },
++                              { "d12-gpio", "d12-spi0-d1", NULL, NULL, NULL } },
++    [13] = &(regmux_info_t) { PINMUX_GROUP_WAKUP,
++                              36,
++                              { 7, 0, -1, -1, -1 },
++                              { "4301c000.pinctrl-pinctrl-single",
++                                "4301c000.pinctrl-pinctrl-single", NULL, NULL, NULL },
++                              { "d13-gpio", "d13-spi0-clk", NULL, NULL, NULL },
++                              { "d13-gpio", "d13-spi0-clk", NULL, NULL, NULL } },
++    [14] = &(regmux_info_t) { PINMUX_GROUP_WAKUP,
++                              33,
++                              { 7, -1, -1, -1, -1 },
++                              { "4301c000.pinctrl-pinctrl-single", NULL, NULL, NULL, NULL },
++                              { "a0-gpio", NULL, NULL, NULL, NULL },
++                              { "a0-gpio", NULL, NULL, NULL, NULL } },
++    [15] = &(regmux_info_t) { PINMUX_GROUP_WAKUP,
++                              32,
++                              { 7, -1, -1, -1, -1 },
++                              { "4301c000.pinctrl-pinctrl-single", NULL, NULL, NULL, NULL },
++                              { "a1-gpio", NULL, NULL, NULL, NULL },
++                              { "a1-gpio", NULL, NULL, NULL, NULL } },
++    [16] = &(regmux_info_t) { PINMUX_GROUP_WAKUP,
++                              31,
++                              { 7, -1, -1, -1, -1 },
++                              { "4301c000.pinctrl-pinctrl-single", NULL, NULL, NULL, NULL },
++                              { "a2-gpio", NULL, NULL, NULL, NULL },
++                              { "a2-gpio", NULL, NULL, NULL, NULL } },
++    [17] = &(regmux_info_t) { PINMUX_GROUP_WAKUP,
++                              27,
++                              { 7, -1, -1, -1, -1 },
++                              { "4301c000.pinctrl-pinctrl-single", NULL, NULL, NULL, NULL },
++                              { "a3-gpio", NULL, NULL, NULL, NULL },
++                              { "a3-gpio", NULL, NULL, NULL, NULL } },
++    [18] = &(regmux_info_t) { PINMUX_GROUP_WAKUP,
++                              30,
++                              { 7, -1, 0, -1, -1 },
++                              { "4301c000.pinctrl-pinctrl-single", NULL, NULL, NULL, NULL },
++                              { "a4-gpio", NULL, NULL, NULL, NULL },
++                              { "a4-gpio", NULL, NULL, NULL, NULL } },
++    [19] = &(regmux_info_t) { PINMUX_GROUP_WAKUP,
++                              23,
++                              { 7, -1, 0, -1, -1 },
++                              { "4301c000.pinctrl-pinctrl-single", NULL, NULL, NULL, NULL },
++                              { "a5-gpio", NULL, NULL, NULL, NULL },
++                              { "a5-gpio", NULL, NULL, NULL, NULL } }
++};
++static regmux_info_t* pinmux_info_rev[MRAA_IOT2050_PINCOUNT] = { NULL };
++static regmux_info_t** pinmux_info_current;
+ static mraa_gpio_context output_en_pins[MRAA_IOT2050_PINCOUNT];
+ static int pull_en_pins[MRAA_IOT2050_PINCOUNT];
+ 
+@@ -109,20 +238,6 @@ err:
+     return -1;
+ }
+ 
+-static inline regmux_info_t*
+-iot2050_get_regmux_by_pinmap(int pinmap)
+-{
+-    int i;
+-
+-    for(i=0; i<MRAA_IOT2050_PINCOUNT; i++) {
+-        if((pinmux_info[i].mode[MUX_REGISTER_MODE_GPIO] != -1) &&
+-            (pinmux_info[i].pinmap == pinmap)) {
+-            return &pinmux_info[i];
+-        }
+-    }
+-    return NULL;
+-}
+-
+ static mraa_result_t
+ iot2050_mux_debugfs(int phy_pin, const char *base_dir, const char *group, const char *function, mraa_gpio_mode_t gpio_mode)
+ {
+@@ -181,10 +296,9 @@ err:
+ }
+ 
+ static mraa_result_t
+-iot2050_mux_mmap(int phy_pin, int mode, mraa_gpio_mode_t gpio_mode)
++iot2050_mux_mmap(const regmux_info_t* info, int mode, mraa_gpio_mode_t gpio_mode)
+ {
+     int8_t mux_mode;
+-    regmux_info_t *info = &pinmux_info[phy_pin];
+ 
+     syslog(LOG_ERR, "iot2050: mmap: Debugfs pinmux failed! Falling back to mmap!");
+ 
+@@ -199,7 +313,7 @@ iot2050_mux_mmap(int phy_pin, int mode, mraa_gpio_mode_t gpio_mode)
+         return MRAA_ERROR_FEATURE_NOT_SUPPORTED;
+     }
+ 
+-    syslog(LOG_DEBUG, "REGMUX[phy_pin %d] group %d index %d mode %d\n", phy_pin, info->group, info->index, mux_mode);
++    syslog(LOG_DEBUG, "REGMUX group %d index %d mode %d\n", info->group, info->index, mux_mode);
+ 
+     platform_pinmux_select_func(pinmux_instance, info->group, info->index, mux_mode);
+     /* Configure as input and output for default */
+@@ -222,12 +336,18 @@ iot2050_mux_mmap(int phy_pin, int mode, mraa_gpio_mode_t gpio_mode)
+ static mraa_result_t
+ iot2050_mux_init_reg(int phy_pin, int mode)
+ {
+-    regmux_info_t *info = &pinmux_info[phy_pin];
++    regmux_info_t* info;
+     int8_t mux_mode;
+     mraa_result_t ret;
+ 
+-    if((phy_pin < 0) || (phy_pin > MRAA_IOT2050_PINCOUNT) || phy_pin == 20)
++    if ((phy_pin < 0) || (phy_pin >= MRAA_IOT2050_PINCOUNT) || phy_pin == 20) {
++        return MRAA_SUCCESS;
++    }
++    if (pinmux_info_current[phy_pin] == NULL) {
+         return MRAA_SUCCESS;
++    }
++    info = pinmux_info_current[phy_pin];
++
+     if((mode < 0) || (mode >= MAX_MUX_REGISTER_MODE)) {
+         return MRAA_ERROR_FEATURE_NOT_SUPPORTED;
+     }
+@@ -242,7 +362,7 @@ iot2050_mux_init_reg(int phy_pin, int mode)
+ 
+     ret = iot2050_mux_debugfs(phy_pin, info->debugfs_path[mode], info->pmx_group[mode], info->pmx_function[mode], 0);
+     if (ret != MRAA_SUCCESS)
+-        return iot2050_mux_mmap(phy_pin, mode, 0);
++        return iot2050_mux_mmap(info, mode, 0);
+     return ret;
+ }
+ 
+@@ -295,27 +415,79 @@ failed:
+ }
+ 
+ static mraa_result_t
+-iot2050_gpio_mode_replace(mraa_gpio_context dev, mraa_gpio_mode_t mode)
++iot2050_gpio_mode_ioexpander(mraa_gpio_context dev, mraa_gpio_mode_t mode)
+ {
+-    regmux_info_t *info;
+-    mraa_gpio_context pull_en_pin;
+-    mraa_result_t ret = MRAA_SUCCESS;
++    unsigned long flags;
++    mraa_gpiod_group_t gpio_iter;
+ 
++    for_each_gpio_group(gpio_iter, dev)
++    {
++        int ret = mraa_gpiod_get_line_flags(gpio_iter->dev_fd, gpio_iter->gpio_lines[0], &flags);
++        if (ret != 0) {
++            syslog(LOG_ERR, "[IOT2050]: error getting line flags");
++            return MRAA_ERROR_INVALID_RESOURCE;
++        }
++
++        if (((mode == MRAA_GPIO_PULLUP) && (flags & GPIO_V2_LINE_FLAG_BIAS_PULL_UP)) ||
++            ((mode == MRAA_GPIO_PULLDOWN) && (flags & GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN)) ||
++            ((mode == MRAA_GPIO_HIZ || mode == MRAA_GPIO_STRONG) && (flags & GPIO_V2_LINE_FLAG_BIAS_DISABLED))) {
++            return MRAA_SUCCESS;
++        }
++
++        switch (mode) {
++            case MRAA_GPIO_PULLUP:
++                flags |= GPIO_V2_LINE_FLAG_BIAS_PULL_UP;
++                flags &= ~GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN;
++                flags &= ~GPIO_V2_LINE_FLAG_BIAS_DISABLED;
++                break;
++            case MRAA_GPIO_PULLDOWN:
++                flags |= GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN;
++                flags &= ~GPIO_V2_LINE_FLAG_BIAS_PULL_UP;
++                flags &= ~GPIO_V2_LINE_FLAG_BIAS_DISABLED;
++                break;
++            case MRAA_GPIO_HIZ:
++            case MRAA_GPIO_STRONG:
++                flags |= GPIO_V2_LINE_FLAG_BIAS_DISABLED;
++                flags &= ~GPIO_V2_LINE_FLAG_BIAS_PULL_UP;
++                flags &= ~GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN;
++                break;
++            default:
++                return MRAA_ERROR_FEATURE_NOT_IMPLEMENTED;
++        }
++
++        flags &= ~GPIO_V2_LINE_FLAG_USED;
++
++        ret = mraa_gpiod_reconfig_lines(gpio_iter->line_request_fd, flags);
++        if (ret != 0) {
++            syslog(LOG_ERR, "[IOT2050]: error reconfiguring line flags");
++            return MRAA_ERROR_INVALID_RESOURCE;
++        }
++    }
++
++    return MRAA_SUCCESS;
++}
++
++static mraa_result_t
++iot2050_gpio_mode_replace(mraa_gpio_context dev, mraa_gpio_mode_t mode)
++{
+     /* Only support mode change on interface pins */
+-    if(dev->phy_pin == -1) {
+-        ret = MRAA_ERROR_INVALID_RESOURCE;
+-        goto failed;
++    if (dev->phy_pin < 0 || dev->phy_pin >= MRAA_IOT2050_PINCOUNT) {
++        return MRAA_ERROR_INVALID_RESOURCE;
+     }
+     /* Handle mode changes for interface pins without pull pin */
+     if (pull_en_pins[dev->phy_pin] == -1) {
+-        return (mode == MRAA_GPIO_STRONG || mode == MRAA_GPIO_HIZ) ?
+-            MRAA_SUCCESS : MRAA_ERROR_FEATURE_NOT_IMPLEMENTED;
++        if (dev->phy_pin == 20) {
++            return MRAA_SUCCESS;
++        }
++        return iot2050_gpio_mode_ioexpander(dev, mode);
+     }
+-    info = iot2050_get_regmux_by_pinmap(dev->pin);
+-    pull_en_pin = mraa_gpio_init_raw(pull_en_pins[dev->phy_pin]);
++
++    mraa_result_t ret = MRAA_SUCCESS;
++
++    regmux_info_t* info = pinmux_info_current[dev->phy_pin];
++    mraa_gpio_context pull_en_pin = mraa_gpio_init_raw(pull_en_pins[dev->phy_pin]);
+     if(pull_en_pin == NULL) {
+-        ret = MRAA_ERROR_INVALID_RESOURCE;
+-        goto failed;
++        return MRAA_ERROR_INVALID_RESOURCE;
+     }
+     switch(mode) {
+         case MRAA_GPIO_PULLUP:
+@@ -326,31 +498,32 @@ iot2050_gpio_mode_replace(mraa_gpio_context dev, mraa_gpio_mode_t mode)
+             if(info) {
+                 ret = iot2050_mux_debugfs(dev->phy_pin, info->debugfs_path[0], info->pmx_group[0], info->pmx_function[0], mode);
+                 if (ret != MRAA_SUCCESS)
+-                    ret = iot2050_mux_mmap(dev->phy_pin, 0, mode);
+-
++                    ret = iot2050_mux_mmap(info, 0, mode);
+             }
+             break;
+         case MRAA_GPIO_PULLDOWN:
+-            if(mraa_gpio_dir(pull_en_pin, MRAA_GPIO_OUT_LOW) != MRAA_SUCCESS) {
++            if (mraa_gpio_dir(pull_en_pin, MRAA_GPIO_OUT_LOW) != MRAA_SUCCESS) {
+                 ret = MRAA_ERROR_INVALID_RESOURCE;
+                 goto failed;
+             }
+-            if(info) {
+-                ret = iot2050_mux_debugfs(dev->phy_pin, info->debugfs_path[0], info->pmx_group[0], info->pmx_function[0], mode);
++            if (info) {
++                ret = iot2050_mux_debugfs(dev->phy_pin, info->debugfs_path[0], info->pmx_group[0],
++                                          info->pmx_function[0], mode);
+                 if (ret != MRAA_SUCCESS)
+-                    ret = iot2050_mux_mmap(dev->phy_pin, 0, mode);
++                    ret = iot2050_mux_mmap(info, 0, mode);
+             }
+             break;
+         case MRAA_GPIO_HIZ:
+         case MRAA_GPIO_STRONG:
+-            if(mraa_gpio_dir(pull_en_pin, MRAA_GPIO_IN) != MRAA_SUCCESS) {
++            if (mraa_gpio_dir(pull_en_pin, MRAA_GPIO_IN) != MRAA_SUCCESS) {
+                 ret = MRAA_ERROR_INVALID_RESOURCE;
+                 goto failed;
+             }
+-            if(info) {
+-                ret = iot2050_mux_debugfs(dev->phy_pin, info->debugfs_path[0], info->pmx_group[0], info->pmx_function[0], mode);
++            if (info) {
++                ret = iot2050_mux_debugfs(dev->phy_pin, info->debugfs_path[0], info->pmx_group[0],
++                                          info->pmx_function[0], mode);
+                 if (ret != MRAA_SUCCESS)
+-                    ret = iot2050_mux_mmap(dev->phy_pin, 0, mode);
++                    ret = iot2050_mux_mmap(info, 0, mode);
+             }
+             break;
+         case MRAA_GPIOD_ACTIVE_LOW:
+@@ -364,7 +537,7 @@ iot2050_gpio_mode_replace(mraa_gpio_context dev, mraa_gpio_mode_t mode)
+     return ret;
+ failed:
+     syslog(LOG_ERR, "iot2050: Error setting gpio mode");
+-    if(pull_en_pin) {
++    if (pull_en_pin) {
+         mraa_gpio_close(pull_en_pin);
+     }
+     return ret;
+@@ -399,22 +572,18 @@ iot2050_gpio_init_internal_replace(mraa_gpio_context dev, int pin)
+     return MRAA_SUCCESS;
+ }
+ static inline void
+-iot2050_setup_pins(mraa_board_t *board, int pin_index, char *pin_name, mraa_pincapabilities_t cap, regmux_info_t mux_info)
++iot2050_setup_pins(mraa_board_t* board, int pin_index, char* pin_name, mraa_pincapabilities_t cap)
+ {
+     strncpy(board->pins[pin_index].name, pin_name, MRAA_PIN_NAME_SIZE);
+     board->pins[pin_index].capabilities = cap;
+-    pinmux_info[pin_index] = mux_info;
+ }
+ 
+ static inline void
+-iot2050_pin_add_gpio(mraa_board_t *board, int pin_index, int chip, int line,
+-                        int output_en_pin, int pull_en_pin, mraa_mux_t *pin_mux, int num_pinmux)
++iot2050_pin_add_gpio(mraa_board_t* board, int pin_index, int chip, int line, int output_en_pin, int pull_en_pin, mraa_mux_t* pin_mux, int num_pinmux)
+ {
+     int i;
+ 
+-    mraa_pininfo_t *pininfo = &(board->pins[pin_index]);
+-    /*for sysfs*/
+-    pininfo->gpio.pinmap = pinmux_info[pin_index].pinmap;
++    mraa_pininfo_t* pininfo = &(board->pins[pin_index]);
+     pininfo->gpio.mux_total = 0;
+     /*for gpio chardev*/
+     pininfo->gpio.gpio_chip = chip;
+@@ -559,25 +728,26 @@ mraa_board_t*
+ mraa_siemens_iot2050()
+ {
+     mraa_board_t* b = (mraa_board_t*) calloc(1, sizeof(mraa_board_t));
+-    mraa_mux_t mux_info[6];
++    mraa_mux_t mux_info[6] = { 0 };
+     int pin_index = 0;
+-    unsigned main_gpio0_chip, main_gpio0_base;
++    unsigned main_gpio0_chip;
+     unsigned wkup_gpio0_chip, wkup_gpio0_base;
+     unsigned d4200_gpio_chip, d4200_gpio_base;
+     unsigned d4201_gpio_chip, d4201_gpio_base;
+     unsigned d4202_gpio_chip, d4202_gpio_base;
+     unsigned line_offset;
+     int res;
++    int is_rev = 0;
+ 
+-    if (mraa_find_gpio_line_by_name("main_gpio0-base", &main_gpio0_chip, &line_offset) < 0 || line_offset != 0) {
+-        goto error;
++    if (mraa_file_contains("/proc/device-tree/model", "SIMATIC IOT2050 Advanced PG2 Rev") ||
++        mraa_file_contains("/proc/device-tree/model", "SIMATIC IOT2050 Advanced M2 Rev")) {
++        is_rev = 1;
+     }
+-    res = mraa_get_chip_base_by_number(main_gpio0_chip);
+-    if (res < 0) {
++    pinmux_info_current = is_rev ? pinmux_info_rev : pinmux_info;
++
++    if (mraa_find_gpio_line_by_name("main_gpio0-base", &main_gpio0_chip, &line_offset) < 0 || line_offset != 0) {
+         goto error;
+     }
+-    main_gpio0_base = res;
+-
+     if (mraa_find_gpio_line_by_name("wkup_gpio0-base", &wkup_gpio0_chip, &line_offset) < 0 || line_offset != 0) {
+         goto error;
+     }
+@@ -587,8 +757,9 @@ mraa_siemens_iot2050()
+     }
+     wkup_gpio0_base = res;
+ 
+-    /* A0-pull is line 0 in D4200 */
+-    if (mraa_find_gpio_line_by_name("A0-pull", &d4200_gpio_chip, &line_offset) < 0 || line_offset != 0) {
++    /* A0/A0-pull is line 0 in D4200 */
++    if (mraa_find_gpio_line_by_name(is_rev ? "A0" : "A0-pull", &d4200_gpio_chip, &line_offset) < 0 ||
++        line_offset != 0) {
+         goto error;
+     }
+     res = mraa_get_chip_base_by_number(d4200_gpio_chip);
+@@ -607,8 +778,9 @@ mraa_siemens_iot2050()
+     }
+     d4201_gpio_base = res;
+ 
+-    /* IO0-pull is line 0 in D4202 */
+-    if (mraa_find_gpio_line_by_name("IO0-pull", &d4202_gpio_chip, &line_offset) < 0 || line_offset != 0) {
++    /* IO0/IO0-pull is line 0 in D4202 */
++    if (mraa_find_gpio_line_by_name(is_rev ? "IO0" : "IO0-pull", &d4202_gpio_chip, &line_offset) < 0 ||
++        line_offset != 0) {
+         goto error;
+     }
+     res = mraa_get_chip_base_by_number(d4202_gpio_chip);
+@@ -623,7 +795,7 @@ mraa_siemens_iot2050()
+     memset(output_en_pins, 0, sizeof(mraa_gpio_context) * MRAA_IOT2050_PINCOUNT);
+     b->platform_name = PLATFORM_NAME;
+     b->phy_pin_count = MRAA_IOT2050_PINCOUNT;
+-    b->chardev_capable = 1;
++    b->chardev_ver = 2;
+     b->adc_raw = 12;
+     b->adc_supported = 12;
+     b->pwm_default_period = 1000; /*us*/
+@@ -644,1201 +816,552 @@ mraa_siemens_iot2050()
+         goto error;
+     }
+ 
+-    /* IO */
+-    iot2050_setup_pins(b, pin_index, "IO0",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            0,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            0,  /*spi*/
+-                            0,  /*i2c*/
+-                            0,  /*aio*/
+-                            1}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_WAKUP,
+-                            17,
+-                            wkup_gpio0_base+29,
+-                            {
+-                                7,  /*GPIO*/
+-                                4,  /*UART*/
+-                                -1, /*I2C*/
+-                                -1, /*SPI*/
+-                                -1  /*PWM*/
+-                            },
+-                            {
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "d0-gpio",
+-                                "d0-uart0-rxd",
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "d0-gpio",
+-                                "d0-uart0-rxd",
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            }
+-                        });
+-
+-    iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 29, d4201_gpio_base+0, d4202_gpio_base+0, NULL, 0);
+-    mux_info[0].pin = d4201_gpio_base+0;
++    iot2050_setup_pins(b, pin_index, "IO0", (mraa_pincapabilities_t) { 1, 1, 0, 0, 0, 0, 0, 1 });
++    if (is_rev) {
++        mux_info[0].pin = d4201_gpio_base + 0;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, d4202_gpio_chip, 0, -1, -1, mux_info, 1);
++    } else {
++        iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 29, d4201_gpio_base + 0,
++                             d4202_gpio_base + 0, NULL, 0);
++    }
++    mux_info[0].pin = d4201_gpio_base + 0;
+     mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[0].value = MRAA_GPIO_OUT_LOW;
+-    mux_info[1].pin = d4202_gpio_base+0;
++    mux_info[1].pin = d4202_gpio_base + 0;
+     mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[1].value = MRAA_GPIO_IN;
+     iot2050_pin_add_uart(b, pin_index, 0, mux_info, 2);
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "IO1",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            0,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            0,  /*spi*/
+-                            0,  /*i2c*/
+-                            0,  /*aio*/
+-                            1}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_WAKUP,
+-                            18,
+-                            wkup_gpio0_base+30,
+-                            {
+-                                7,  /*GPIO*/
+-                                4,  /*UART*/
+-                                -1, /*I2C*/
+-                                -1, /*SPI*/
+-                                -1  /*PWM*/
+-                            },
+-                            {
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "d1-gpio",
+-                                "d1-uart0-txd",
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "d1-gpio",
+-                                "d1-uart0-txd",
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            }
+-                        });
+-    iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 30, d4201_gpio_base+1, d4202_gpio_base+1, NULL, 0);
+-    mux_info[0].pin = d4201_gpio_base+1;
++    iot2050_setup_pins(b, pin_index, "IO1", (mraa_pincapabilities_t) { 1, 1, 0, 0, 0, 0, 0, 1 });
++    if (is_rev) {
++        mux_info[0].pin = d4201_gpio_base + 1;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, d4202_gpio_chip, 1, -1, -1, mux_info, 1);
++    } else {
++        iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 30, d4201_gpio_base + 1,
++                             d4202_gpio_base + 1, NULL, 0);
++    }
++    mux_info[0].pin = d4201_gpio_base + 1;
+     mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[0].value = MRAA_GPIO_OUT_HIGH;
+-    mux_info[1].pin = d4202_gpio_base+1;
++    mux_info[1].pin = d4202_gpio_base + 1;
+     mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[1].value = MRAA_GPIO_IN;
+     iot2050_pin_add_uart(b, pin_index, 0, mux_info, 2);
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "IO2",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            0,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            0,  /*spi*/
+-                            0,  /*i2c*/
+-                            0,  /*aio*/
+-                            1}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_WAKUP,
+-                            19,
+-                            wkup_gpio0_base+31,
+-                            {
+-                                7,  /*GPIO*/
+-                                4,  /*UART*/
+-                                -1, /*I2C*/
+-                                -1, /*SPI*/
+-                                -1  /*PWM*/
+-                            },
+-                            {
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "d2-gpio",
+-                                "d2-uart0-ctsn",
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "d2-gpio",
+-                                "d2-uart0-ctsn",
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            }
+-                        });
+-    iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 31, d4201_gpio_base+2, d4202_gpio_base+2, NULL, 0);
+-    mux_info[0].pin = d4201_gpio_base+2;
++    iot2050_setup_pins(b, pin_index, "IO2", (mraa_pincapabilities_t) { 1, 1, 0, 0, 0, 0, 0, 1 });
++    if (is_rev) {
++        mux_info[0].pin = d4201_gpio_base + 2;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, d4202_gpio_chip, 2, -1, -1, mux_info, 1);
++    } else {
++        iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 31, d4201_gpio_base + 2,
++                             d4202_gpio_base + 2, NULL, 0);
++    }
++    mux_info[0].pin = d4201_gpio_base + 2;
+     mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[0].value = MRAA_GPIO_OUT_LOW;
+-    mux_info[1].pin = d4202_gpio_base+2;
++    mux_info[1].pin = d4202_gpio_base + 2;
+     mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[1].value = MRAA_GPIO_IN;
+     iot2050_pin_add_uart(b, pin_index, 0, mux_info, 2);
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "IO3",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            0,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            0,  /*spi*/
+-                            0,  /*i2c*/
+-                            0,  /*aio*/
+-                            1}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_WAKUP,
+-                            21,
+-                            wkup_gpio0_base+33,
+-                            {
+-                                7,  /*GPIO*/
+-                                4,  /*UART*/
+-                                -1, /*I2C*/
+-                                -1, /*SPI*/
+-                                -1  /*PWM*/
+-                            },
+-                            {
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "d3-gpio",
+-                                "d3-uart0-rtsn",
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "d3-gpio",
+-                                "d3-uart0-rtsn",
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            }
+-                        });
+-    iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 33, d4201_gpio_base+3, d4202_gpio_base+3, NULL, 0);
+-    mux_info[0].pin = d4201_gpio_base+3;
++    iot2050_setup_pins(b, pin_index, "IO3", (mraa_pincapabilities_t) { 1, 1, 0, 0, 0, 0, 0, 1 });
++    if (is_rev) {
++        mux_info[0].pin = d4201_gpio_base + 3;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, d4202_gpio_chip, 3, -1, -1, mux_info, 1);
++    } else {
++        iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 33, d4201_gpio_base + 3,
++                             d4202_gpio_base + 3, NULL, 0);
++    }
++    mux_info[0].pin = d4201_gpio_base + 3;
+     mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[0].value = MRAA_GPIO_OUT_HIGH;
+-    mux_info[1].pin = d4202_gpio_base+3;
++    mux_info[1].pin = d4202_gpio_base + 3;
+     mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[1].value = MRAA_GPIO_IN;
+     iot2050_pin_add_uart(b, pin_index, 0, mux_info, 2);
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "IO4",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            1,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            0,  /*spi*/
+-                            0,  /*i2c*/
+-                            0,  /*aio*/
+-                            0}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_MAIN,
+-                            33,
+-                            main_gpio0_base+33,
+-                            {
+-                                7,  /*GPIO*/
+-                                -1, /*UART*/
+-                                -1, /*I2C*/
+-                                -1, /*SPI*/
+-                                5   /*PWM*/
+-                            },
+-                            {
+-                                "11c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "11c000.pinctrl-pinctrl-single"
+-                            },
+-                            {
+-                                "d4-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "d4-ehrpwm0-a"
+-                            },
+-                            {
+-                                "d4-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "d4-ehrpwm0-a"
+-                            }
+-                        });
+-    iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 33, d4201_gpio_base+4, d4202_gpio_base+4, NULL, 0);
+-    mux_info[0].pin = d4201_gpio_base+4;
++    iot2050_setup_pins(b, pin_index, "IO4", (mraa_pincapabilities_t) { 1, 1, 1, 0, 0, 0, 0, 0 });
++    if (is_rev) {
++        mux_info[0].pin = d4201_gpio_base + 4;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, d4202_gpio_chip, 4, -1, -1, mux_info, 1);
++    } else {
++        iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 33, d4201_gpio_base + 4,
++                             d4202_gpio_base + 4, NULL, 0);
++    }
++    mux_info[0].pin = d4201_gpio_base + 4;
+     mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[0].value = MRAA_GPIO_OUT_HIGH;
+-    mux_info[1].pin = d4202_gpio_base+4;
++    mux_info[1].pin = d4202_gpio_base + 4;
+     mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[1].value = MRAA_GPIO_IN;
+     iot2050_pin_add_pwm(b, pin_index, 0, 0, mux_info, 2);
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "IO5",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            1,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            0,  /*spi*/
+-                            0,  /*i2c*/
+-                            0,  /*aio*/
+-                            0}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_MAIN,
+-                            35,
+-                            main_gpio0_base+35,
+-                            {
+-                                7,  /*GPIO*/
+-                                -1, /*UART*/
+-                                -1, /*I2C*/
+-                                -1, /*SPI*/
+-                                5   /*PWM*/
+-                            },
+-                            {
+-                                "11c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "11c000.pinctrl-pinctrl-single"
+-                            },
+-                            {
+-                                "d5-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "d5-ehrpwm1-a"
+-                            },
+-                            {
+-                                "d5-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "d5-ehrpwm1-a"
+-                            }
+-                        });
+-    iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 35, d4201_gpio_base+5, d4202_gpio_base+5, NULL, 0);
+-    mux_info[0].pin = d4201_gpio_base+5;
++    iot2050_setup_pins(b, pin_index, "IO5", (mraa_pincapabilities_t) { 1, 1, 1, 0, 0, 0, 0, 0 });
++    if (is_rev) {
++        mux_info[0].pin = d4201_gpio_base + 5;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, d4202_gpio_chip, 5, -1, -1, mux_info, 1);
++    } else {
++        iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 35, d4201_gpio_base + 5,
++                             d4202_gpio_base + 5, NULL, 0);
++    }
++    mux_info[0].pin = d4201_gpio_base + 5;
+     mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[0].value = MRAA_GPIO_OUT_HIGH;
+-    mux_info[1].pin = d4202_gpio_base+5;
++    mux_info[1].pin = d4202_gpio_base + 5;
+     mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[1].value = MRAA_GPIO_IN;
+     iot2050_pin_add_pwm(b, pin_index, 1, 0, mux_info, 2);
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "IO6",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            1,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            0,  /*spi*/
+-                            0,  /*i2c*/
+-                            0,  /*aio*/
+-                            0}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_MAIN,
+-                            38,
+-                            main_gpio0_base+38,
+-                            {
+-                                7,  /*GPIO*/
+-                                -1, /*UART*/
+-                                -1, /*I2C*/
+-                                -1, /*SPI*/
+-                                5   /*PWM*/
+-                            },
+-                            {
+-                                "11c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "11c000.pinctrl-pinctrl-single"
+-                            },
+-                            {
+-                                "d6-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "d6-ehrpwm2-a"
+-                            },
+-                            {
+-                                "d6-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "d6-ehrpwm2-a"
+-                            }
+-                        });
+-    iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 38, d4201_gpio_base+6, d4202_gpio_base+6, NULL, 0);
+-    mux_info[0].pin = d4201_gpio_base+6;
++    iot2050_setup_pins(b, pin_index, "IO6", (mraa_pincapabilities_t) { 1, 1, 1, 0, 0, 0, 0, 0 });
++    if (is_rev) {
++        mux_info[0].pin = d4201_gpio_base + 6;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, d4202_gpio_chip, 6, -1, -1, mux_info, 1);
++    } else {
++        iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 38, d4201_gpio_base + 6,
++                             d4202_gpio_base + 6, NULL, 0);
++    }
++    mux_info[0].pin = d4201_gpio_base + 6;
+     mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[0].value = MRAA_GPIO_OUT_HIGH;
+-    mux_info[1].pin = d4202_gpio_base+6;
++    mux_info[1].pin = d4202_gpio_base + 6;
+     mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[1].value = MRAA_GPIO_IN;
+     iot2050_pin_add_pwm(b, pin_index, 2, 0, mux_info, 2);
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "IO7",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            1,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            0,  /*spi*/
+-                            0,  /*i2c*/
+-                            0,  /*aio*/
+-                            0}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_MAIN,
+-                            43,
+-                            main_gpio0_base+43,
+-                            {
+-                                7,  /*GPIO*/
+-                                -1, /*UART*/
+-                                -1, /*I2C*/
+-                                -1, /*SPI*/
+-                                5   /*PWM*/
+-                            },
+-                            {
+-                                "11c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "11c000.pinctrl-pinctrl-single"
+-                            },
+-                            {
+-                                "d7-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "d7-ehrpwm3-a"
+-                            },
+-                            {
+-                                "d7-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "d7-ehrpwm3-a"
+-                            }
+-                        });
+-    iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 43, d4201_gpio_base+7, d4202_gpio_base+7, NULL, 0);
+-    mux_info[0].pin = d4201_gpio_base+7;
++    iot2050_setup_pins(b, pin_index, "IO7", (mraa_pincapabilities_t) { 1, 1, 1, 0, 0, 0, 0, 0 });
++    if (is_rev) {
++        mux_info[0].pin = d4201_gpio_base + 7;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, d4202_gpio_chip, 7, -1, -1, mux_info, 1);
++    } else {
++        iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 43, d4201_gpio_base + 7,
++                             d4202_gpio_base + 7, NULL, 0);
++    }
++    mux_info[0].pin = d4201_gpio_base + 7;
+     mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[0].value = MRAA_GPIO_OUT_HIGH;
+-    mux_info[1].pin = d4202_gpio_base+7;
++    mux_info[1].pin = d4202_gpio_base + 7;
+     mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[1].value = MRAA_GPIO_IN;
+     iot2050_pin_add_pwm(b, pin_index, 3, 0, mux_info, 2);
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "IO8",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            1,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            0,  /*spi*/
+-                            0,  /*i2c*/
+-                            0,  /*aio*/
+-                            0}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_MAIN,
+-                            48,
+-                            main_gpio0_base+48,
+-                            {
+-                                7,  /*GPIO*/
+-                                -1, /*UART*/
+-                                -1, /*I2C*/
+-                                -1, /*SPI*/
+-                                5   /*PWM*/
+-                            },
+-                            {
+-                                "11c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "11c000.pinctrl-pinctrl-single"
+-                            },
+-                            {
+-                                "d8-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "d8-ehrpwm4-a"
+-                            },
+-                            {
+-                                "d8-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "d8-ehrpwm4-a"
+-                            }
+-                        });
+-    iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 48, d4201_gpio_base+8, d4202_gpio_base+8, NULL, 0);
+-    mux_info[0].pin = d4201_gpio_base+8;
++    iot2050_setup_pins(b, pin_index, "IO8", (mraa_pincapabilities_t) { 1, 1, 1, 0, 0, 0, 0, 0 });
++    if (is_rev) {
++        mux_info[0].pin = d4201_gpio_base + 8;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, d4202_gpio_chip, 8, -1, -1, mux_info, 1);
++    } else {
++        iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 48, d4201_gpio_base + 8,
++                             d4202_gpio_base + 8, NULL, 0);
++    }
++    mux_info[0].pin = d4201_gpio_base + 8;
+     mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[0].value = MRAA_GPIO_OUT_HIGH;
+-    mux_info[1].pin = d4202_gpio_base+8;
++    mux_info[1].pin = d4202_gpio_base + 8;
+     mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[1].value = MRAA_GPIO_IN;
+     iot2050_pin_add_pwm(b, pin_index, 4, 0, mux_info, 2);
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "IO9",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            1,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            0,  /*spi*/
+-                            0,  /*i2c*/
+-                            0,  /*aio*/
+-                            0}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_MAIN,
+-                            51,
+-                            main_gpio0_base+51,
+-                            {
+-                                7,  /*GPIO*/
+-                                -1, /*UART*/
+-                                -1, /*I2C*/
+-                                -1, /*SPI*/
+-                                5   /*PWM*/
+-                            },
+-                            {
+-                                "11c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "11c000.pinctrl-pinctrl-single"
+-                            },
+-                            {
+-                                "d9-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "d9-ehrpwm5-a"
+-                            },
+-                            {
+-                                "d9-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                "d9-ehrpwm5-a"
+-                            }
+-                        });
+-    iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 51, d4201_gpio_base+9, d4202_gpio_base+9, NULL, 0);
+-    mux_info[0].pin = d4201_gpio_base+9;
++    iot2050_setup_pins(b, pin_index, "IO9", (mraa_pincapabilities_t) { 1, 1, 1, 0, 0, 0, 0, 0 });
++    if (is_rev) {
++        mux_info[0].pin = d4201_gpio_base + 9;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, d4202_gpio_chip, 9, -1, -1, mux_info, 1);
++    } else {
++        iot2050_pin_add_gpio(b, pin_index, main_gpio0_chip, 51, d4201_gpio_base + 9,
++                             d4202_gpio_base + 9, NULL, 0);
++    }
++    mux_info[0].pin = d4201_gpio_base + 9;
+     mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[0].value = MRAA_GPIO_OUT_HIGH;
+-    mux_info[1].pin = d4202_gpio_base+9;
++    mux_info[1].pin = d4202_gpio_base + 9;
+     mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[1].value = MRAA_GPIO_IN;
+     iot2050_pin_add_pwm(b, pin_index, 5, 0, mux_info, 2);
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "IO10",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            0,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            1,  /*spi*/
+-                            0,  /*i2c*/
+-                            0,  /*aio*/
+-                            0}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_WAKUP,
+-                            39,
+-                            wkup_gpio0_base+51,
+-                            {
+-                                7,  /*GPIO*/
+-                                -1, /*UART*/
+-                                -1, /*I2C*/
+-                                0, /*SPI*/
+-                                -1  /*PWM*/
+-                            },
+-                            {
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL
+-                            },
+-                            {
+-                                "d10-gpio",
+-                                NULL,
+-                                NULL,
+-                                "d10-spi0-cs0",
+-                                NULL
+-                            },
+-                            {
+-                                "d10-gpio",
+-                                NULL,
+-                                NULL,
+-                                "d10-spi0-cs0",
+-                                NULL
+-                            }
+-                        });
+-    iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 51, d4201_gpio_base+10, d4202_gpio_base+10, NULL, 0);
+-    mux_info[0].pin = d4201_gpio_base+10;
++    iot2050_setup_pins(b, pin_index, "IO10", (mraa_pincapabilities_t) { 1, 1, 0, 0, 1, 0, 0, 0 });
++    if (is_rev) {
++        mux_info[0].pin = d4201_gpio_base + 10;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, d4202_gpio_chip, 10, -1, -1, mux_info, 1);
++    } else {
++        iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 51, d4201_gpio_base + 10,
++                             d4202_gpio_base + 10, NULL, 0);
++    }
++    mux_info[0].pin = d4201_gpio_base + 10;
+     mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[0].value = MRAA_GPIO_OUT_HIGH;
+-    mux_info[1].pin = d4202_gpio_base+10;
++    mux_info[1].pin = d4202_gpio_base + 10;
+     mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[1].value = MRAA_GPIO_IN;
+     iot2050_pin_add_spi(b, pin_index, 0, mux_info, 2);
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "IO11",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            0,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            1,  /*spi*/
+-                            0,  /*i2c*/
+-                            0,  /*aio*/
+-                            0}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_WAKUP,
+-                            37,
+-                            wkup_gpio0_base+49,
+-                            {
+-                                7,  /*GPIO*/
+-                                -1, /*UART*/
+-                                -1, /*I2C*/
+-                                0, /*SPI*/
+-                                -1  /*PWM*/
+-                            },
+-                            {
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL
+-                            },
+-                            {
+-                                "d11-gpio",
+-                                NULL,
+-                                NULL,
+-                                "d11-spi0-d0",
+-                                NULL
+-                            },
+-                            {
+-                                "d11-gpio",
+-                                NULL,
+-                                NULL,
+-                                "d11-spi0-d0",
+-                                NULL
+-                            }
+-                        });
+-    iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 49, d4201_gpio_base+11, d4202_gpio_base+11, NULL, 0);
+-    mux_info[0].pin = d4201_gpio_base+11;
++    iot2050_setup_pins(b, pin_index, "IO11", (mraa_pincapabilities_t) { 1, 1, 0, 0, 1, 0, 0, 0 });
++    if (is_rev) {
++        mux_info[0].pin = d4201_gpio_base + 11;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, d4202_gpio_chip, 11, -1, -1, mux_info, 1);
++    } else {
++        iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 49, d4201_gpio_base + 11,
++                             d4202_gpio_base + 11, NULL, 0);
++    }
++    mux_info[0].pin = d4201_gpio_base + 11;
+     mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[0].value = MRAA_GPIO_OUT_HIGH;
+-    mux_info[1].pin = d4202_gpio_base+11;
++    mux_info[1].pin = d4202_gpio_base + 11;
+     mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[1].value = MRAA_GPIO_IN;
+     iot2050_pin_add_spi(b, pin_index, 0, mux_info, 2);
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "IO12",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            0,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            1,  /*spi*/
+-                            0,  /*i2c*/
+-                            0,  /*aio*/
+-                            0}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_WAKUP,
+-                            38,
+-                            wkup_gpio0_base+50,
+-                            {
+-                                7,  /*GPIO*/
+-                                -1, /*UART*/
+-                                -1, /*I2C*/
+-                                0, /*SPI*/
+-                                -1  /*PWM*/
+-                            },
+-                            {
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL
+-                            },
+-                            {
+-                                "d12-gpio",
+-                                NULL,
+-                                NULL,
+-                                "d12-spi0-d1",
+-                                NULL
+-                            },
+-                            {
+-                                "d12-gpio",
+-                                NULL,
+-                                NULL,
+-                                "d12-spi0-d1",
+-                                NULL
+-                            }
+-                        });
+-    iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 50, d4201_gpio_base+12, d4202_gpio_base+12, NULL, 0);
+-    mux_info[0].pin = d4201_gpio_base+12;
++    iot2050_setup_pins(b, pin_index, "IO12", (mraa_pincapabilities_t) { 1, 1, 0, 0, 1, 0, 0, 0 });
++    if (is_rev) {
++        mux_info[0].pin = d4201_gpio_base + 12;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, d4202_gpio_chip, 12, -1, -1, mux_info, 1);
++    } else {
++        iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 50, d4201_gpio_base + 12,
++                             d4202_gpio_base + 12, NULL, 0);
++    }
++    mux_info[0].pin = d4201_gpio_base + 12;
+     mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[0].value = MRAA_GPIO_OUT_LOW;
+-    mux_info[1].pin = d4202_gpio_base+12;
++    mux_info[1].pin = d4202_gpio_base + 12;
+     mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[1].value = MRAA_GPIO_IN;
+     iot2050_pin_add_spi(b, pin_index, 0, mux_info, 2);
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "IO13",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            0,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            1,  /*spi*/
+-                            0,  /*i2c*/
+-                            0,  /*aio*/
+-                            0}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_WAKUP,
+-                            36,
+-                            wkup_gpio0_base+48,
+-                            {
+-                                7,  /*GPIO*/
+-                                -1, /*UART*/
+-                                -1, /*I2C*/
+-                                0, /*SPI*/
+-                                -1  /*PWM*/
+-                            },
+-                            {
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL
+-                            },
+-                            {
+-                                "d13-gpio",
+-                                NULL,
+-                                NULL,
+-                                "d13-spi0-clk",
+-                                NULL
+-                            },
+-                            {
+-                                "d13-gpio",
+-                                NULL,
+-                                NULL,
+-                                "d13-spi0-clk",
+-                                NULL
+-                            }
+-                        });
+-    iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 48, d4201_gpio_base+13, d4202_gpio_base+13, NULL, 0);
+-    mux_info[0].pin = d4201_gpio_base+13;
++    iot2050_setup_pins(b, pin_index, "IO13", (mraa_pincapabilities_t) { 1, 1, 0, 0, 1, 0, 0, 0 });
++    if (is_rev) {
++        mux_info[0].pin = d4201_gpio_base + 13;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, d4202_gpio_chip, 13, -1, -1, mux_info, 1);
++    } else {
++        iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 48, d4201_gpio_base + 13,
++                             d4202_gpio_base + 13, NULL, 0);
++    }
++    mux_info[0].pin = d4201_gpio_base + 13;
+     mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[0].value = MRAA_GPIO_OUT_HIGH;
+-    mux_info[1].pin = d4202_gpio_base+13;
++    mux_info[1].pin = d4202_gpio_base + 13;
+     mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+     mux_info[1].value = MRAA_GPIO_IN;
+     iot2050_pin_add_spi(b, pin_index, 0, mux_info, 2);
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "A0",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            0,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            0,  /*spi*/
+-                            0,  /*i2c*/
+-                            1,  /*aio*/
+-                            0}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_WAKUP,
+-                            33,
+-                            wkup_gpio0_base+45,
+-                            {
+-                                7,  /*GPIO*/
+-                                -1, /*UART*/
+-                                -1, /*I2C*/
+-                                -1, /*SPI*/
+-                                -1  /*PWM*/
+-                            },
+-                            {
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "a0-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "a0-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            }
+-                        });
+-    mux_info[0].pin = d4200_gpio_base+8;
+-    mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[0].value = MRAA_GPIO_OUT_LOW;
+-    iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 45, wkup_gpio0_base+38, d4200_gpio_base+0, mux_info, 1);
+-    // D/A switch
+-    mux_info[0].pin = d4200_gpio_base+8;
+-    mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[0].value = MRAA_GPIO_IN;
+-    // muxed GPIO as input
+-    mux_info[1].pin = wkup_gpio0_base+45;
+-    mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[1].value = MRAA_GPIO_IN;
+-    // output enable as input
+-    mux_info[2].pin = wkup_gpio0_base+38;
+-    mux_info[2].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[2].value = MRAA_GPIO_OUT_LOW;
+-    // pull enable as input
+-    mux_info[3].pin = d4200_gpio_base+0;
+-    mux_info[3].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[3].value = MRAA_GPIO_IN;
+-    iot2050_pin_add_aio(b, pin_index, 0, mux_info, 4);
++    iot2050_setup_pins(b, pin_index, "A0", (mraa_pincapabilities_t) { 1, 1, 0, 0, 0, 0, 1, 0 });
++    if (is_rev) {
++        /* IO14_EN# PIN */
++        mux_info[0].pin = d4200_gpio_base + 8;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        iot2050_pin_add_gpio(b, pin_index, d4200_gpio_chip, 0, -1, -1, mux_info, 1);
++        mux_info[0].pin = d4200_gpio_base + 8;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        mux_info[1].pin = d4200_gpio_base + 0;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_IN;
++        iot2050_pin_add_aio(b, pin_index, 0, mux_info, 2);
++    } else {
++        mux_info[0].pin = wkup_gpio0_base + 45;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 45, wkup_gpio0_base + 38,
++                             d4200_gpio_base + 0, mux_info, 1);
++        mux_info[0].pin = d4200_gpio_base + 8;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        mux_info[1].pin = wkup_gpio0_base + 45;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_IN;
++        mux_info[2].pin = wkup_gpio0_base + 38;
++        mux_info[2].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[2].value = MRAA_GPIO_OUT_LOW;
++        mux_info[3].pin = d4200_gpio_base + 0;
++        mux_info[3].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[3].value = MRAA_GPIO_IN;
++        iot2050_pin_add_aio(b, pin_index, 0, mux_info, 4);
++    }
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "A1",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            0,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            0,  /*spi*/
+-                            0,  /*i2c*/
+-                            1,  /*aio*/
+-                            0}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_WAKUP,
+-                            32,
+-                            wkup_gpio0_base+44,
+-                            {
+-                                7,  /*GPIO*/
+-                                -1, /*UART*/
+-                                -1, /*I2C*/
+-                                -1, /*SPI*/
+-                                -1  /*PWM*/
+-                            },
+-                            {
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "a1-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "a1-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            }
+-                        });
+-    mux_info[0].pin = d4200_gpio_base+9;
+-    mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[0].value = MRAA_GPIO_OUT_LOW;
+-    iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 44, wkup_gpio0_base+37, d4200_gpio_base+1, mux_info, 1);
+-    // D/A switch
+-    mux_info[0].pin = d4200_gpio_base+9;
+-    mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[0].value = MRAA_GPIO_IN;
+-    // muxed GPIO as input
+-    mux_info[1].pin = wkup_gpio0_base+44;
+-    mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[1].value = MRAA_GPIO_IN;
+-    // output enable as input
+-    mux_info[2].pin = wkup_gpio0_base+37;
+-    mux_info[2].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[2].value = MRAA_GPIO_OUT_LOW;
+-    // pull enable as input
+-    mux_info[3].pin = d4200_gpio_base+1;
+-    mux_info[3].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[3].value = MRAA_GPIO_IN;
+-    iot2050_pin_add_aio(b, pin_index, 1, mux_info, 4);
++    iot2050_setup_pins(b, pin_index, "A1", (mraa_pincapabilities_t) { 1, 1, 0, 0, 0, 0, 1, 0 });
++    if (is_rev) {
++        /* IO15_EN# PIN */
++        mux_info[0].pin = d4200_gpio_base + 9;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        iot2050_pin_add_gpio(b, pin_index, d4200_gpio_chip, 1, -1, -1, mux_info, 1);
++        mux_info[0].pin = d4200_gpio_base + 9;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        mux_info[1].pin = d4200_gpio_base + 1;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_IN;
++        iot2050_pin_add_aio(b, pin_index, 1, mux_info, 2);
++    } else {
++        mux_info[0].pin = wkup_gpio0_base + 44;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 44, wkup_gpio0_base + 37, -1, mux_info, 1);
++        mux_info[0].pin = d4200_gpio_base + 9;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        mux_info[1].pin = wkup_gpio0_base + 44;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_IN;
++        mux_info[2].pin = wkup_gpio0_base + 37;
++        mux_info[2].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[2].value = MRAA_GPIO_OUT_LOW;
++        mux_info[3].pin = d4200_gpio_base + 1;
++        mux_info[3].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[3].value = MRAA_GPIO_IN;
++        iot2050_pin_add_aio(b, pin_index, 1, mux_info, 4);
++    }
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "A2",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            0,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            0,  /*spi*/
+-                            0,  /*i2c*/
+-                            1,  /*aio*/
+-                            0}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_WAKUP,
+-                            31,
+-                            wkup_gpio0_base+43,
+-                            {
+-                                7,  /*GPIO*/
+-                                -1, /*UART*/
+-                                -1, /*I2C*/
+-                                -1, /*SPI*/
+-                                -1  /*PWM*/
+-                            },
+-                            {
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "a2-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "a2-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            }
+-                        });
+-    mux_info[0].pin = d4200_gpio_base+10;
+-    mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[0].value = MRAA_GPIO_OUT_LOW;
+-    iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 43, wkup_gpio0_base+36, d4200_gpio_base+2, mux_info, 1);
+-    // D/A switch
+-    mux_info[0].pin = d4200_gpio_base+10;
+-    mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[0].value = MRAA_GPIO_IN;
+-    // muxed GPIO as input
+-    mux_info[1].pin = wkup_gpio0_base+43;
+-    mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[1].value = MRAA_GPIO_IN;
+-    // output enable as input
+-    mux_info[2].pin = wkup_gpio0_base+36;
+-    mux_info[2].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[2].value = MRAA_GPIO_OUT_LOW;
+-    // pull enable as input
+-    mux_info[3].pin = d4200_gpio_base+2;
+-    mux_info[3].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[3].value = MRAA_GPIO_IN;
+-    iot2050_pin_add_aio(b, pin_index, 2, mux_info, 4);
++    iot2050_setup_pins(b, pin_index, "A2", (mraa_pincapabilities_t) { 1, 1, 0, 0, 0, 0, 1, 0 });
++    if (is_rev) {
++        /* IO16_EN# PIN */
++        mux_info[0].pin = d4200_gpio_base + 10;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        iot2050_pin_add_gpio(b, pin_index, d4200_gpio_chip, 2, -1, -1, mux_info, 1);
++        mux_info[0].pin = d4200_gpio_base + 10;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        mux_info[1].pin = d4200_gpio_base + 2;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_IN;
++        iot2050_pin_add_aio(b, pin_index, 2, mux_info, 2);
++    } else {
++        mux_info[0].pin = wkup_gpio0_base + 43;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 43, wkup_gpio0_base + 36,
++                             d4200_gpio_base + 2, mux_info, 1);
++        mux_info[0].pin = d4200_gpio_base + 10;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        mux_info[1].pin = wkup_gpio0_base + 43;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_IN;
++        mux_info[2].pin = wkup_gpio0_base + 36;
++        mux_info[2].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[2].value = MRAA_GPIO_OUT_LOW;
++        mux_info[3].pin = d4200_gpio_base + 2;
++        mux_info[3].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[3].value = MRAA_GPIO_IN;
++        iot2050_pin_add_aio(b, pin_index, 2, mux_info, 4);
++    }
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "A3",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            0,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            0,  /*spi*/
+-                            0,  /*i2c*/
+-                            1,  /*aio*/
+-                            0}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_WAKUP,
+-                            27,
+-                            wkup_gpio0_base+39,
+-                            {
+-                                7,  /*GPIO*/
+-                                -1, /*UART*/
+-                                -1, /*I2C*/
+-                                -1, /*SPI*/
+-                                -1  /*PWM*/
+-                            },
+-                            {
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "a3-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "a3-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            }
+-                        });
+-    mux_info[0].pin = d4200_gpio_base+11;
+-    mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[0].value = MRAA_GPIO_OUT_LOW;
+-    iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 39, wkup_gpio0_base+34, d4200_gpio_base+3, mux_info, 1);
+-    // D/A switch
+-    mux_info[0].pin = d4200_gpio_base+11;
+-    mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[0].value = MRAA_GPIO_IN;
+-    // muxed GPIO as input
+-    mux_info[1].pin = wkup_gpio0_base+39;
+-    mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[1].value = MRAA_GPIO_IN;
+-    // output enable as input
+-    mux_info[2].pin = wkup_gpio0_base+34;
+-    mux_info[2].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[2].value = MRAA_GPIO_OUT_LOW;
+-    // pull enable as input
+-    mux_info[3].pin = d4200_gpio_base+3;
+-    mux_info[3].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[3].value = MRAA_GPIO_IN;
+-    iot2050_pin_add_aio(b, pin_index, 3, mux_info, 4);
++    iot2050_setup_pins(b, pin_index, "A3", (mraa_pincapabilities_t) { 1, 1, 0, 0, 0, 0, 1, 0 });
++    if (is_rev) {
++        /* IO17_EN# PIN */
++        mux_info[0].pin = d4200_gpio_base + 11;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        iot2050_pin_add_gpio(b, pin_index, d4200_gpio_chip, 3, -1, -1, mux_info, 1);
++        mux_info[0].pin = d4200_gpio_base + 11;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        mux_info[1].pin = d4200_gpio_base + 3;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_IN;
++        iot2050_pin_add_aio(b, pin_index, 3, mux_info, 2);
++    } else {
++        mux_info[0].pin = wkup_gpio0_base + 39;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 39, wkup_gpio0_base + 34,
++                             d4200_gpio_base + 3, mux_info, 1);
++        mux_info[0].pin = d4200_gpio_base + 11;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        mux_info[1].pin = wkup_gpio0_base + 39;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_IN;
++        mux_info[2].pin = wkup_gpio0_base + 34;
++        mux_info[2].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[2].value = MRAA_GPIO_OUT_LOW;
++        mux_info[3].pin = d4200_gpio_base + 3;
++        mux_info[3].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[3].value = MRAA_GPIO_IN;
++        iot2050_pin_add_aio(b, pin_index, 3, mux_info, 4);
++    }
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "A4",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            0,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            0,  /*spi*/
+-                            1,  /*i2c*/
+-                            1,  /*aio*/
+-                            0}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_WAKUP,
+-                            30,
+-                            wkup_gpio0_base+42,
+-                            {
+-                                7, /*GPIO*/
+-                                -1, /*UART*/
+-                                0,  /*I2C*/
+-                                -1, /*SPI*/
+-                                -1  /*PWM*/
+-                            },
+-                            {
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "a4-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "a4-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            }
+-                        });
+-    mux_info[0].pin = d4200_gpio_base+12;
+-    mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[0].value = MRAA_GPIO_OUT_LOW;
+-    mux_info[1].pin = wkup_gpio0_base+21;
+-    mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[1].value = MRAA_GPIO_OUT_HIGH;
+-    iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 42, wkup_gpio0_base+41, d4200_gpio_base+4, mux_info, 2);
+-    // A/D/I switch
+-    mux_info[0].pin = d4200_gpio_base+12;
+-    mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[0].value = MRAA_GPIO_IN;
+-    mux_info[1].pin = wkup_gpio0_base+21;
+-    mux_info[1].pincmd = PINCMD_SET_OUT_VALUE;
+-    mux_info[1].value = 0;
+-    // pull enable as input
+-    mux_info[2].pin = d4200_gpio_base+4;
+-    mux_info[2].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[2].value = MRAA_GPIO_IN;
+-    iot2050_pin_add_i2c(b, pin_index, 0, mux_info, 3);
+-    // A/D/I switch
+-    mux_info[0].pin = d4200_gpio_base+12;
+-    mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[0].value = MRAA_GPIO_IN;
+-    mux_info[1].pin = wkup_gpio0_base+21;
+-    mux_info[1].pincmd = PINCMD_SET_OUT_VALUE;
+-    mux_info[1].value = 1;
+-    // muxed GPIO as input
+-    mux_info[2].pin = wkup_gpio0_base+42;
+-    mux_info[2].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[2].value = MRAA_GPIO_IN;
+-    // output enable as input
+-    mux_info[3].pin = wkup_gpio0_base+41;
+-    mux_info[3].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[3].value = MRAA_GPIO_OUT_LOW;
+-    // pull enable as input
+-    mux_info[4].pin = d4200_gpio_base+4;
+-    mux_info[4].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[4].value = MRAA_GPIO_IN;
+-    iot2050_pin_add_aio(b, pin_index, 4, mux_info, 5);
++    iot2050_setup_pins(b, pin_index, "A4", (mraa_pincapabilities_t) { 1, 1, 0, 0, 0, 1, 1, 0 });
++    if (is_rev) {
++        /* IO18_EN# PIN */
++        mux_info[0].pin = d4200_gpio_base + 12;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        /* AMUX_IN */
++        mux_info[1].pin = wkup_gpio0_base + 21;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_OUT_HIGH;
++        iot2050_pin_add_gpio(b, pin_index, d4200_gpio_chip, 4, -1, -1, mux_info, 2);
++        /* IO18_EN# PIN */
++        mux_info[0].pin = d4200_gpio_base + 12;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        /* AMUX_IN */
++        mux_info[1].pin = wkup_gpio0_base + 21;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_OUT_HIGH;
++        /* IO18 GPIO should be input */
++        mux_info[2].pin = d4200_gpio_base + 4;
++        mux_info[2].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[2].value = MRAA_GPIO_IN;
++        iot2050_pin_add_aio(b, pin_index, 4, mux_info, 3);
++        /* IO18_EN# PIN */
++        mux_info[0].pin = d4200_gpio_base + 12;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        /* AMUX_IN */
++        mux_info[1].pin = wkup_gpio0_base + 21;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_i2c(b, pin_index, 0, mux_info, 2);
++    } else {
++        mux_info[0].pin = d4200_gpio_base + 12;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        mux_info[1].pin = wkup_gpio0_base + 21;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_OUT_HIGH;
++        iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 42, wkup_gpio0_base + 41,
++                             d4200_gpio_base + 4, mux_info, 2);
++        mux_info[0].pin = d4200_gpio_base + 12;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        mux_info[1].pin = wkup_gpio0_base + 42;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_IN;
++        mux_info[2].pin = wkup_gpio0_base + 41;
++        mux_info[2].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[2].value = MRAA_GPIO_OUT_LOW;
++        mux_info[3].pin = d4200_gpio_base + 4;
++        mux_info[3].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[3].value = MRAA_GPIO_IN;
++        iot2050_pin_add_aio(b, pin_index, 4, mux_info, 5);
++        mux_info[0].pin = d4200_gpio_base + 12;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        mux_info[1].pin = wkup_gpio0_base + 21;
++        mux_info[1].pincmd = PINCMD_SET_OUT_VALUE;
++        mux_info[1].value = 0;
++        mux_info[2].pin = d4200_gpio_base + 4;
++        mux_info[2].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[2].value = MRAA_GPIO_IN;
++        iot2050_pin_add_i2c(b, pin_index, 0, mux_info, 3);
++    }
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "A5",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            0,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            0,  /*spi*/
+-                            1,  /*i2c*/
+-                            1,  /*aio*/
+-                            0}, /*uart*/
+-                        (regmux_info_t) {
+-                            PINMUX_GROUP_WAKUP,
+-                            23,
+-                            wkup_gpio0_base+35,
+-                            {
+-                                7, /*GPIO*/
+-                                -1, /*UART*/
+-                                0,  /*I2C*/
+-                                -1, /*SPI*/
+-                                -1  /*PWM*/
+-                            },
+-                            {
+-                                "4301c000.pinctrl-pinctrl-single",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "a5-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            },
+-                            {
+-                                "a5-gpio",
+-                                NULL,
+-                                NULL,
+-                                NULL,
+-                                NULL
+-                            }
+-                        });
+-    mux_info[0].pin = d4200_gpio_base+13;
+-    mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[0].value = MRAA_GPIO_OUT_LOW;
+-    mux_info[1].pin = wkup_gpio0_base+21;
+-    mux_info[1].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[1].value = MRAA_GPIO_OUT_HIGH;
+-    iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 35, d4201_gpio_base+14, d4200_gpio_base+5, mux_info, 2);
+-    // A/D/I switch
+-    mux_info[0].pin = d4200_gpio_base+13;
+-    mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[0].value = MRAA_GPIO_IN;
+-    mux_info[1].pin = wkup_gpio0_base+21;
+-    mux_info[1].pincmd = PINCMD_SET_OUT_VALUE;
+-    mux_info[1].value = 0;
+-    // pull enable as input
+-    mux_info[2].pin = d4200_gpio_base+5;
+-    mux_info[2].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[2].value = MRAA_GPIO_IN;
+-    iot2050_pin_add_i2c(b, pin_index, 0, mux_info, 3);
+-    // A/D/I switch
+-    mux_info[0].pin = d4200_gpio_base+13;
+-    mux_info[0].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[0].value = MRAA_GPIO_IN;
+-    mux_info[1].pin = wkup_gpio0_base+21;
+-    mux_info[1].pincmd = PINCMD_SET_OUT_VALUE;
+-    mux_info[1].value = 1;
+-    // muxed GPIO as input
+-    mux_info[2].pin = wkup_gpio0_base+35;
+-    mux_info[2].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[2].value = MRAA_GPIO_IN;
+-    // output enable as input
+-    mux_info[3].pin = d4201_gpio_base+14;
+-    mux_info[3].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[3].value = MRAA_GPIO_OUT_LOW;
+-    // pull enable as input
+-    mux_info[4].pin = d4200_gpio_base+5;
+-    mux_info[4].pincmd = PINCMD_SET_DIRECTION;
+-    mux_info[4].value = MRAA_GPIO_IN;
+-    iot2050_pin_add_aio(b, pin_index, 5, mux_info, 5);
++    iot2050_setup_pins(b, pin_index, "A5", (mraa_pincapabilities_t) { 1, 1, 0, 0, 0, 1, 1, 0 });
++    if (is_rev) {
++        /* IO19_EN# PIN */
++        mux_info[0].pin = d4200_gpio_base + 13;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        /* AMUX_IN */
++        mux_info[1].pin = wkup_gpio0_base + 21;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_OUT_HIGH;
++        iot2050_pin_add_gpio(b, pin_index, d4200_gpio_chip, 5, -1, -1, mux_info, 2);
++        /* IO19_EN# PIN */
++        mux_info[0].pin = d4200_gpio_base + 13;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        /* AMUX_IN */
++        mux_info[1].pin = wkup_gpio0_base + 21;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_OUT_HIGH;
++        /* IO19 GPIO should be input */
++        mux_info[2].pin = d4200_gpio_base + 5;
++        mux_info[2].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[2].value = MRAA_GPIO_IN;
++        iot2050_pin_add_aio(b, pin_index, 5, mux_info, 3);
++        /* IO19_EN# PIN */
++        mux_info[0].pin = d4200_gpio_base + 13;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        /* AMUX_IN */
++        mux_info[1].pin = wkup_gpio0_base + 21;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_OUT_LOW;
++        iot2050_pin_add_i2c(b, pin_index, 0, mux_info, 2);
++    } else {
++        mux_info[0].pin = d4200_gpio_base + 13;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_OUT_LOW;
++        mux_info[1].pin = wkup_gpio0_base + 21;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_OUT_HIGH;
++        iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 35, d4201_gpio_base + 14,
++                             d4200_gpio_base + 5, mux_info, 2);
++        mux_info[0].pin = d4200_gpio_base + 13;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        mux_info[1].pin = wkup_gpio0_base + 35;
++        mux_info[1].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[1].value = MRAA_GPIO_IN;
++        mux_info[2].pin = d4201_gpio_base + 14;
++        mux_info[2].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[2].value = MRAA_GPIO_OUT_LOW;
++        mux_info[3].pin = d4200_gpio_base + 5;
++        mux_info[3].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[3].value = MRAA_GPIO_IN;
++        iot2050_pin_add_aio(b, pin_index, 5, mux_info, 5);
++        mux_info[0].pin = d4200_gpio_base + 13;
++        mux_info[0].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[0].value = MRAA_GPIO_IN;
++        mux_info[1].pin = wkup_gpio0_base + 21;
++        mux_info[1].pincmd = PINCMD_SET_OUT_VALUE;
++        mux_info[1].value = 0;
++        mux_info[2].pin = d4200_gpio_base + 5;
++        mux_info[2].pincmd = PINCMD_SET_DIRECTION;
++        mux_info[2].value = MRAA_GPIO_IN;
++        iot2050_pin_add_i2c(b, pin_index, 0, mux_info, 3);
++    }
+     pin_index++;
+ 
+-    iot2050_setup_pins(b, pin_index, "USER",
+-                        (mraa_pincapabilities_t) {
+-                            1,  /*valid*/
+-                            1,  /*gpio*/
+-                            0,  /*pwm*/
+-                            0,  /*fast gpio*/
+-                            0,  /*spi*/
+-                            0,  /*i2c*/
+-                            0,  /*aio*/
+-                            0}, /*uart*/
+-                        (regmux_info_t) {
+-                            -1,
+-                            -1,
+-                            wkup_gpio0_base+25,
+-                            {0},
+-                            {0},
+-                            {0},
+-                            {0}
+-                        });
++    iot2050_setup_pins(b, pin_index, "USER", (mraa_pincapabilities_t) { 1, 1, 0, 0, 0, 0, 0, 0 });
+     iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 25, -1, -1, NULL, 0);
+     pin_index++;
+ 
+@@ -1879,6 +1402,8 @@ mraa_siemens_iot2050_sm()
+     unsigned line_offset;
+     mraa_board_t* b = (mraa_board_t*) calloc(1, sizeof(mraa_board_t));
+ 
++    pinmux_info_current = pinmux_info_rev;
++
+     if (NULL == b) {
+         goto error_board;
+     }
+@@ -1905,24 +1430,8 @@ mraa_siemens_iot2050_sm()
+ 
+     /* USER BUTTON */
+     iot2050_setup_pins(b, pin_index, "USER",
+-                        (mraa_pincapabilities_t) {
+-                            .valid = 1,
+-                            .gpio = 1,
+-                            .pwm = 0,
+-                            .fast_gpio = 0,
+-                            .spi = 0,
+-                            .i2c = 0,
+-                            .aio = 0,
+-                            .uart = 0},
+-                        (regmux_info_t) {
+-                            .group = -1,
+-                            .index = -1,
+-                            .pinmap = wkup_gpio0_base+25,
+-                            .mode = {0},
+-                            .debugfs_path = {0},
+-                            .pmx_function = {0},
+-                            .pmx_group = {0},
+-                        });
++                       (mraa_pincapabilities_t) {
++                       .valid = 1, .gpio = 1, .pwm = 0, .fast_gpio = 0, .spi = 0, .i2c = 0, .aio = 0, .uart = 0 });
+     iot2050_pin_add_gpio(b, pin_index, wkup_gpio0_chip, 25, -1, -1, NULL, 0);
+ 
+     /* LED */

--- a/meta/recipes-app/mraa/mraa_2.2.0+git20220805.8b1c5493.bb
+++ b/meta/recipes-app/mraa/mraa_2.2.0+git20220805.8b1c5493.bb
@@ -8,7 +8,7 @@
 # COPYING.MIT file in the top-level directory.
 #
 
-PR = "5"
+PR = "6"
 
 inherit dpkg
 
@@ -30,6 +30,8 @@ SRC_URI += "git://github.com/eclipse/mraa.git;protocol=https;branch=master \
             file://0013-iot2050-add-support-for-gpio-chardev-interface.patch \
             file://0014-iot2050-fix-pinmux-handling-of-user-pin.patch \
             file://0015-gpio-fix-fd-and-memory-leaks-in-gpiod-chardev-init-p.patch \
+            file://0016-gpio-add-GPIO-character-device-v2-support.patch \
+            file://0017-iot2050-add-GPIO-chardev-v2-and-revision-aware-pinmu.patch \
             file://20-mraa-permissions.rules \
             file://rules"
 

--- a/meta/recipes-bsp/u-boot/files/0015-board-siemens-iot2050-Add-Arduino-rev-support.patch
+++ b/meta/recipes-bsp/u-boot/files/0015-board-siemens-iot2050-Add-Arduino-rev-support.patch
@@ -1,0 +1,950 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Baocheng Su <baocheng.su@siemens.com>
+Date: Mon, 10 Aug 2026 19:57:01 +0800
+Subject: [PATCH] board: siemens: iot2050: Add Arduino rev support
+
+Read the board revision from system information and select the matching
+device tree for IOT2050 Advanced PG2 and M2 variants.
+
+Add U-Boot and SPL support for the revised Arduino interface, including
+board revision handling and device tree selection.
+
+Sync the device tree files with the Linux kernel. This includes changes
+already upstream and IOT2050-specific changes that are not upstream yet.
+---
+ arch/arm/dts/k3-am65-iot2050-boot-image.dtsi  |   2 +
+ ...am6548-iot2050-advanced-m2-rev-u-boot.dtsi |   1 +
+ ...m6548-iot2050-advanced-pg2-rev-u-boot.dtsi |   1 +
+ board/siemens/iot2050/board.c                 |  30 ++-
+ configs/iot2050_defconfig                     |   2 +-
+ drivers/sysinfo/iot2050.c                     |   6 +-
+ drivers/sysinfo/iot2050.h                     |   1 +
+ ...k3-am65-iot2050-arduino-connector-rev.dtsi | 231 ++++++++++++++++++
+ .../ti/k3-am65-iot2050-arduino-connector.dtsi |  58 ++---
+ .../arm64/ti/k3-am6528-iot2050-basic-pg2.dts  |   2 +-
+ .../k3-am6548-iot2050-advanced-m2-common.dtsi |  83 +++++++
+ .../ti/k3-am6548-iot2050-advanced-m2-rev.dts  |  23 ++
+ .../ti/k3-am6548-iot2050-advanced-m2.dts      |  77 +-----
+ .../ti/k3-am6548-iot2050-advanced-pg2-rev.dts |  28 +++
+ .../ti/k3-am6548-iot2050-advanced-pg2.dts     |   2 +-
+ 15 files changed, 435 insertions(+), 112 deletions(-)
+ create mode 120000 arch/arm/dts/k3-am6548-iot2050-advanced-m2-rev-u-boot.dtsi
+ create mode 120000 arch/arm/dts/k3-am6548-iot2050-advanced-pg2-rev-u-boot.dtsi
+ create mode 100644 dts/upstream/src/arm64/ti/k3-am65-iot2050-arduino-connector-rev.dtsi
+ create mode 100644 dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-m2-common.dtsi
+ create mode 100644 dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-m2-rev.dts
+ create mode 100644 dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-pg2-rev.dts
+
+diff --git a/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi b/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
+index 05257a33d994..36f6b12c1d4f 100644
+--- a/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
++++ b/arch/arm/dts/k3-am65-iot2050-boot-image.dtsi
+@@ -247,7 +247,9 @@
+ 		fit@380000 {
+ 			fit,fdt-list-val = "ti/k3-am6528-iot2050-basic-pg2",
+ 					   "ti/k3-am6548-iot2050-advanced-pg2",
++					   "ti/k3-am6548-iot2050-advanced-pg2-rev",
+ 					   "ti/k3-am6548-iot2050-advanced-m2",
++					   "ti/k3-am6548-iot2050-advanced-m2-rev",
+ 					   "ti/k3-am6548-iot2050-advanced-sm";
+ 
+ 			images {
+diff --git a/arch/arm/dts/k3-am6548-iot2050-advanced-m2-rev-u-boot.dtsi b/arch/arm/dts/k3-am6548-iot2050-advanced-m2-rev-u-boot.dtsi
+new file mode 120000
+index 000000000000..859776d3ffe1
+--- /dev/null
++++ b/arch/arm/dts/k3-am6548-iot2050-advanced-m2-rev-u-boot.dtsi
+@@ -0,0 +1 @@
++k3-am6528-iot2050-basic-pg2-u-boot.dtsi
+\ No newline at end of file
+diff --git a/arch/arm/dts/k3-am6548-iot2050-advanced-pg2-rev-u-boot.dtsi b/arch/arm/dts/k3-am6548-iot2050-advanced-pg2-rev-u-boot.dtsi
+new file mode 120000
+index 000000000000..859776d3ffe1
+--- /dev/null
++++ b/arch/arm/dts/k3-am6548-iot2050-advanced-pg2-rev-u-boot.dtsi
+@@ -0,0 +1 @@
++k3-am6528-iot2050-basic-pg2-u-boot.dtsi
+\ No newline at end of file
+diff --git a/board/siemens/iot2050/board.c b/board/siemens/iot2050/board.c
+index 1fbb30af923b..91c0ab371ca5 100644
+--- a/board/siemens/iot2050/board.c
++++ b/board/siemens/iot2050/board.c
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: GPL-2.0+
+ /*
+  * Board specific initialization for IOT2050
+- * Copyright (c) Siemens AG, 2018-2023
++ * Copyright (c) Siemens AG, 2018-2026
+  *
+  * Authors:
+  *   Le Jin <le.jin@siemens.com>
+@@ -210,6 +210,7 @@ void set_board_info_env(void)
+ {
+ 	struct udevice *sysinfo;
+ 	const char *fdtfile;
++	int board_rev;
+ 	char buf[41];
+ 
+ 	if (env_get("board_uuid"))
+@@ -248,15 +249,22 @@ void set_board_info_env(void)
+ 		}
+ 	}
+ 
++	if (sysinfo_get_int(sysinfo, BOARD_REVISION, &board_rev))
++		board_rev = 0;
++
+ 	if (board_is_advanced()) {
+ 		if (board_is_pg1())
+ 			fdtfile = "ti/k3-am6548-iot2050-advanced.dtb";
+ 		else if (board_is_m2())
+-			fdtfile = "ti/k3-am6548-iot2050-advanced-m2.dtb";
++			fdtfile = board_rev == 1 ?
++				"ti/k3-am6548-iot2050-advanced-m2-rev.dtb" :
++				"ti/k3-am6548-iot2050-advanced-m2.dtb";
+ 		else if (board_is_sm())
+ 			fdtfile = "ti/k3-am6548-iot2050-advanced-sm.dtb";
+ 		else
+-			fdtfile = "ti/k3-am6548-iot2050-advanced-pg2.dtb";
++			fdtfile = board_rev == 1 ?
++				"ti/k3-am6548-iot2050-advanced-pg2-rev.dtb" :
++				"ti/k3-am6548-iot2050-advanced-pg2.dtb";
+ 	} else {
+ 		if (board_is_pg1())
+ 			fdtfile = "ti/k3-am6528-iot2050-basic.dtb";
+@@ -470,10 +478,18 @@ int dram_init_banksize(void)
+ #ifdef CONFIG_SPL_LOAD_FIT
+ int board_fit_config_name_match(const char *name)
+ {
++	struct udevice *sysinfo;
++	char board_name_tmp[32];
+ 	char upper_name[32];
++	int board_rev = 0;
++
++	if (!setup_sysinfo(&sysinfo))
++		return -1;
+ 
+ 	get_board_name();
+ 
++	sysinfo_get_int(sysinfo, BOARD_REVISION, &board_rev);
++
+ 	/* skip the prefix "ti/k3-am65x8-" */
+ 	name += 13;
+ 
+@@ -481,7 +497,13 @@ int board_fit_config_name_match(const char *name)
+ 		return -1;
+ 
+ 	str_to_upper(name, upper_name, sizeof(upper_name));
+-	if (!strcmp(upper_name, iot2050_board_name))
++
++	strlcpy(board_name_tmp, iot2050_board_name, sizeof(board_name_tmp));
++	if (board_rev == 1 &&
++	    strlcat(board_name_tmp, "-REV", sizeof(board_name_tmp)) >= sizeof(board_name_tmp))
++		return -1;
++
++	if (!strcmp(upper_name, board_name_tmp))
+ 		return 0;
+ 
+ 	return -1;
+diff --git a/configs/iot2050_defconfig b/configs/iot2050_defconfig
+index 02ef5e5e8b77..e904c283c0e8 100644
+--- a/configs/iot2050_defconfig
++++ b/configs/iot2050_defconfig
+@@ -75,7 +75,7 @@ CONFIG_CMD_TIME=y
+ CONFIG_OF_CONTROL=y
+ CONFIG_SPL_OF_CONTROL=y
+ CONFIG_OF_UPSTREAM=y
+-CONFIG_OF_LIST="ti/k3-am6528-iot2050-basic ti/k3-am6528-iot2050-basic-pg2 ti/k3-am6548-iot2050-advanced ti/k3-am6548-iot2050-advanced-pg2 ti/k3-am6548-iot2050-advanced-m2 ti/k3-am6548-iot2050-advanced-sm"
++CONFIG_OF_LIST="ti/k3-am6528-iot2050-basic ti/k3-am6528-iot2050-basic-pg2 ti/k3-am6548-iot2050-advanced ti/k3-am6548-iot2050-advanced-pg2 ti/k3-am6548-iot2050-advanced-pg2-rev ti/k3-am6548-iot2050-advanced-m2 ti/k3-am6548-iot2050-advanced-m2-rev ti/k3-am6548-iot2050-advanced-sm"
+ CONFIG_OF_OVERLAY_LIST="ti/k3-am6548-iot2050-advanced-m2-bkey-usb3 ti/k3-am6548-iot2050-advanced-m2-bkey-ekey-pcie ti/k3-am6548-iot2050-advanced-dma-isolation"
+ CONFIG_SPL_MULTI_DTB_FIT=y
+ CONFIG_SPL_OF_LIST="ti/k3-am6528-iot2050-basic"
+diff --git a/drivers/sysinfo/iot2050.c b/drivers/sysinfo/iot2050.c
+index 579a9f4711db..c1db57f4a951 100644
+--- a/drivers/sysinfo/iot2050.c
++++ b/drivers/sysinfo/iot2050.c
+@@ -26,7 +26,8 @@ struct iot2050_info {
+ 	u8 mac_addr_cnt;
+ 	u8 mac_addr[8][ARP_HLEN];
+ 	char seboot_version[40 + 1];
+-	u8 padding[3];
++	u8 rev;
++	u8 padding[2];
+ 	u32 ddr_size_mb;
+ } __packed;
+ 
+@@ -93,6 +94,9 @@ static int sysinfo_iot2050_get_int(struct udevice *dev, int id, int *val)
+ 	case SYSID_BOARD_RAM_SIZE_MB:
+ 		*val = priv->info->ddr_size_mb;
+ 		return 0;
++	case BOARD_REVISION:
++		*val = priv->info->rev;
++		return 0;
+ 	default:
+ 		return -EINVAL;
+ 	};
+diff --git a/drivers/sysinfo/iot2050.h b/drivers/sysinfo/iot2050.h
+index 657221db0960..09ac4e471b84 100644
+--- a/drivers/sysinfo/iot2050.h
++++ b/drivers/sysinfo/iot2050.h
+@@ -11,4 +11,5 @@ enum sysinfo_id_iot2050 {
+ 	BOARD_NAME,
+ 	BOARD_UUID,
+ 	BOARD_SEBOOT_VER,
++	BOARD_REVISION,
+ };
+diff --git a/dts/upstream/src/arm64/ti/k3-am65-iot2050-arduino-connector-rev.dtsi b/dts/upstream/src/arm64/ti/k3-am65-iot2050-arduino-connector-rev.dtsi
+new file mode 100644
+index 000000000000..70638b5252c8
+--- /dev/null
++++ b/dts/upstream/src/arm64/ti/k3-am65-iot2050-arduino-connector-rev.dtsi
+@@ -0,0 +1,231 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (c) Siemens AG, 2026
++ *
++ * Authors:
++ *   Baocheng Su <baocheng.su@siemens.com>
++ *
++ * Arduino connector rework for IOT2050 Advanced PG2 variants (M2/PG2).
++ *
++ * All the arduino pins are connected to the I2C GPIO expanders (D4200,
++ * D4201, D4202).
++ */
++
++&main_pmx0 {
++	ehrpwm0_pins_default: ehrpwm0-default-pins {
++		pinctrl-single,pins = <
++			/* (AG18) EHRPWM0_A */
++			AM65X_IOPAD(0x0084, PIN_OUTPUT, 5)
++		>;
++	};
++
++	ehrpwm1_pins_default: ehrpwm1-default-pins {
++		pinctrl-single,pins = <
++			/* (AF17) EHRPWM1_A */
++			AM65X_IOPAD(0x008C, PIN_OUTPUT, 5)
++		>;
++	};
++
++	ehrpwm2_pins_default: ehrpwm2-default-pins {
++		pinctrl-single,pins = <
++			/* (AH16) EHRPWM2_A */
++			AM65X_IOPAD(0x0098, PIN_OUTPUT, 5)
++		>;
++	};
++
++	ehrpwm3_pins_default: ehrpwm3-default-pins {
++		pinctrl-single,pins = <
++			/* (AH15) EHRPWM3_A */
++			AM65X_IOPAD(0x00AC, PIN_OUTPUT, 5)
++		>;
++	};
++
++	ehrpwm4_pins_default: ehrpwm4-default-pins {
++		pinctrl-single,pins = <
++			/* (AG15) EHRPWM4_A */
++			AM65X_IOPAD(0x00C0, PIN_OUTPUT, 5)
++		>;
++	};
++
++	ehrpwm5_pins_default: ehrpwm5-default-pins {
++		pinctrl-single,pins = <
++			/* (AD15) EHRPWM5_A */
++			AM65X_IOPAD(0x00CC, PIN_OUTPUT, 5)
++		>;
++	};
++};
++
++&main_gpio0 {
++	gpio-line-names = "main_gpio0-base";
++};
++
++&wkup_pmx0 {
++	mcu_uart0_pins_default: mcu-uart0-default-pins {
++		pinctrl-single,pins = <
++			/* (P4) MCU_UART0_RXD */
++			AM65X_WKUP_IOPAD(0x0044, PIN_INPUT, 4)
++			/* (P5) MCU_UART0_TXD */
++			AM65X_WKUP_IOPAD(0x0048, PIN_OUTPUT, 4)
++			/* (P1) MCU_UART0_CTSn */
++			AM65X_WKUP_IOPAD(0x004C, PIN_INPUT, 4)
++			/* (N3) MCU_UART0_RTSn */
++			AM65X_WKUP_IOPAD(0x0054, PIN_OUTPUT, 4)
++		>;
++	};
++
++	wkup_i2c0_pins_default: wkup-i2c0-default-pins {
++		pinctrl-single,pins = <
++			/* (AC7) WKUP_I2C0_SCL */
++			AM65X_WKUP_IOPAD(0x00e0, PIN_INPUT,  0)
++			/* (AD6) WKUP_I2C0_SDA */
++			AM65X_WKUP_IOPAD(0x00e4, PIN_INPUT,  0)
++		>;
++	};
++
++	arduino_i2c_aio_switch_pins_default: arduino-i2c-aio-switch-default-pins {
++		pinctrl-single,pins = <
++			/* (R2) WKUP_GPIO0_21 */
++			AM65X_WKUP_IOPAD(0x0024, PIN_OUTPUT, 7)
++		>;
++	};
++
++	io_expander_int_pins_default: io-expander-int-default-pins {
++		pinctrl-single,pins = <
++			/* (M2) WKUP_GPIO0_36 → D4200 INT */
++			AM65X_WKUP_IOPAD(0x0060, PIN_INPUT_PULLUP, 7)
++			/* (M3) WKUP_GPIO0_37 → D4201 INT */
++			AM65X_WKUP_IOPAD(0x0064, PIN_INPUT_PULLUP, 7)
++			/* (M4) WKUP_GPIO0_38 → D4202 INT */
++			AM65X_WKUP_IOPAD(0x0068, PIN_INPUT_PULLUP, 7)
++		>;
++	};
++};
++
++&wkup_gpio0 {
++	pinctrl-names = "default";
++	pinctrl-0 =
++		<&arduino_i2c_aio_switch_pins_default>,
++		<&io_expander_int_pins_default>,
++		<&push_button_pins_default>,
++		<&db9_com_mode_pins_default>;
++
++	gpio-line-names =
++		/* 0..9 */
++		"wkup_gpio0-base", "", "", "", "UART0-mode1", "UART0-mode0",
++		"UART0-enable", "UART0-terminate", "", "WIFI-disable",
++		/* 10..19 */
++		"", "", "", "", "", "", "", "", "", "",
++		/* 20..29 */
++		"", "A4A5-I2C-mux", "", "", "", "USER-button", "", "", "", "",
++		/* 30..39 */
++		"", "", "", "", "", "", "D4200-INT", "D4201-INT", "D4202-INT";
++};
++
++&wkup_i2c0 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&wkup_i2c0_pins_default>;
++	clock-frequency = <400000>;
++};
++
++&mcu_i2c0 {
++	/* D4200 */
++	pcal9535_1: gpio@20 {
++		compatible = "nxp,pcal9535";
++		reg = <0x20>;
++		interrupt-parent = <&wkup_gpio0>;
++		interrupts = <37 IRQ_TYPE_EDGE_FALLING>;
++		#gpio-cells = <2>;
++		gpio-controller;
++		gpio-line-names =
++			"A0", "A1", "A2", "A3", "A4", "A5",
++			"IO14-direction", "IO15-direction",
++			"IO14-enable", "IO15-enable", "IO16-enable",
++			"IO17-enable", "IO18-enable", "IO19-enable",
++			"IO18-direction", "IO16-direction";
++	};
++
++	/* D4201 */
++	pcal9535_2: gpio@21 {
++		compatible = "nxp,pcal9535";
++		reg = <0x21>;
++		interrupt-parent = <&wkup_gpio0>;
++		interrupts = <36 IRQ_TYPE_EDGE_FALLING>;
++		#gpio-cells = <2>;
++		gpio-controller;
++		gpio-line-names =
++			"IO0-direction", "IO1-direction", "IO2-direction",
++			"IO3-direction", "IO4-direction", "IO5-direction",
++			"IO6-direction", "IO7-direction",
++			"IO8-direction", "IO9-direction", "IO10-direction",
++			"IO11-direction", "IO12-direction", "IO13-direction",
++			"IO19-direction";
++	};
++
++	/* D4202 */
++	pcal9535_3: gpio@25 {
++		compatible = "nxp,pcal9535";
++		reg = <0x25>;
++		interrupt-parent = <&wkup_gpio0>;
++		interrupts = <38 IRQ_TYPE_EDGE_FALLING>;
++		#gpio-cells = <2>;
++		gpio-controller;
++		gpio-line-names =
++			"IO0", "IO1", "IO2", "IO3",	"IO4", "IO5", "IO6", "IO7",
++			"IO8", "IO9", "IO10", "IO11", "IO12", "IO13";
++	};
++};
++
++&mcu_uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mcu_uart0_pins_default>;
++	status = "okay";
++};
++
++&mcu_spi0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mcu_spi0_pins_default>;
++};
++
++&tscadc1 {
++	status = "okay";
++	adc {
++		ti,adc-channels = <0 1 2 3 4 5>;
++	};
++};
++
++&ehrpwm0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ehrpwm0_pins_default>;
++	status = "okay";
++};
++
++&ehrpwm1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ehrpwm1_pins_default>;
++	status = "okay";
++};
++
++&ehrpwm2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ehrpwm2_pins_default>;
++	status = "okay";
++};
++
++&ehrpwm3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ehrpwm3_pins_default>;
++	status = "okay";
++};
++
++&ehrpwm4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ehrpwm4_pins_default>;
++	status = "okay";
++};
++
++&ehrpwm5 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ehrpwm5_pins_default>;
++	status = "okay";
++};
+diff --git a/dts/upstream/src/arm64/ti/k3-am65-iot2050-arduino-connector.dtsi b/dts/upstream/src/arm64/ti/k3-am65-iot2050-arduino-connector.dtsi
+index 6c7fdaf1f2c4..7ff0abd7c62e 100644
+--- a/dts/upstream/src/arm64/ti/k3-am65-iot2050-arduino-connector.dtsi
++++ b/dts/upstream/src/arm64/ti/k3-am65-iot2050-arduino-connector.dtsi
+@@ -138,28 +138,28 @@
+ 	d2_uart0_ctsn: d2-uart0-ctsn-pins {
+ 		pinctrl-single,pins = <
+ 			/* (P1) MCU_UART0_CTSn */
+-			AM65X_WKUP_IOPAD(0x004c, PIN_INPUT, 4)
++			AM65X_WKUP_IOPAD(0x004C, PIN_INPUT, 4)
+ 		>;
+ 	};
+ 
+ 	d2_gpio: d2-gpio-pins {
+ 		pinctrl-single,pins = <
+ 			/* (P5) WKUP_GPIO0_31 */
+-			AM65X_WKUP_IOPAD(0x004c, PIN_INPUT, 7)
++			AM65X_WKUP_IOPAD(0x004C, PIN_INPUT, 7)
+ 		>;
+ 	};
+ 
+ 	d2_gpio_pullup: d2-gpio-pullup-pins {
+ 		pinctrl-single,pins = <
+ 			/* (P5) WKUP_GPIO0_31 */
+-			AM65X_WKUP_IOPAD(0x004c, PIN_INPUT, 7)
++			AM65X_WKUP_IOPAD(0x004C, PIN_INPUT, 7)
+ 		>;
+ 	};
+ 
+ 	d2_gpio_pulldown: d2-gpio-pulldown-pins {
+ 		pinctrl-single,pins = <
+ 			/* (P5) WKUP_GPIO0_31 */
+-			AM65X_WKUP_IOPAD(0x004c, PIN_INPUT_PULLDOWN, 7)
++			AM65X_WKUP_IOPAD(0x004C, PIN_INPUT_PULLDOWN, 7)
+ 		>;
+ 	};
+ 
+@@ -348,42 +348,42 @@
+ 	a2_gpio: a2-gpio-pins {
+ 		pinctrl-single,pins = <
+ 			/* (L5) WKUP_GPIO0_43 */
+-			AM65X_WKUP_IOPAD(0x007c, PIN_INPUT, 7)
++			AM65X_WKUP_IOPAD(0x007C, PIN_INPUT, 7)
+ 		>;
+ 	};
+ 
+ 	a2_gpio_pullup: a2-gpio-pullup-pins {
+ 		pinctrl-single,pins = <
+ 			/* (L5) WKUP_GPIO0_43 */
+-			AM65X_WKUP_IOPAD(0x007c, PIN_INPUT, 7)
++			AM65X_WKUP_IOPAD(0x007C, PIN_INPUT, 7)
+ 		>;
+ 	};
+ 
+ 	a2_gpio_pulldown: a2-gpio-pulldown-pins {
+ 		pinctrl-single,pins = <
+ 			/* (L5) WKUP_GPIO0_43 */
+-			AM65X_WKUP_IOPAD(0x007c, PIN_INPUT_PULLDOWN, 7)
++			AM65X_WKUP_IOPAD(0x007C, PIN_INPUT_PULLDOWN, 7)
+ 		>;
+ 	};
+ 
+ 	a3_gpio: a3-gpio-pins {
+ 		pinctrl-single,pins = <
+ 			/* (M5) WKUP_GPIO0_39 */
+-			AM65X_WKUP_IOPAD(0x006c, PIN_INPUT, 7)
++			AM65X_WKUP_IOPAD(0x006C, PIN_INPUT, 7)
+ 		>;
+ 	};
+ 
+ 	a3_gpio_pullup: a3-gpio-pullup-pins {
+ 		pinctrl-single,pins = <
+ 			/* (M5) WKUP_GPIO0_39 */
+-			AM65X_WKUP_IOPAD(0x006c, PIN_INPUT, 7)
++			AM65X_WKUP_IOPAD(0x006C, PIN_INPUT, 7)
+ 		>;
+ 	};
+ 
+ 	a3_gpio_pulldown: a3-gpio-pulldown-pins {
+ 		pinctrl-single,pins = <
+ 			/* (M5) WKUP_GPIO0_39 */
+-			AM65X_WKUP_IOPAD(0x006c, PIN_INPUT_PULLDOWN, 7)
++			AM65X_WKUP_IOPAD(0x006C, PIN_INPUT_PULLDOWN, 7)
+ 		>;
+ 	};
+ 
+@@ -411,21 +411,21 @@
+ 	a5_gpio: a5-gpio-pins {
+ 		pinctrl-single,pins = <
+ 			/* (N5) WKUP_GPIO0_35 */
+-			AM65X_WKUP_IOPAD(0x005c, PIN_INPUT, 7)
++			AM65X_WKUP_IOPAD(0x005C, PIN_INPUT, 7)
+ 		>;
+ 	};
+ 
+ 	a5_gpio_pullup: a5-gpio-pullup-pins {
+ 		pinctrl-single,pins = <
+ 			/* (N5) WKUP_GPIO0_35 */
+-			AM65X_WKUP_IOPAD(0x005c, PIN_INPUT_PULLUP, 7)
++			AM65X_WKUP_IOPAD(0x005C, PIN_INPUT_PULLUP, 7)
+ 		>;
+ 	};
+ 
+ 	a5_gpio_pulldown: a5-gpio-pulldown-pins {
+ 		pinctrl-single,pins = <
+ 			/* (N5) WKUP_GPIO0_35 */
+-			AM65X_WKUP_IOPAD(0x005c, PIN_INPUT_PULLDOWN, 7)
++			AM65X_WKUP_IOPAD(0x005C, PIN_INPUT_PULLDOWN, 7)
+ 		>;
+ 	};
+ 
+@@ -533,28 +533,28 @@
+ 	d5_ehrpwm1_a: d5-ehrpwm1-a-pins {
+ 		pinctrl-single,pins = <
+ 			/* (AF17) EHRPWM1_A */
+-			AM65X_IOPAD(0x008c, PIN_OUTPUT, 5)
++			AM65X_IOPAD(0x008C, PIN_OUTPUT, 5)
+ 		>;
+ 	};
+ 
+ 	d5_gpio: d5-gpio-pins {
+ 		pinctrl-single,pins = <
+ 			/* (AF17) GPIO0_35 */
+-			AM65X_IOPAD(0x008c, PIN_INPUT, 7)
++			AM65X_IOPAD(0x008C, PIN_INPUT, 7)
+ 		>;
+ 	};
+ 
+ 	d5_gpio_pullup: d5-gpio-pullup-pins {
+ 		pinctrl-single,pins = <
+ 			/* (AF17) GPIO0_35 */
+-			AM65X_IOPAD(0x008c, PIN_INPUT_PULLUP, 7)
++			AM65X_IOPAD(0x008C, PIN_INPUT_PULLUP, 7)
+ 		>;
+ 	};
+ 
+ 	d5_gpio_pulldown: d5-gpio-pulldown-pins {
+ 		pinctrl-single,pins = <
+ 			/* (AF17) GPIO0_35 */
+-			AM65X_IOPAD(0x008c, PIN_INPUT_PULLDOWN, 7)
++			AM65X_IOPAD(0x008C, PIN_INPUT_PULLDOWN, 7)
+ 		>;
+ 	};
+ 
+@@ -589,84 +589,84 @@
+ 	d7_ehrpwm3_a: d7-ehrpwm3-a-pins {
+ 		pinctrl-single,pins = <
+ 			/* (AH15) EHRPWM3_A */
+-			AM65X_IOPAD(0x00ac, PIN_OUTPUT, 5)
++			AM65X_IOPAD(0x00AC, PIN_OUTPUT, 5)
+ 		>;
+ 	};
+ 
+ 	d7_gpio: d7-gpio-pins {
+ 		pinctrl-single,pins = <
+ 			/* (AH15) GPIO0_43 */
+-			AM65X_IOPAD(0x00ac, PIN_INPUT, 7)
++			AM65X_IOPAD(0x00AC, PIN_INPUT, 7)
+ 		>;
+ 	};
+ 
+ 	d7_gpio_pullup: d7-gpio-pullup-pins {
+ 		pinctrl-single,pins = <
+ 			/* (AH15) GPIO0_43 */
+-			AM65X_IOPAD(0x00ac, PIN_INPUT_PULLUP, 7)
++			AM65X_IOPAD(0x00AC, PIN_INPUT_PULLUP, 7)
+ 		>;
+ 	};
+ 
+ 	d7_gpio_pulldown: d7-gpio-pulldown-pins {
+ 		pinctrl-single,pins = <
+ 			/* (AH15) GPIO0_43 */
+-			AM65X_IOPAD(0x00ac, PIN_INPUT_PULLDOWN, 7)
++			AM65X_IOPAD(0x00AC, PIN_INPUT_PULLDOWN, 7)
+ 		>;
+ 	};
+ 
+ 	d8_ehrpwm4_a: d8-ehrpwm4-a-pins {
+ 		pinctrl-single,pins = <
+ 			/* (AG15) EHRPWM4_A */
+-			AM65X_IOPAD(0x00c0, PIN_OUTPUT, 5)
++			AM65X_IOPAD(0x00C0, PIN_OUTPUT, 5)
+ 		>;
+ 	};
+ 
+ 	d8_gpio: d8-gpio-pins {
+ 		pinctrl-single,pins = <
+ 			/* (AG15) GPIO0_48 */
+-			AM65X_IOPAD(0x00c0, PIN_INPUT, 7)
++			AM65X_IOPAD(0x00C0, PIN_INPUT, 7)
+ 		>;
+ 	};
+ 
+ 	d8_gpio_pullup: d8-gpio-pullup-pins {
+ 		pinctrl-single,pins = <
+ 			/* (AG15) GPIO0_48 */
+-			AM65X_IOPAD(0x00c0, PIN_INPUT_PULLUP, 7)
++			AM65X_IOPAD(0x00C0, PIN_INPUT_PULLUP, 7)
+ 		>;
+ 	};
+ 
+ 	d8_gpio_pulldown: d8-gpio-pulldown-pins {
+ 		pinctrl-single,pins = <
+ 			/* (AG15) GPIO0_48 */
+-			AM65X_IOPAD(0x00c0, PIN_INPUT_PULLDOWN, 7)
++			AM65X_IOPAD(0x00C0, PIN_INPUT_PULLDOWN, 7)
+ 		>;
+ 	};
+ 
+ 	d9_ehrpwm5_a: d9-ehrpwm5-a-pins {
+ 		pinctrl-single,pins = <
+ 			/* (AD15) EHRPWM5_A */
+-			AM65X_IOPAD(0x00cc, PIN_OUTPUT, 5)
++			AM65X_IOPAD(0x00CC, PIN_OUTPUT, 5)
+ 		>;
+ 	};
+ 
+ 	d9_gpio: d9-gpio-pins {
+ 		pinctrl-single,pins = <
+ 			/* (AD15) GPIO0_51 */
+-			AM65X_IOPAD(0x00cc, PIN_INPUT, 7)
++			AM65X_IOPAD(0x00CC, PIN_INPUT, 7)
+ 		>;
+ 	};
+ 
+ 	d9_gpio_pullup: d9-gpio-pullup-pins {
+ 		pinctrl-single,pins = <
+ 			/* (AD15) GPIO0_51 */
+-			AM65X_IOPAD(0x00cc, PIN_INPUT_PULLUP, 7)
++			AM65X_IOPAD(0x00CC, PIN_INPUT_PULLUP, 7)
+ 		>;
+ 	};
+ 
+ 	d9_gpio_pulldown: d9-gpio-pulldown-pins {
+ 		pinctrl-single,pins = <
+ 			/* (AD15) GPIO0_51 */
+-			AM65X_IOPAD(0x00cc, PIN_INPUT_PULLDOWN, 7)
++			AM65X_IOPAD(0x00CC, PIN_INPUT_PULLDOWN, 7)
+ 		>;
+ 	};
+ };
+diff --git a/dts/upstream/src/arm64/ti/k3-am6528-iot2050-basic-pg2.dts b/dts/upstream/src/arm64/ti/k3-am6528-iot2050-basic-pg2.dts
+index c1faf9497b63..a312f6db15e3 100644
+--- a/dts/upstream/src/arm64/ti/k3-am6528-iot2050-basic-pg2.dts
++++ b/dts/upstream/src/arm64/ti/k3-am6528-iot2050-basic-pg2.dts
+@@ -16,8 +16,8 @@
+ /dts-v1/;
+ 
+ #include "k3-am6528-iot2050-basic-common.dtsi"
+-#include "k3-am65-iot2050-common-pg2.dtsi"
+ #include "k3-am65-iot2050-dp.dtsi"
++#include "k3-am65-iot2050-common-pg2.dtsi"
+ #include "k3-am65-iot2050-usb3.dtsi"
+ 
+ / {
+diff --git a/dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-m2-common.dtsi b/dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-m2-common.dtsi
+new file mode 100644
+index 000000000000..665e2f9d3f4b
+--- /dev/null
++++ b/dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-m2-common.dtsi
+@@ -0,0 +1,83 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (c) Siemens AG, 2018-2026
++ *
++ * Authors:
++ *   Chao Zeng <chao.zeng@siemens.com>
++ *   Jan Kiszka <jan.kiszka@siemens.com>
++ */
++
++#include "k3-am6548-iot2050-advanced-common.dtsi"
++#include "k3-am65-iot2050-dp.dtsi"
++#include "k3-am65-iot2050-common-pg2.dtsi"
++
++&main_pmx0 {
++	main_bkey_pcie_reset: main-bkey-pcie-reset-default-pins {
++		pinctrl-single,pins = <
++			AM65X_IOPAD(0x01bc, PIN_OUTPUT_PULLUP, 7)  /* (AG13) GPIO1_15 */
++		>;
++	};
++
++	main_pmx0_m2_config_pins_default: main-pmx0-m2-config-default-pins {
++		pinctrl-single,pins = <
++			AM65X_IOPAD(0x01c8, PIN_INPUT_PULLUP, 7)  /* (AE13) GPIO1_18 */
++			AM65X_IOPAD(0x01cc, PIN_INPUT_PULLUP, 7)  /* (AD13) GPIO1_19 */
++		>;
++	};
++
++	main_m2_pcie_mux_control: main-m2-pcie-mux-control-default-pins {
++		pinctrl-single,pins = <
++			AM65X_IOPAD(0x0148, PIN_INPUT_PULLUP, 7)  /* (AG22) GPIO0_82 */
++			AM65X_IOPAD(0x0160, PIN_INPUT_PULLUP, 7)  /* (AE20) GPIO0_88 */
++			AM65X_IOPAD(0x0164, PIN_INPUT_PULLUP, 7)  /* (AF19) GPIO0_89 */
++		>;
++	};
++};
++
++&main_pmx1 {
++	main_pmx1_m2_config_pins_default: main-pmx1-m2-config-default-pins {
++		pinctrl-single,pins = <
++			AM65X_IOPAD(0x0018, PIN_INPUT_PULLUP, 7)  /* (B22) GPIO1_88 */
++			AM65X_IOPAD(0x001c, PIN_INPUT_PULLUP, 7)  /* (C23) GPIO1_89 */
++		>;
++	};
++};
++
++&main_gpio0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&main_m2_pcie_mux_control>;
++};
++
++&main_gpio1 {
++	pinctrl-names = "default";
++	pinctrl-0 =
++		<&main_pcie_enable_pins_default>,
++		<&main_pmx0_m2_config_pins_default>,
++		<&main_pmx1_m2_config_pins_default>,
++		<&cp2102n_reset_pin_default>;
++};
++
++/*
++ * Base configuration for B-key slot with PCIe x2, E-key with USB 2.0 only.
++ * Firmware switches to other modes via device tree overlays.
++ */
++
++&serdes0 {
++	assigned-clocks = <&k3_clks 153 4>, <&serdes0 AM654_SERDES_CMU_REFCLK>;
++	assigned-clock-parents = <&k3_clks 153 8>, <&k3_clks 153 4>;
++};
++
++&pcie0_rc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&main_bkey_pcie_reset>;
++
++	num-lanes = <2>;
++	phys = <&serdes0 PHY_TYPE_PCIE 1>, <&serdes1 PHY_TYPE_PCIE 1>;
++	phy-names = "pcie-phy0","pcie-phy1";
++	reset-gpios = <&main_gpio1 15 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++};
++
++&pcie1_rc {
++	status = "disabled";
++};
+diff --git a/dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-m2-rev.dts b/dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-m2-rev.dts
+new file mode 100644
+index 000000000000..07b2350fb218
+--- /dev/null
++++ b/dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-m2-rev.dts
+@@ -0,0 +1,23 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (c) Siemens AG, 2026
++ *
++ * Authors:
++ *   Baocheng Su <baocheng.su@siemens.com>
++ *
++ * AM6548-based (quad-core) IOT2050 M.2 variant (based on Advanced Product
++ * Generation 2), 2 GB RAM, 16 GB eMMC, USB-serial converter on connector X30
++ *
++ * Rev: Arduino interface re-design
++ *
++ * Product homepage:
++ * https://new.siemens.com/global/en/products/automation/pc-based/iot-gateways/simatic-iot2050.html
++ */
++
++#include "k3-am6548-iot2050-advanced-m2-common.dtsi"
++#include "k3-am65-iot2050-arduino-connector-rev.dtsi"
++
++/ {
++	compatible = "siemens,iot2050-advanced-m2-rev", "ti,am654";
++	model = "SIMATIC IOT2050 Advanced M2 Rev";
++};
+diff --git a/dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-m2.dts b/dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-m2.dts
+index cc619bbec181..0ff659a2c1b8 100644
+--- a/dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-m2.dts
++++ b/dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-m2.dts
+@@ -1,6 +1,6 @@
+ // SPDX-License-Identifier: GPL-2.0-only
+ /*
+- * Copyright (c) Siemens AG, 2018-2023
++ * Copyright (c) Siemens AG, 2018-2026
+  *
+  * Authors:
+  *   Chao Zeng <chao.zeng@siemens.com>
+@@ -13,83 +13,10 @@
+  * https://new.siemens.com/global/en/products/automation/pc-based/iot-gateways/simatic-iot2050.html
+  */
+ 
+-#include "k3-am6548-iot2050-advanced-common.dtsi"
+-#include "k3-am65-iot2050-common-pg2.dtsi"
++#include "k3-am6548-iot2050-advanced-m2-common.dtsi"
+ #include "k3-am65-iot2050-arduino-connector.dtsi"
+-#include "k3-am65-iot2050-dp.dtsi"
+ 
+ / {
+ 	compatible = "siemens,iot2050-advanced-m2", "ti,am654";
+ 	model = "SIMATIC IOT2050 Advanced M2";
+ };
+-
+-&main_pmx0 {
+-	main_bkey_pcie_reset: main-bkey-pcie-reset-default-pins {
+-		pinctrl-single,pins = <
+-			AM65X_IOPAD(0x01bc, PIN_OUTPUT_PULLUP, 7)  /* (AG13) GPIO1_15 */
+-		>;
+-	};
+-
+-	main_pmx0_m2_config_pins_default: main-pmx0-m2-config-default-pins {
+-		pinctrl-single,pins = <
+-			AM65X_IOPAD(0x01c8, PIN_INPUT_PULLUP, 7)  /* (AE13) GPIO1_18 */
+-			AM65X_IOPAD(0x01cc, PIN_INPUT_PULLUP, 7)  /* (AD13) GPIO1_19 */
+-		>;
+-	};
+-
+-	main_m2_pcie_mux_control: main-m2-pcie-mux-control-default-pins {
+-		pinctrl-single,pins = <
+-			AM65X_IOPAD(0x0148, PIN_INPUT_PULLUP, 7)  /* (AG22) GPIO0_82 */
+-			AM65X_IOPAD(0x0160, PIN_INPUT_PULLUP, 7)  /* (AE20) GPIO0_88 */
+-			AM65X_IOPAD(0x0164, PIN_INPUT_PULLUP, 7)  /* (AF19) GPIO0_89 */
+-		>;
+-	};
+-};
+-
+-&main_pmx1 {
+-	main_pmx1_m2_config_pins_default: main-pmx1-m2-config-default-pins {
+-		pinctrl-single,pins = <
+-			AM65X_IOPAD(0x0018, PIN_INPUT_PULLUP, 7)  /* (B22) GPIO1_88 */
+-			AM65X_IOPAD(0x001c, PIN_INPUT_PULLUP, 7)  /* (C23) GPIO1_89 */
+-		>;
+-	};
+-};
+-
+-&main_gpio0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&main_m2_pcie_mux_control>;
+-};
+-
+-&main_gpio1 {
+-	pinctrl-names = "default";
+-	pinctrl-0 =
+-		<&main_pcie_enable_pins_default>,
+-		<&main_pmx0_m2_config_pins_default>,
+-		<&main_pmx1_m2_config_pins_default>,
+-		<&cp2102n_reset_pin_default>;
+-};
+-
+-/*
+- * Base configuration for B-key slot with PCIe x2, E-key with USB 2.0 only.
+- * Firmware switches to other modes via device tree overlays.
+- */
+-
+-&serdes0 {
+-	assigned-clocks = <&k3_clks 153 4>, <&serdes0 AM654_SERDES_CMU_REFCLK>;
+-	assigned-clock-parents = <&k3_clks 153 8>, <&k3_clks 153 4>;
+-};
+-
+-&pcie0_rc {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&main_bkey_pcie_reset>;
+-
+-	num-lanes = <2>;
+-	phys = <&serdes0 PHY_TYPE_PCIE 1>, <&serdes1 PHY_TYPE_PCIE 1>;
+-	phy-names = "pcie-phy0","pcie-phy1";
+-	reset-gpios = <&main_gpio1 15 GPIO_ACTIVE_HIGH>;
+-	status = "okay";
+-};
+-
+-&pcie1_rc {
+-	status = "disabled";
+-};
+diff --git a/dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-pg2-rev.dts b/dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-pg2-rev.dts
+new file mode 100644
+index 000000000000..d84c2ffa31b8
+--- /dev/null
++++ b/dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-pg2-rev.dts
+@@ -0,0 +1,28 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (c) Siemens AG, 2026
++ *
++ * Authors:
++ *   Baocheng Su <baocheng.su@siemens.com>
++ *
++ * AM6548-based (quad-core) IOT2050 Advanced variant, Product Generation 2
++ * 2 GB RAM, 16 GB eMMC, USB-serial converter on connector X30
++ *
++ * Rev: Arduino interface re-design
++ *
++ * Product homepage:
++ * https://new.siemens.com/global/en/products/automation/pc-based/iot-gateways/simatic-iot2050.html
++ */
++
++/dts-v1/;
++
++#include "k3-am6548-iot2050-advanced-common.dtsi"
++#include "k3-am65-iot2050-dp.dtsi"
++#include "k3-am65-iot2050-common-pg2.dtsi"
++#include "k3-am65-iot2050-arduino-connector-rev.dtsi"
++#include "k3-am65-iot2050-usb3.dtsi"
++
++/ {
++	compatible = "siemens,iot2050-advanced-pg2-rev", "ti,am654";
++	model = "SIMATIC IOT2050 Advanced PG2 Rev";
++};
+diff --git a/dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-pg2.dts b/dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-pg2.dts
+index ec721275e8e2..231af1363d91 100644
+--- a/dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-pg2.dts
++++ b/dts/upstream/src/arm64/ti/k3-am6548-iot2050-advanced-pg2.dts
+@@ -16,9 +16,9 @@
+ /dts-v1/;
+ 
+ #include "k3-am6548-iot2050-advanced-common.dtsi"
++#include "k3-am65-iot2050-dp.dtsi"
+ #include "k3-am65-iot2050-common-pg2.dtsi"
+ #include "k3-am65-iot2050-arduino-connector.dtsi"
+-#include "k3-am65-iot2050-dp.dtsi"
+ #include "k3-am65-iot2050-usb3.dtsi"
+ 
+ / {

--- a/meta/recipes-bsp/u-boot/u-boot-iot2050_2026.07.bb
+++ b/meta/recipes-bsp/u-boot/u-boot-iot2050_2026.07.bb
@@ -29,6 +29,7 @@ SRC_URI += " \
     file://0012-arm64-dts-ti-iot2050-Keep-SPI-NOR-in-SPL.patch \
     file://0013-arm-k3-Fix-SPL-reserved-memory-fixup-order.patch \
     file://0014-arm-armv8-mmu-Match-reserved-memory-basenames.patch \
+    file://0015-board-siemens-iot2050-Add-Arduino-rev-support.patch \
     "
 
 SRC_URI[sha256sum] = "78e8bfc382fe388f9b55aa1daf8c563522a037779b5d4c349d1415e381f1243e"

--- a/meta/recipes-kernel/linux/files/patches/0029-arm64-dts-ti-iot2050-Add-revised-Arduino-connector-s.patch
+++ b/meta/recipes-kernel/linux/files/patches/0029-arm64-dts-ti-iot2050-Add-revised-Arduino-connector-s.patch
@@ -1,0 +1,567 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Su Bao Cheng <baocheng.su@siemens.com>
+Date: Wed, 24 Jun 2026 21:42:59 -0400
+Subject: [PATCH] arm64: dts: ti: iot2050: Add revised Arduino connector
+ support
+
+Add device tree descriptions for the revised Arduino connector used by
+IOT2050 Advanced M2 and Advanced PG2 boards.
+
+The revised connector design moves the Arduino I/O signals and direction
+controls to three PCAL9535 GPIO expanders. Add their interrupt connections,
+GPIO line names, pin multiplexing, ADC, PWM, MCU UART, and I2C configuration.
+
+Split the common Advanced M2 board configuration from the board-specific
+device tree so that it can be shared by the original and revised M2 variants.
+Keep the existing device tree names unchanged and add separate DTBs for the
+revised M2 and PG2 variants.
+
+Signed-off-by: Su Bao Cheng <baocheng.su@siemens.com>
+---
+ .../devicetree/bindings/arm/ti/k3.yaml        |   2 +
+ arch/arm64/boot/dts/ti/Makefile               |   8 +
+ ...k3-am65-iot2050-arduino-connector-rev.dtsi | 231 ++++++++++++++++++
+ .../k3-am6548-iot2050-advanced-m2-common.dtsi |  83 +++++++
+ .../ti/k3-am6548-iot2050-advanced-m2-rev.dts  |  23 ++
+ .../dts/ti/k3-am6548-iot2050-advanced-m2.dts  |  77 +-----
+ .../ti/k3-am6548-iot2050-advanced-pg2-rev.dts |  28 +++
+ 7 files changed, 377 insertions(+), 75 deletions(-)
+ create mode 100644 arch/arm64/boot/dts/ti/k3-am65-iot2050-arduino-connector-rev.dtsi
+ create mode 100644 arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2-common.dtsi
+ create mode 100644 arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2-rev.dts
+ create mode 100644 arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-pg2-rev.dts
+
+diff --git a/Documentation/devicetree/bindings/arm/ti/k3.yaml b/Documentation/devicetree/bindings/arm/ti/k3.yaml
+index 5df99e361c21..e1f8b47a5abe 100644
+--- a/Documentation/devicetree/bindings/arm/ti/k3.yaml
++++ b/Documentation/devicetree/bindings/arm/ti/k3.yaml
+@@ -105,7 +105,9 @@ properties:
+           - enum:
+               - siemens,iot2050-advanced
+               - siemens,iot2050-advanced-m2
++              - siemens,iot2050-advanced-m2-rev
+               - siemens,iot2050-advanced-pg2
++              - siemens,iot2050-advanced-pg2-rev
+               - siemens,iot2050-advanced-sm
+               - siemens,iot2050-basic
+               - siemens,iot2050-basic-pg2
+diff --git a/arch/arm64/boot/dts/ti/Makefile b/arch/arm64/boot/dts/ti/Makefile
+index a97736de605f..c497fd41df0e 100644
+--- a/arch/arm64/boot/dts/ti/Makefile
++++ b/arch/arm64/boot/dts/ti/Makefile
+@@ -73,13 +73,19 @@ k3-am6548-iot2050-advanced-m2-bkey-ekey-pcie-dtbs := k3-am6548-iot2050-advanced-
+ 	k3-am6548-iot2050-advanced-m2-bkey-ekey-pcie.dtbo
+ k3-am6548-iot2050-advanced-m2-bkey-usb3-dtbs := k3-am6548-iot2050-advanced-m2.dtb \
+ 	k3-am6548-iot2050-advanced-m2-bkey-usb3.dtbo
++k3-am6548-iot2050-advanced-m2-rev-bkey-ekey-pcie-dtbs := k3-am6548-iot2050-advanced-m2-rev.dtb \
++	k3-am6548-iot2050-advanced-m2-bkey-ekey-pcie.dtbo
++k3-am6548-iot2050-advanced-m2-rev-bkey-usb3-dtbs := k3-am6548-iot2050-advanced-m2-rev.dtb \
++	k3-am6548-iot2050-advanced-m2-bkey-usb3.dtbo
+ dtb-$(CONFIG_ARCH_K3) += k3-am6528-iot2050-basic.dtb
+ dtb-$(CONFIG_ARCH_K3) += k3-am6528-iot2050-basic-pg2.dtb
+ dtb-$(CONFIG_ARCH_K3) += k3-am6548-iot2050-advanced.dtb
+ dtb-$(CONFIG_ARCH_K3) += k3-am6548-iot2050-advanced-m2.dtb
++dtb-$(CONFIG_ARCH_K3) += k3-am6548-iot2050-advanced-m2-rev.dtb
+ dtb-$(CONFIG_ARCH_K3) += k3-am6548-iot2050-advanced-m2-bkey-ekey-pcie.dtb
+ dtb-$(CONFIG_ARCH_K3) += k3-am6548-iot2050-advanced-m2-bkey-usb3.dtb
+ dtb-$(CONFIG_ARCH_K3) += k3-am6548-iot2050-advanced-pg2.dtb
++dtb-$(CONFIG_ARCH_K3) += k3-am6548-iot2050-advanced-pg2-rev.dtb
+ dtb-$(CONFIG_ARCH_K3) += k3-am6548-iot2050-advanced-sm.dtb
+ dtb-$(CONFIG_ARCH_K3) += k3-am654-base-board.dtb
+ dtb-$(CONFIG_ARCH_K3) += k3-am654-gp-evm.dtb
+@@ -237,7 +243,9 @@ DTC_FLAGS_k3-am642-evm += -@
+ DTC_FLAGS_k3-am642-phyboard-electra-rdk += -@
+ DTC_FLAGS_k3-am642-tqma64xxl-mbax4xxl += -@
+ DTC_FLAGS_k3-am6548-iot2050-advanced-m2 += -@
++DTC_FLAGS_k3-am6548-iot2050-advanced-m2-rev += -@
+ DTC_FLAGS_k3-am6548-iot2050-advanced-pg2 += -@
++DTC_FLAGS_k3-am6548-iot2050-advanced-pg2-rev += -@
+ DTC_FLAGS_k3-am6548-iot2050-advanced-sm += -@
+ DTC_FLAGS_k3-am68-sk-base-board += -@
+ DTC_FLAGS_k3-am69-sk += -@
+diff --git a/arch/arm64/boot/dts/ti/k3-am65-iot2050-arduino-connector-rev.dtsi b/arch/arm64/boot/dts/ti/k3-am65-iot2050-arduino-connector-rev.dtsi
+new file mode 100644
+index 000000000000..70638b5252c8
+--- /dev/null
++++ b/arch/arm64/boot/dts/ti/k3-am65-iot2050-arduino-connector-rev.dtsi
+@@ -0,0 +1,231 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (c) Siemens AG, 2026
++ *
++ * Authors:
++ *   Baocheng Su <baocheng.su@siemens.com>
++ *
++ * Arduino connector rework for IOT2050 Advanced PG2 variants (M2/PG2).
++ *
++ * All the arduino pins are connected to the I2C GPIO expanders (D4200,
++ * D4201, D4202).
++ */
++
++&main_pmx0 {
++	ehrpwm0_pins_default: ehrpwm0-default-pins {
++		pinctrl-single,pins = <
++			/* (AG18) EHRPWM0_A */
++			AM65X_IOPAD(0x0084, PIN_OUTPUT, 5)
++		>;
++	};
++
++	ehrpwm1_pins_default: ehrpwm1-default-pins {
++		pinctrl-single,pins = <
++			/* (AF17) EHRPWM1_A */
++			AM65X_IOPAD(0x008C, PIN_OUTPUT, 5)
++		>;
++	};
++
++	ehrpwm2_pins_default: ehrpwm2-default-pins {
++		pinctrl-single,pins = <
++			/* (AH16) EHRPWM2_A */
++			AM65X_IOPAD(0x0098, PIN_OUTPUT, 5)
++		>;
++	};
++
++	ehrpwm3_pins_default: ehrpwm3-default-pins {
++		pinctrl-single,pins = <
++			/* (AH15) EHRPWM3_A */
++			AM65X_IOPAD(0x00AC, PIN_OUTPUT, 5)
++		>;
++	};
++
++	ehrpwm4_pins_default: ehrpwm4-default-pins {
++		pinctrl-single,pins = <
++			/* (AG15) EHRPWM4_A */
++			AM65X_IOPAD(0x00C0, PIN_OUTPUT, 5)
++		>;
++	};
++
++	ehrpwm5_pins_default: ehrpwm5-default-pins {
++		pinctrl-single,pins = <
++			/* (AD15) EHRPWM5_A */
++			AM65X_IOPAD(0x00CC, PIN_OUTPUT, 5)
++		>;
++	};
++};
++
++&main_gpio0 {
++	gpio-line-names = "main_gpio0-base";
++};
++
++&wkup_pmx0 {
++	mcu_uart0_pins_default: mcu-uart0-default-pins {
++		pinctrl-single,pins = <
++			/* (P4) MCU_UART0_RXD */
++			AM65X_WKUP_IOPAD(0x0044, PIN_INPUT, 4)
++			/* (P5) MCU_UART0_TXD */
++			AM65X_WKUP_IOPAD(0x0048, PIN_OUTPUT, 4)
++			/* (P1) MCU_UART0_CTSn */
++			AM65X_WKUP_IOPAD(0x004C, PIN_INPUT, 4)
++			/* (N3) MCU_UART0_RTSn */
++			AM65X_WKUP_IOPAD(0x0054, PIN_OUTPUT, 4)
++		>;
++	};
++
++	wkup_i2c0_pins_default: wkup-i2c0-default-pins {
++		pinctrl-single,pins = <
++			/* (AC7) WKUP_I2C0_SCL */
++			AM65X_WKUP_IOPAD(0x00e0, PIN_INPUT,  0)
++			/* (AD6) WKUP_I2C0_SDA */
++			AM65X_WKUP_IOPAD(0x00e4, PIN_INPUT,  0)
++		>;
++	};
++
++	arduino_i2c_aio_switch_pins_default: arduino-i2c-aio-switch-default-pins {
++		pinctrl-single,pins = <
++			/* (R2) WKUP_GPIO0_21 */
++			AM65X_WKUP_IOPAD(0x0024, PIN_OUTPUT, 7)
++		>;
++	};
++
++	io_expander_int_pins_default: io-expander-int-default-pins {
++		pinctrl-single,pins = <
++			/* (M2) WKUP_GPIO0_36 → D4200 INT */
++			AM65X_WKUP_IOPAD(0x0060, PIN_INPUT_PULLUP, 7)
++			/* (M3) WKUP_GPIO0_37 → D4201 INT */
++			AM65X_WKUP_IOPAD(0x0064, PIN_INPUT_PULLUP, 7)
++			/* (M4) WKUP_GPIO0_38 → D4202 INT */
++			AM65X_WKUP_IOPAD(0x0068, PIN_INPUT_PULLUP, 7)
++		>;
++	};
++};
++
++&wkup_gpio0 {
++	pinctrl-names = "default";
++	pinctrl-0 =
++		<&arduino_i2c_aio_switch_pins_default>,
++		<&io_expander_int_pins_default>,
++		<&push_button_pins_default>,
++		<&db9_com_mode_pins_default>;
++
++	gpio-line-names =
++		/* 0..9 */
++		"wkup_gpio0-base", "", "", "", "UART0-mode1", "UART0-mode0",
++		"UART0-enable", "UART0-terminate", "", "WIFI-disable",
++		/* 10..19 */
++		"", "", "", "", "", "", "", "", "", "",
++		/* 20..29 */
++		"", "A4A5-I2C-mux", "", "", "", "USER-button", "", "", "", "",
++		/* 30..39 */
++		"", "", "", "", "", "", "D4200-INT", "D4201-INT", "D4202-INT";
++};
++
++&wkup_i2c0 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&wkup_i2c0_pins_default>;
++	clock-frequency = <400000>;
++};
++
++&mcu_i2c0 {
++	/* D4200 */
++	pcal9535_1: gpio@20 {
++		compatible = "nxp,pcal9535";
++		reg = <0x20>;
++		interrupt-parent = <&wkup_gpio0>;
++		interrupts = <37 IRQ_TYPE_EDGE_FALLING>;
++		#gpio-cells = <2>;
++		gpio-controller;
++		gpio-line-names =
++			"A0", "A1", "A2", "A3", "A4", "A5",
++			"IO14-direction", "IO15-direction",
++			"IO14-enable", "IO15-enable", "IO16-enable",
++			"IO17-enable", "IO18-enable", "IO19-enable",
++			"IO18-direction", "IO16-direction";
++	};
++
++	/* D4201 */
++	pcal9535_2: gpio@21 {
++		compatible = "nxp,pcal9535";
++		reg = <0x21>;
++		interrupt-parent = <&wkup_gpio0>;
++		interrupts = <36 IRQ_TYPE_EDGE_FALLING>;
++		#gpio-cells = <2>;
++		gpio-controller;
++		gpio-line-names =
++			"IO0-direction", "IO1-direction", "IO2-direction",
++			"IO3-direction", "IO4-direction", "IO5-direction",
++			"IO6-direction", "IO7-direction",
++			"IO8-direction", "IO9-direction", "IO10-direction",
++			"IO11-direction", "IO12-direction", "IO13-direction",
++			"IO19-direction";
++	};
++
++	/* D4202 */
++	pcal9535_3: gpio@25 {
++		compatible = "nxp,pcal9535";
++		reg = <0x25>;
++		interrupt-parent = <&wkup_gpio0>;
++		interrupts = <38 IRQ_TYPE_EDGE_FALLING>;
++		#gpio-cells = <2>;
++		gpio-controller;
++		gpio-line-names =
++			"IO0", "IO1", "IO2", "IO3",	"IO4", "IO5", "IO6", "IO7",
++			"IO8", "IO9", "IO10", "IO11", "IO12", "IO13";
++	};
++};
++
++&mcu_uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mcu_uart0_pins_default>;
++	status = "okay";
++};
++
++&mcu_spi0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mcu_spi0_pins_default>;
++};
++
++&tscadc1 {
++	status = "okay";
++	adc {
++		ti,adc-channels = <0 1 2 3 4 5>;
++	};
++};
++
++&ehrpwm0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ehrpwm0_pins_default>;
++	status = "okay";
++};
++
++&ehrpwm1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ehrpwm1_pins_default>;
++	status = "okay";
++};
++
++&ehrpwm2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ehrpwm2_pins_default>;
++	status = "okay";
++};
++
++&ehrpwm3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ehrpwm3_pins_default>;
++	status = "okay";
++};
++
++&ehrpwm4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ehrpwm4_pins_default>;
++	status = "okay";
++};
++
++&ehrpwm5 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ehrpwm5_pins_default>;
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2-common.dtsi b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2-common.dtsi
+new file mode 100644
+index 000000000000..665e2f9d3f4b
+--- /dev/null
++++ b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2-common.dtsi
+@@ -0,0 +1,83 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (c) Siemens AG, 2018-2026
++ *
++ * Authors:
++ *   Chao Zeng <chao.zeng@siemens.com>
++ *   Jan Kiszka <jan.kiszka@siemens.com>
++ */
++
++#include "k3-am6548-iot2050-advanced-common.dtsi"
++#include "k3-am65-iot2050-dp.dtsi"
++#include "k3-am65-iot2050-common-pg2.dtsi"
++
++&main_pmx0 {
++	main_bkey_pcie_reset: main-bkey-pcie-reset-default-pins {
++		pinctrl-single,pins = <
++			AM65X_IOPAD(0x01bc, PIN_OUTPUT_PULLUP, 7)  /* (AG13) GPIO1_15 */
++		>;
++	};
++
++	main_pmx0_m2_config_pins_default: main-pmx0-m2-config-default-pins {
++		pinctrl-single,pins = <
++			AM65X_IOPAD(0x01c8, PIN_INPUT_PULLUP, 7)  /* (AE13) GPIO1_18 */
++			AM65X_IOPAD(0x01cc, PIN_INPUT_PULLUP, 7)  /* (AD13) GPIO1_19 */
++		>;
++	};
++
++	main_m2_pcie_mux_control: main-m2-pcie-mux-control-default-pins {
++		pinctrl-single,pins = <
++			AM65X_IOPAD(0x0148, PIN_INPUT_PULLUP, 7)  /* (AG22) GPIO0_82 */
++			AM65X_IOPAD(0x0160, PIN_INPUT_PULLUP, 7)  /* (AE20) GPIO0_88 */
++			AM65X_IOPAD(0x0164, PIN_INPUT_PULLUP, 7)  /* (AF19) GPIO0_89 */
++		>;
++	};
++};
++
++&main_pmx1 {
++	main_pmx1_m2_config_pins_default: main-pmx1-m2-config-default-pins {
++		pinctrl-single,pins = <
++			AM65X_IOPAD(0x0018, PIN_INPUT_PULLUP, 7)  /* (B22) GPIO1_88 */
++			AM65X_IOPAD(0x001c, PIN_INPUT_PULLUP, 7)  /* (C23) GPIO1_89 */
++		>;
++	};
++};
++
++&main_gpio0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&main_m2_pcie_mux_control>;
++};
++
++&main_gpio1 {
++	pinctrl-names = "default";
++	pinctrl-0 =
++		<&main_pcie_enable_pins_default>,
++		<&main_pmx0_m2_config_pins_default>,
++		<&main_pmx1_m2_config_pins_default>,
++		<&cp2102n_reset_pin_default>;
++};
++
++/*
++ * Base configuration for B-key slot with PCIe x2, E-key with USB 2.0 only.
++ * Firmware switches to other modes via device tree overlays.
++ */
++
++&serdes0 {
++	assigned-clocks = <&k3_clks 153 4>, <&serdes0 AM654_SERDES_CMU_REFCLK>;
++	assigned-clock-parents = <&k3_clks 153 8>, <&k3_clks 153 4>;
++};
++
++&pcie0_rc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&main_bkey_pcie_reset>;
++
++	num-lanes = <2>;
++	phys = <&serdes0 PHY_TYPE_PCIE 1>, <&serdes1 PHY_TYPE_PCIE 1>;
++	phy-names = "pcie-phy0","pcie-phy1";
++	reset-gpios = <&main_gpio1 15 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++};
++
++&pcie1_rc {
++	status = "disabled";
++};
+diff --git a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2-rev.dts b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2-rev.dts
+new file mode 100644
+index 000000000000..07b2350fb218
+--- /dev/null
++++ b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2-rev.dts
+@@ -0,0 +1,23 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (c) Siemens AG, 2026
++ *
++ * Authors:
++ *   Baocheng Su <baocheng.su@siemens.com>
++ *
++ * AM6548-based (quad-core) IOT2050 M.2 variant (based on Advanced Product
++ * Generation 2), 2 GB RAM, 16 GB eMMC, USB-serial converter on connector X30
++ *
++ * Rev: Arduino interface re-design
++ *
++ * Product homepage:
++ * https://new.siemens.com/global/en/products/automation/pc-based/iot-gateways/simatic-iot2050.html
++ */
++
++#include "k3-am6548-iot2050-advanced-m2-common.dtsi"
++#include "k3-am65-iot2050-arduino-connector-rev.dtsi"
++
++/ {
++	compatible = "siemens,iot2050-advanced-m2-rev", "ti,am654";
++	model = "SIMATIC IOT2050 Advanced M2 Rev";
++};
+diff --git a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2.dts b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2.dts
+index abf0690fca89..0ff659a2c1b8 100644
+--- a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2.dts
++++ b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-m2.dts
+@@ -1,6 +1,6 @@
+ // SPDX-License-Identifier: GPL-2.0-only
+ /*
+- * Copyright (c) Siemens AG, 2018-2023
++ * Copyright (c) Siemens AG, 2018-2026
+  *
+  * Authors:
+  *   Chao Zeng <chao.zeng@siemens.com>
+@@ -13,83 +13,10 @@
+  * https://new.siemens.com/global/en/products/automation/pc-based/iot-gateways/simatic-iot2050.html
+  */
+ 
+-#include "k3-am6548-iot2050-advanced-common.dtsi"
+-#include "k3-am65-iot2050-dp.dtsi"
+-#include "k3-am65-iot2050-common-pg2.dtsi"
++#include "k3-am6548-iot2050-advanced-m2-common.dtsi"
+ #include "k3-am65-iot2050-arduino-connector.dtsi"
+ 
+ / {
+ 	compatible = "siemens,iot2050-advanced-m2", "ti,am654";
+ 	model = "SIMATIC IOT2050 Advanced M2";
+ };
+-
+-&main_pmx0 {
+-	main_bkey_pcie_reset: main-bkey-pcie-reset-default-pins {
+-		pinctrl-single,pins = <
+-			AM65X_IOPAD(0x01bc, PIN_OUTPUT_PULLUP, 7)  /* (AG13) GPIO1_15 */
+-		>;
+-	};
+-
+-	main_pmx0_m2_config_pins_default: main-pmx0-m2-config-default-pins {
+-		pinctrl-single,pins = <
+-			AM65X_IOPAD(0x01c8, PIN_INPUT_PULLUP, 7)  /* (AE13) GPIO1_18 */
+-			AM65X_IOPAD(0x01cc, PIN_INPUT_PULLUP, 7)  /* (AD13) GPIO1_19 */
+-		>;
+-	};
+-
+-	main_m2_pcie_mux_control: main-m2-pcie-mux-control-default-pins {
+-		pinctrl-single,pins = <
+-			AM65X_IOPAD(0x0148, PIN_INPUT_PULLUP, 7)  /* (AG22) GPIO0_82 */
+-			AM65X_IOPAD(0x0160, PIN_INPUT_PULLUP, 7)  /* (AE20) GPIO0_88 */
+-			AM65X_IOPAD(0x0164, PIN_INPUT_PULLUP, 7)  /* (AF19) GPIO0_89 */
+-		>;
+-	};
+-};
+-
+-&main_pmx1 {
+-	main_pmx1_m2_config_pins_default: main-pmx1-m2-config-default-pins {
+-		pinctrl-single,pins = <
+-			AM65X_IOPAD(0x0018, PIN_INPUT_PULLUP, 7)  /* (B22) GPIO1_88 */
+-			AM65X_IOPAD(0x001c, PIN_INPUT_PULLUP, 7)  /* (C23) GPIO1_89 */
+-		>;
+-	};
+-};
+-
+-&main_gpio0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&main_m2_pcie_mux_control>;
+-};
+-
+-&main_gpio1 {
+-	pinctrl-names = "default";
+-	pinctrl-0 =
+-		<&main_pcie_enable_pins_default>,
+-		<&main_pmx0_m2_config_pins_default>,
+-		<&main_pmx1_m2_config_pins_default>,
+-		<&cp2102n_reset_pin_default>;
+-};
+-
+-/*
+- * Base configuration for B-key slot with PCIe x2, E-key with USB 2.0 only.
+- * Firmware switches to other modes via device tree overlays.
+- */
+-
+-&serdes0 {
+-	assigned-clocks = <&k3_clks 153 4>, <&serdes0 AM654_SERDES_CMU_REFCLK>;
+-	assigned-clock-parents = <&k3_clks 153 8>, <&k3_clks 153 4>;
+-};
+-
+-&pcie0_rc {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&main_bkey_pcie_reset>;
+-
+-	num-lanes = <2>;
+-	phys = <&serdes0 PHY_TYPE_PCIE 1>, <&serdes1 PHY_TYPE_PCIE 1>;
+-	phy-names = "pcie-phy0","pcie-phy1";
+-	reset-gpios = <&main_gpio1 15 GPIO_ACTIVE_HIGH>;
+-	status = "okay";
+-};
+-
+-&pcie1_rc {
+-	status = "disabled";
+-};
+diff --git a/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-pg2-rev.dts b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-pg2-rev.dts
+new file mode 100644
+index 000000000000..d84c2ffa31b8
+--- /dev/null
++++ b/arch/arm64/boot/dts/ti/k3-am6548-iot2050-advanced-pg2-rev.dts
+@@ -0,0 +1,28 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (c) Siemens AG, 2026
++ *
++ * Authors:
++ *   Baocheng Su <baocheng.su@siemens.com>
++ *
++ * AM6548-based (quad-core) IOT2050 Advanced variant, Product Generation 2
++ * 2 GB RAM, 16 GB eMMC, USB-serial converter on connector X30
++ *
++ * Rev: Arduino interface re-design
++ *
++ * Product homepage:
++ * https://new.siemens.com/global/en/products/automation/pc-based/iot-gateways/simatic-iot2050.html
++ */
++
++/dts-v1/;
++
++#include "k3-am6548-iot2050-advanced-common.dtsi"
++#include "k3-am65-iot2050-dp.dtsi"
++#include "k3-am65-iot2050-common-pg2.dtsi"
++#include "k3-am65-iot2050-arduino-connector-rev.dtsi"
++#include "k3-am65-iot2050-usb3.dtsi"
++
++/ {
++	compatible = "siemens,iot2050-advanced-pg2-rev", "ti,am654";
++	model = "SIMATIC IOT2050 Advanced PG2 Rev";
++};


### PR DESCRIPTION
The hardware design of the Arduino IO will be changed in next revision of the hardware of the PG2 Advanced & M.2 variants.

The new hardware will use the I2C IO expander directly to single the GPIO. Only GPIO is changed.

This requires the new SEBoot with the new "rev" field of the boardinfo to be workable, which is in the backlog and will be submitted soon.