### PR TITLE
fix(iot2050-firmware-update): missing compilation dependency

### DIFF
--- a/meta-example/recipes-app/iot2050-firmware-update/iot2050-firmware-update_1.1.1.bb
+++ b/meta-example/recipes-app/iot2050-firmware-update/iot2050-firmware-update_1.1.1.bb
@@ -38,6 +38,7 @@ inherit dpkg-raw
 
 DEBIAN_DEPENDS = "python3-cryptography, python3-grpcio, python3-packaging, u-boot-tools, iot2050-firmware-common"
 DEBIAN_BUILD_DEPENDS = "openssl"
+DEPENDS = "iot2050-firmware-common"
 
 do_install() {
     install -v -d ${D}/usr/sbin/


### PR DESCRIPTION
- iot2050-firware-common is required to install iot2050-firmware-update, however isar-apt does not have it.