### PR TITLE
fix(watchdog): service hardware watchdog during initramfs crypt setup

### DIFF
--- a/meta/conf/machine/iot2050.conf
+++ b/meta/conf/machine/iot2050.conf
@@ -30,3 +30,6 @@ WKS_FILE ?= "iot2050.wks.in"
 SWUPDATE_BOOTLOADER = "efibootguard"
 
 CONSOLE_KERNEL_PARAMS ?= "console=ttyS3,115200n8 earlycon=ns16550a,mmio32,0x02810000"
+
+# watchdog is managed by U-Boot - disable EFI Boot Guard's own handling
+WDOG_TIMEOUT = "0"

--- a/meta/conf/machine/iot2050.conf
+++ b/meta/conf/machine/iot2050.conf
@@ -33,3 +33,8 @@ CONSOLE_KERNEL_PARAMS ?= "console=ttyS3,115200n8 earlycon=ns16550a,mmio32,0x0281
 
 # watchdog is managed by U-Boot - disable EFI Boot Guard's own handling
 WDOG_TIMEOUT = "0"
+
+# make sure the initramfs crypt-hook services the independently armed
+# hardware watchdog during the lengthy TPM2/LUKS partition setup, since
+# WDOG_TIMEOUT above only configures EFI Boot Guard's own watchdog handling
+INITRAMFS_WATCHDOG_DEVICE = "/dev/watchdog"

--- a/meta/recipes-core/images/iot2050-image-base.bb
+++ b/meta/recipes-core/images/iot2050-image-base.bb
@@ -14,9 +14,6 @@ inherit image
 
 DESCRIPTION = "IOT2050 Debian Base Image"
 
-# watchdog is managed by U-Boot - disable
-WDOG_TIMEOUT = "0"
-
 IMAGE_INSTALL += "${IOT2050_META_PACKAGES}"
 
 IMAGE_PREINSTALL += "libubootenv-tool"


### PR DESCRIPTION
WDOG_TIMEOUT only configures EFI Boot Guard's own watchdog handling and does not stop U-Boot from independently arming the hardware watchdog. INITRAMFS_WATCHDOG_DEVICE was left unset, so the initramfs crypt-hook never serviced it during the lengthy TPM2/LUKS partition setup on first boot, causing the device to hard-reset mid-encryption if setup exceeded the bootloader-armed timeout.

Move WDOG_TIMEOUT from iot2050-image-base.bb to iot2050.conf so it applies regardless of which image recipe is used, and add INITRAMFS_WATCHDOG_DEVICE=/dev/watchdog so the crypt-hook keeps the hardware watchdog alive during setup.