### PR TITLE
trusted-firmware-a-iot2050: Use 2.8.45 LTS

### DIFF
--- a/meta/recipes-bsp/trusted-firmware-a/trusted-firmware-a-iot2050_2.8.45.bb
+++ b/meta/recipes-bsp/trusted-firmware-a/trusted-firmware-a-iot2050_2.8.45.bb
@@ -12,13 +12,12 @@
 inherit trusted-firmware-a
 
 SRC_URI += "https://github.com/ARM-software/arm-trusted-firmware/archive/refs/tags/lts-v${PV}.tar.gz"
-SRC_URI[sha256sum] = "bb15ce95447a987ca8acbaa45126a338671da3c330c41283e3ded969ff1501f2"
+SRC_URI[sha256sum] = "0c9e29c0fb57195fdf361d6582c4d723dba3c749838b7dbbd90fa673af8a4a6d"
 
 S = "${WORKDIR}/arm-trusted-firmware-lts-v${PV}"
 
 TF_A_NAME = "iot2050"
 TF_A_PLATFORM = "k3"
-# Keep the IOT2050 UART selection and avoid non-reproducible date/time macros.
-TF_A_EXTRA_BUILDARGS = "SPD=opteed K3_USART=1 TARGET_BOARD=generic \
+TF_A_EXTRA_BUILDARGS = "SPD=opteed K3_USART=1 \
 	BUILD_MESSAGE_TIMESTAMP='"reproducible"'"
 TF_A_BINARIES = "generic/release/bl31.bin"


### PR DESCRIPTION
Use the latest 2.8 LTS release to retain compatibility with the existing IOT2050 Firmware, which does not support TF-A 2.14's runtime capability query.

With TF-A 2.14.6, the Firmware NACKs the optional capability query and emits:

ERROR:   Unable to query firmware capabilities (-19)

The message has no functional impact, but indicates a protocol compatibility problem during boot. Using TF-A 2.8.45 avoids the message without adding a platform-specific patch.